### PR TITLE
Update putfile stream enhancements

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
@@ -1,7 +1,7 @@
 package com.smartdevicelink.Dispatcher;
 
-public interface IDispatchingStrategy<messageType> {
-	public void dispatch(messageType message);
+public interface IDispatchingStrategy<T> {
+	public void dispatch(T message);
 	
 	public void handleDispatchingError(String info, Exception ex);
 	

--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
@@ -5,17 +5,17 @@ import java.util.concurrent.PriorityBlockingQueue;
 
 import com.smartdevicelink.util.DebugTool;
 
-public class ProxyMessageDispatcher<messageType> {
-	PriorityBlockingQueue<messageType> _queue = null;
+public class ProxyMessageDispatcher<T> {
+	PriorityBlockingQueue<T> _queue = null;
 	private Thread _messageDispatchingThread = null;
-	IDispatchingStrategy<messageType> _strategy = null;
+	IDispatchingStrategy<T> _strategy = null;
 
 	// Boolean to track if disposed
 	private Boolean dispatcherDisposed = false;
 	
-	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<messageType> messageComparator, 
-			IDispatchingStrategy<messageType> strategy) {
-		_queue = new PriorityBlockingQueue<messageType>(10, messageComparator);
+	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<T> messageComparator, 
+			IDispatchingStrategy<T> strategy) {
+		_queue = new PriorityBlockingQueue<T>(10, messageComparator);
 		
 		_strategy = strategy;
 		
@@ -38,7 +38,7 @@ public class ProxyMessageDispatcher<messageType> {
 	private void handleMessages() {
 		
 		try {
-			messageType thisMessage;
+			T thisMessage;
 		
 			while(dispatcherDisposed == false) {
 				thisMessage = _queue.take();
@@ -53,7 +53,7 @@ public class ProxyMessageDispatcher<messageType> {
 		}
 	}
 		
-	public void queueMessage(messageType message) {
+	public void queueMessage(T message) {
 		try {
 			_queue.put(message);
 		} catch(ClassCastException e) { 

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/ISdlConnectionListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/ISdlConnectionListener.java
@@ -26,7 +26,4 @@ public interface ISdlConnectionListener {
 	
 	public void onHeartbeatTimedOut(byte sessionID);
 	
-	public void onOnStreamRPC(IPutFileResponseListener putFileListener, OnStreamRPC rpcNote);
-	
-	public void onStreamRPCResponse(IPutFileResponseListener putFileListener, StreamRPCResponse result);	
 }

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/ISdlConnectionListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/ISdlConnectionListener.java
@@ -2,9 +2,7 @@ package com.smartdevicelink.SdlConnection;
 
 import com.smartdevicelink.protocol.ProtocolMessage;
 import com.smartdevicelink.protocol.enums.SessionType;
-import com.smartdevicelink.proxy.interfaces.IPutFileResponseListener;
-import com.smartdevicelink.proxy.rpc.OnStreamRPC;
-import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
+
 
 public interface ISdlConnectionListener {
 	public void onTransportDisconnected(String info);

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/ISdlConnectionListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/ISdlConnectionListener.java
@@ -2,6 +2,9 @@ package com.smartdevicelink.SdlConnection;
 
 import com.smartdevicelink.protocol.ProtocolMessage;
 import com.smartdevicelink.protocol.enums.SessionType;
+import com.smartdevicelink.proxy.interfaces.IPutFileResponseListener;
+import com.smartdevicelink.proxy.rpc.OnStreamRPC;
+import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
 
 public interface ISdlConnectionListener {
 	public void onTransportDisconnected(String info);
@@ -21,5 +24,9 @@ public interface ISdlConnectionListener {
 	
 	public void onProtocolError(String info, Exception e);
 	
-	public void onHeartbeatTimedOut(byte sessionID);	
+	public void onHeartbeatTimedOut(byte sessionID);
+	
+	public void onOnStreamRPC(IPutFileResponseListener putFileListener, OnStreamRPC rpcNote);
+	
+	public void onStreamRPCResponse(IPutFileResponseListener putFileListener, StreamRPCResponse result);	
 }

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -272,15 +272,30 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
         }
 		return null;
 	}
-	
-	public void stopStream()
+
+	public void pauseRPCStream()
+	{
+		if (mPacketizer != null)
+		{
+			mPacketizer.pause();
+		}
+	}
+
+	public void resumeRPCStream()
+	{
+		if (mPacketizer != null)
+		{
+			mPacketizer.resume();
+		}
+	}
+
+	public void stopRPCStream()
 	{
 		if (mPacketizer != null)
 		{
 			mPacketizer.stop();
 		}
 	}
-	
 	
 	@Override
 	public void sendStreamPacket(ProtocolMessage pm) {

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -1,9 +1,6 @@
 package com.smartdevicelink.SdlConnection;
 
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
@@ -17,11 +14,6 @@ import com.smartdevicelink.protocol.ProtocolMessage;
 import com.smartdevicelink.protocol.WiProProtocol;
 import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.proxy.RPCRequest;
-import com.smartdevicelink.proxy.interfaces.IPutFileResponseListener;
-import com.smartdevicelink.proxy.rpc.OnStreamRPC;
-import com.smartdevicelink.proxy.rpc.PutFile;
-import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
-import com.smartdevicelink.proxy.rpc.enums.Result;
 import com.smartdevicelink.streaming.AbstractPacketizer;
 import com.smartdevicelink.streaming.IStreamListener;
 import com.smartdevicelink.streaming.StreamPacketizer;

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlSession.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlSession.java
@@ -10,9 +10,6 @@ import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.protocol.heartbeat.IHeartbeatMonitor;
 import com.smartdevicelink.protocol.heartbeat.IHeartbeatMonitorListener;
 import com.smartdevicelink.proxy.LockScreenManager;
-import com.smartdevicelink.proxy.interfaces.IPutFileResponseListener;
-import com.smartdevicelink.proxy.rpc.OnStreamRPC;
-import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.TransportType;
 

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlSession.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlSession.java
@@ -10,6 +10,9 @@ import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.protocol.heartbeat.IHeartbeatMonitor;
 import com.smartdevicelink.protocol.heartbeat.IHeartbeatMonitorListener;
 import com.smartdevicelink.proxy.LockScreenManager;
+import com.smartdevicelink.proxy.interfaces.IPutFileResponseListener;
+import com.smartdevicelink.proxy.rpc.OnStreamRPC;
+import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.TransportType;
 
@@ -215,6 +218,15 @@ public class SdlSession implements ISdlConnectionListener, IHeartbeatMonitorList
 		this.sessionListener.onProtocolSessionNACKed(sessionType, sessionID, version, correlationID);		
 	}
 
+	@Override
+	public void onOnStreamRPC(IPutFileResponseListener putFileListener, OnStreamRPC rpcNote) {
+		this.sessionListener.onOnStreamRPC(putFileListener, rpcNote);
+	}
 
+	@Override
+	public void onStreamRPCResponse(IPutFileResponseListener putFileListener, StreamRPCResponse result) {
+		this.sessionListener.onStreamRPCResponse(putFileListener, result);
+	
+	}
 	
 }

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlSession.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlSession.java
@@ -216,17 +216,5 @@ public class SdlSession implements ISdlConnectionListener, IHeartbeatMonitorList
 	public void onProtocolSessionNACKed(SessionType sessionType,
 			byte sessionID, byte version, String correlationID) {
 		this.sessionListener.onProtocolSessionNACKed(sessionType, sessionID, version, correlationID);		
-	}
-
-	@Override
-	public void onOnStreamRPC(IPutFileResponseListener putFileListener, OnStreamRPC rpcNote) {
-		this.sessionListener.onOnStreamRPC(putFileListener, rpcNote);
-	}
-
-	@Override
-	public void onStreamRPCResponse(IPutFileResponseListener putFileListener, StreamRPCResponse result) {
-		this.sessionListener.onStreamRPCResponse(putFileListener, result);
-	
-	}
-	
+	}	
 }

--- a/sdl_android_lib/src/com/smartdevicelink/protocol/ProtocolMessage.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/ProtocolMessage.java
@@ -55,6 +55,10 @@ public class ProtocolMessage {
 		return _bulkData;
 	}
 
+	public void setBulkDataNoCopy(byte[] bulkData) {
+		this._bulkData = bulkData;
+	}
+
 	public void setBulkData(byte[] bulkData) {
 		if (this._bulkData != null)
 			this._bulkData = null;

--- a/sdl_android_lib/src/com/smartdevicelink/protocol/enums/FunctionID.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/enums/FunctionID.java
@@ -66,6 +66,8 @@ public class FunctionID {
 	public static final String ON_SDL_CHOICE_CHOSEN = "OnSdlChoiceChosen";
 	
 	public static final String SEND_LOCATION = "SendLocation";
+	public static final String ON_STREAM_RPC = "OnStreamRPC";
+	public static final String STREAM_RPC = "StreamRPC";
 
     public FunctionID() {
     }

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/RPCRequestFactory.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/RPCRequestFactory.java
@@ -526,6 +526,18 @@ public class RPCRequestFactory {
 		putFile.setLength(iLength);
 		return putFile;
 	}
+	
+	public static PutFile buildPutFile(String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile, Integer iCorrelationID) {
+		PutFile putFile = new PutFile();
+		putFile.setCorrelationID(iCorrelationID);
+		putFile.setSdlFileName(sdlFileName);
+		putFile.setFileType(fileType);
+		putFile.setPersistentFile(bPersistentFile);
+		putFile.setSystemFile(bSystemFile);
+		putFile.setOffset(iOffset);
+		putFile.setLength(iLength);
+		return putFile;
+	}	
 		
 	public static RegisterAppInterface buildRegisterAppInterface(String appName, String appID) {
 		return buildRegisterAppInterface(appName, false, appID);

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/RPCStreamController.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/RPCStreamController.java
@@ -27,6 +27,6 @@ public class RPCStreamController {
 	}
 	public void stop()
 	{
-		rpcPacketizer.stop();
+		rpcPacketizer.onPutFileStreamError(null, "Stop Putfile Stream Requested");
 	}	
 }

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/RPCStreamController.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/RPCStreamController.java
@@ -1,0 +1,32 @@
+package com.smartdevicelink.proxy;
+
+import com.smartdevicelink.streaming.StreamRPCPacketizer;
+
+public class RPCStreamController {
+	private StreamRPCPacketizer rpcPacketizer;
+	private Integer iCorrelationID;
+
+	public RPCStreamController(StreamRPCPacketizer rpcPacketizer, Integer iCorrelationID)
+	{
+		this.rpcPacketizer = rpcPacketizer;
+		this.iCorrelationID = iCorrelationID;
+	}	
+	
+	public Integer getCorrelationID()
+	{
+		return iCorrelationID;
+	}
+	
+	public void pause()
+	{
+		rpcPacketizer.pause();
+	}
+	public void resume()
+	{
+		rpcPacketizer.resume();
+	}
+	public void stop()
+	{
+		rpcPacketizer.stop();
+	}	
+}

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -197,9 +197,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	protected List<Integer> _diagModes = null;
 	protected Boolean firstTimeFull = true;
 	protected String _proxyVersionInfo = null;
-	protected Boolean _bResumeSuccess = false;
-	private StreamRPCPacketizer rpcPacketizer = null;
-
+	protected Boolean _bResumeSuccess = false;	
 	
 	private CopyOnWriteArrayList<IPutFileResponseListener> _putFileListenerList = new CopyOnWriteArrayList<IPutFileResponseListener>();
 	
@@ -2799,73 +2797,56 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			e.printStackTrace();
 		}
 	}
-	
-	public boolean pausePutFileStream()
-	{
-		if (rpcPacketizer == null)
-			return false;
-		rpcPacketizer.pause();
-
-		return true;
-	}
-
-	public boolean resumePutFileStream()
-	{
-		if (rpcPacketizer == null)
-			return false;
-		rpcPacketizer.resume();
-
-		return true;
-	}
 
 	@SuppressWarnings("unchecked")
-	private boolean startRPCStream(String sLocalFile, PutFile request, SessionType sType, byte rpcSessionID, byte wiproVersion)
+	private RPCStreamController startRPCStream(String sLocalFile, PutFile request, SessionType sType, byte rpcSessionID, byte wiproVersion)
 	{		
-		if (sdlSession == null) return false;		
+		if (sdlSession == null) return null;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
-		if (sdlConn == null) return false;
+		if (sdlConn == null) return null;
 					
 		FileInputStream is = getFileInputStream(sLocalFile);
-		if (is == null) return false;
+		if (is == null) return null;
 		
-		Long lSize = getFileInputStreamSize(is);
-		if (lSize == null)
+		Integer iSize = Integer.valueOf(getFileInputStreamSize(is).intValue());
+		if (iSize == null)
 		{	
 			closeFileInputStream(is);
-			return false;
+			return null;
 		}
 
 		try {
-			rpcPacketizer = new StreamRPCPacketizer((SdlProxyBase<IProxyListenerBase>) this, sdlConn, is, request, sType, rpcSessionID, wiproVersion, lSize);
+			StreamRPCPacketizer rpcPacketizer = new StreamRPCPacketizer((SdlProxyBase<IProxyListenerBase>) this, sdlConn, is, request, sType, rpcSessionID, wiproVersion, iSize);
 			rpcPacketizer.start();
-			return true;
+			RPCStreamController streamController = new RPCStreamController(rpcPacketizer, request.getCorrelationID());
+			return streamController;
 		} catch (Exception e) {
-            Log.e("SdlProxy", "Unable to start streaming:" + e.toString());  
-            return false;
+            Log.e("SyncConnection", "Unable to start streaming:" + e.toString());  
+            return null;
         }			
 	}
 
 	@SuppressWarnings("unchecked")
-	private boolean startRPCStream(InputStream is, PutFile request, SessionType sType, byte rpcSessionID, byte wiproVersion)
+	private RPCStreamController startRPCStream(InputStream is, PutFile request, SessionType sType, byte rpcSessionID, byte wiproVersion)
 	{		
-		if (sdlSession == null) return false;		
+		if (sdlSession == null) return null;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
-		if (sdlConn == null) return false;
+		if (sdlConn == null) return null;
+		Integer iSize = request.getLength();
 
 		if (request.getLength() == null)
 		{
-			return false;
-		}
-		
-		Long lSize = request.getLength().longValue();			
+			return null;
+		}		
 		
 		try {
-			rpcPacketizer = new StreamRPCPacketizer((SdlProxyBase<IProxyListenerBase>) this, sdlConn, is, request, sType, rpcSessionID, wiproVersion, lSize);
+			StreamRPCPacketizer rpcPacketizer = new StreamRPCPacketizer((SdlProxyBase<IProxyListenerBase>) this, sdlConn, is, request, sType, rpcSessionID, wiproVersion, iSize);
 			rpcPacketizer.start();
-			return true;
+			RPCStreamController streamController = new RPCStreamController(rpcPacketizer, request.getCorrelationID());
+			return streamController;
 		} catch (Exception e) {
             Log.e("SyncConnection", "Unable to start streaming:" + e.toString());  
-            return false;
+            return null;
         }			
 	}
 

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -4298,14 +4298,14 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * Used to push a binary stream of file data onto the module from a mobile device.
 	 * Responses are captured through callback on IProxyListener.
 	 * 
-	 * @param is - The input stream of byte data that PutFileStream will read from 
+	 * @param is - The input stream of byte data that putFileStream will read from 
 	 * @param sdlFileName - The file reference name used by the putFile RPC.
 	 * @param iOffset - The data offset in bytes, a value of zero is used to indicate data starting from the beginging of the file.
 	 * A value greater than zero is used for resuming partial data chunks.
 	 * @param iLength - The total length of the file being sent.
 	 * @throws SdlException
 	*/
-	public void PutFileStream(InputStream is, String sdlFileName, Integer iOffset, Integer iLength) throws SdlException 
+	public void putFileStream(InputStream is, String sdlFileName, Integer iOffset, Integer iLength) throws SdlException 
 	{
 		PutFile msg = RPCRequestFactory.buildPutFile(sdlFileName, iOffset, iLength);		
 		startRPCStream(is, msg);
@@ -4323,7 +4323,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @return OutputStream - The output stream of byte data that is written to by the app developer
 	 * @throws SdlException
 	*/
-	public OutputStream PutFileStream(String sdlFileName, Integer iOffset, Integer iLength) throws SdlException 
+	public OutputStream putFileStream(String sdlFileName, Integer iOffset, Integer iLength) throws SdlException 
 	{
 		PutFile msg = RPCRequestFactory.buildPutFile(sdlFileName, iOffset, iLength);		
 		return startRPCStream(msg);
@@ -4343,7 +4343,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @param  bSystemFile - Indicates if the file is meant to be passed thru core to elsewhere on the system.
 	 * @throws SdlException
 	*/
-	public void PutFileStream(InputStream is, String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile) throws SdlException
+	public void putFileStream(InputStream is, String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile) throws SdlException
 	{
 		PutFile msg = RPCRequestFactory.buildPutFile(sdlFileName, iOffset, iLength, fileType, bPersistentFile, bSystemFile);
 		startRPCStream(is, msg);
@@ -4363,7 +4363,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @return OutputStream - The output stream of byte data that is written to by the app developer
 	 * @throws SdlException
 	*/
-	public OutputStream PutFileStream(String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile) throws SdlException
+	public OutputStream putFileStream(String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile) throws SdlException
 	{
 		PutFile msg = RPCRequestFactory.buildPutFile(sdlFileName, iOffset, iLength, fileType, bPersistentFile, bSystemFile);
 		return startRPCStream(msg);
@@ -4384,7 +4384,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @return boolean - True if the putfile stream was started successfully, false if an exception occurred during stream creation. 
 	 * @throws SdlException
 	*/	
-	public boolean PutFileStream(String sPath, String sdlFileName, Integer iOffset, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile, Integer iCorrelationID) throws SdlException 
+	public boolean putFileStream(String sPath, String sdlFileName, Integer iOffset, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile, Integer iCorrelationID) throws SdlException 
 	{
 		PutFile msg = RPCRequestFactory.buildPutFile(sdlFileName, iOffset, 0, fileType, bPersistentFile, bSystemFile, iCorrelationID);
 		return startPutFileStream(sPath, msg);
@@ -4394,7 +4394,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * Used to push a stream of putfile RPC's containing binary data from a mobile device to the module.
 	 * Responses are captured through callback on IProxyListener.
 	 *
-	 * @param is - The input stream of byte data that PutFileStream will read from.
+	 * @param is - The input stream of byte data that putFileStream will read from.
 	 * @param sdlFileName - The file reference name used by the putFile RPC.
 	 * @param iOffset - The data offset in bytes, a value of zero is used to indicate data starting from the beginging of a file.
 	 * A value greater than zero is used for resuming partial data chunks.
@@ -4405,7 +4405,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @return boolean - True if the putfile stream was started successfully, false if an exception occurred during stream creation. 
 	 * @throws SdlException
 	*/	
-	public boolean PutFileStream(InputStream is, String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile, Integer iCorrelationID) throws SdlException 
+	public boolean putFileStream(InputStream is, String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile, Integer iCorrelationID) throws SdlException 
 	{
 		PutFile msg = RPCRequestFactory.buildPutFile(sdlFileName, iOffset, iLength, fileType, bPersistentFile, bSystemFile, iCorrelationID);
 		return startPutFileStream(is, msg);
@@ -4413,7 +4413,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 	/**
 	 *
-	 * Used to end an existing PutFileStream that was previously initiated with any PutFileStream method.
+	 * Used to end an existing putFileStream that was previously initiated with any putFileStream method.
 	 *
 	 */
 	public void endPutFileStream()

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -198,6 +198,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	protected Boolean firstTimeFull = true;
 	protected String _proxyVersionInfo = null;
 	protected Boolean _bResumeSuccess = false;
+	private StreamRPCPacketizer rpcPacketizer = null;
+
 	
 	private CopyOnWriteArrayList<IPutFileResponseListener> _putFileListenerList = new CopyOnWriteArrayList<IPutFileResponseListener>();
 	
@@ -2798,6 +2800,25 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 	}
 	
+	public boolean pausePutFileStream()
+	{
+		if (rpcPacketizer == null)
+			return false;
+		rpcPacketizer.pause();
+
+		return true;
+	}
+
+	public boolean resumePutFileStream()
+	{
+		if (rpcPacketizer == null)
+			return false;
+		rpcPacketizer.resume();
+
+		return true;
+	}
+
+	@SuppressWarnings("unchecked")
 	private boolean startRPCStream(String sLocalFile, PutFile request, SessionType sType, byte rpcSessionID, byte wiproVersion)
 	{		
 		if (sdlSession == null) return false;		
@@ -2815,8 +2836,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 
 		try {
-			@SuppressWarnings("unchecked")
-			StreamRPCPacketizer rpcPacketizer = new StreamRPCPacketizer((SdlProxyBase<IProxyListenerBase>) this, sdlConn, is, request, sType, rpcSessionID, wiproVersion, lSize);
+			rpcPacketizer = new StreamRPCPacketizer((SdlProxyBase<IProxyListenerBase>) this, sdlConn, is, request, sType, rpcSessionID, wiproVersion, lSize);
 			rpcPacketizer.start();
 			return true;
 		} catch (Exception e) {
@@ -2825,6 +2845,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
         }			
 	}
 
+	@SuppressWarnings("unchecked")
 	private boolean startRPCStream(InputStream is, PutFile request, SessionType sType, byte rpcSessionID, byte wiproVersion)
 	{		
 		if (sdlSession == null) return false;		
@@ -2839,8 +2860,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		Long lSize = request.getLength().longValue();			
 		
 		try {
-			@SuppressWarnings("unchecked")
-			StreamRPCPacketizer rpcPacketizer = new StreamRPCPacketizer((SdlProxyBase<IProxyListenerBase>) this, sdlConn, is, request, sType, rpcSessionID, wiproVersion, lSize);
+			rpcPacketizer = new StreamRPCPacketizer((SdlProxyBase<IProxyListenerBase>) this, sdlConn, is, request, sType, rpcSessionID, wiproVersion, lSize);
 			rpcPacketizer.start();
 			return true;
 		} catch (Exception e) {
@@ -2885,9 +2905,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		if (sdlSession == null) return;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
 		if (sdlConn == null) return;
-		sdlConn.stopStream();
+		sdlConn.stopRPCStream();
 	}
-	
 	
 	public boolean startH264(InputStream is) {
 		
@@ -2936,7 +2955,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		if (sdlConn == null) return;
 		sdlConn.endService(SessionType.NAV, sdlSession.getSessionId());
 	}
-	
+
 	public boolean startPCM(InputStream is) {
 		if (sdlSession == null) return false;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2815,7 +2815,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			rpcPacketizer.start();
 			return true;
 		} catch (Exception e) {
-            Log.e("SyncConnection", "Unable to start streaming:" + e.toString());  
+            Log.e("SdlProxy", "Unable to start streaming:" + e.toString());  
             return false;
         }			
 	}
@@ -4296,18 +4296,18 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * Responses are captured through callback on IProxyListener.
 	 *
 	 * @param is - The input stream of byte data that PutFileStream will read from
-	 * @param syncFileName - The file reference name used by the putFile RPC.
+	 * @param sdlFileName - The file reference name used by the putFile RPC.
 	 * @param iOffset - The data offset in bytes, a value of zero is used to indicate data starting from the beginging of the file.
 	 * A value greater than zero is used for resuming partial data chunks.
 	 * @param iLength - The total length of the file being sent.
 	 * @param fileType - The selected file type -- see the FileType enumeration for details
 	 * @param bPersistentFile - Indicates if the file is meant to persist between sessions / ignition cycles.
 	 * @param  bSystemFile - Indicates if the file is meant to be passed thru core to elsewhere on the system.
-	 * @throws SyncException
+	 * @throws SdlException
 	*/
-	public void PutFileStream(InputStream is, String syncFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile) throws SdlException
+	public void PutFileStream(InputStream is, String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile) throws SdlException
 	{
-		PutFile msg = RPCRequestFactory.buildPutFile(syncFileName, iOffset, iLength, fileType, bPersistentFile, bSystemFile);
+		PutFile msg = RPCRequestFactory.buildPutFile(sdlFileName, iOffset, iLength, fileType, bPersistentFile, bSystemFile);
 		startRPCStream(is, msg);
 	}
 	
@@ -4315,7 +4315,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * Used to push a binary stream of file data onto the module from a mobile device.
 	 * Responses are captured through callback on IProxyListener.
 	 *
-	 * @param syncFileName - The file reference name used by the putFile RPC.
+	 * @param sdlFileName - The file reference name used by the putFile RPC.
 	 * @param iOffset - The data offset in bytes, a value of zero is used to indicate data starting from the beginging of a file.
 	 * A value greater than zero is used for resuming partial data chunks.
 	 * @param iLength - The total length of the file being sent.
@@ -4323,7 +4323,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @param bPersistentFile - Indicates if the file is meant to persist between sessions / ignition cycles.
 	 * @param  bSystemFile - Indicates if the file is meant to be passed thru core to elsewhere on the system.
 	 * @return OutputStream - The output stream of byte data that is written to by the app developer
-	 * @throws SyncException
+	 * @throws SdlException
 	*/
 	public OutputStream PutFileStream(String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile) throws SdlException
 	{

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -224,6 +224,11 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	{
 		_putFileListenerList.addIfAbsent(_putFileListener);
 	}
+
+	public void remPutFileResponseListener(IPutFileResponseListener _putFileListener)
+	{
+		_putFileListenerList.remove(_putFileListener);
+	}
 	
 	// Private Class to Interface with SdlConnection
 	private class SdlInterfaceBroker implements ISdlConnectionListener {
@@ -2808,7 +2813,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			closeFileInputStream(is);
 			return false;
 		}
-       
+
 		try {
 			@SuppressWarnings("unchecked")
 			StreamRPCPacketizer rpcPacketizer = new StreamRPCPacketizer((SdlProxyBase<IProxyListenerBase>) this, sdlConn, is, request, sType, rpcSessionID, wiproVersion, lSize);
@@ -2819,14 +2824,47 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             return false;
         }			
 	}
-	
+
+	private boolean startRPCStream(InputStream is, PutFile request, SessionType sType, byte rpcSessionID, byte wiproVersion)
+	{		
+		if (sdlSession == null) return false;		
+		SdlConnection sdlConn = sdlSession.getSdlConnection();		
+		if (sdlConn == null) return false;
+
+		if (request.getLength() == null)
+		{
+			return false;
+		}
+		
+		Long lSize = request.getLength().longValue();			
+		
+		try {
+			@SuppressWarnings("unchecked")
+			StreamRPCPacketizer rpcPacketizer = new StreamRPCPacketizer((SdlProxyBase<IProxyListenerBase>) this, sdlConn, is, request, sType, rpcSessionID, wiproVersion, lSize);
+			rpcPacketizer.start();
+			return true;
+		} catch (Exception e) {
+            Log.e("SyncConnection", "Unable to start streaming:" + e.toString());  
+            return false;
+        }			
+	}
+
 	private boolean startPutFileStream(String sPath, PutFile msg) {
 		if (sdlSession == null) return false;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
 		if (sdlConn == null) return false;
 		startRPCStream(sPath, msg, SessionType.RPC, sdlSession.getSessionId(), _wiproVersion);
 		return true;
-	}	
+	}
+
+	private boolean startPutFileStream(InputStream is, PutFile msg) {
+		if (sdlSession == null) return false;		
+		SdlConnection sdlConn = sdlSession.getSdlConnection();		
+		if (sdlConn == null) return false;
+		if (is == null) return false;
+		startRPCStream(is, msg, SessionType.RPC, sdlSession.getSessionId(), _wiproVersion);
+		return true;
+	}
 	
 	public boolean startRPCStream(InputStream is, RPCRequest msg) {
 		if (sdlSession == null) return false;		
@@ -4351,7 +4389,28 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		PutFile msg = RPCRequestFactory.buildPutFile(sdlFileName, iOffset, 0, fileType, bPersistentFile, bSystemFile, iCorrelationID);
 		return startPutFileStream(sPath, msg);
 	}
-		
+
+	/**
+	 * Used to push a stream of putfile RPC's containing binary data from a mobile device to the module.
+	 * Responses are captured through callback on IProxyListener.
+	 *
+	 * @param is - The input stream of byte data that PutFileStream will read from.
+	 * @param sdlFileName - The file reference name used by the putFile RPC.
+	 * @param iOffset - The data offset in bytes, a value of zero is used to indicate data starting from the beginging of a file.
+	 * A value greater than zero is used for resuming partial data chunks.
+	 * @param fileType - The selected file type -- see the FileType enumeration for details
+	 * @param bPersistentFile - Indicates if the file is meant to persist between sessions / ignition cycles.
+	 * @param  bSystemFile - Indicates if the file is meant to be passed thru core to elsewhere on the system.
+	 * @param correlationID - A unique ID that correlates each RPCRequest and RPCResponse.
+	 * @return boolean - True if the putfile stream was started successfully, false if an exception occurred during stream creation. 
+	 * @throws SdlException
+	*/	
+	public boolean PutFileStream(InputStream is, String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile, Integer iCorrelationID) throws SdlException 
+	{
+		PutFile msg = RPCRequestFactory.buildPutFile(sdlFileName, iOffset, iLength, fileType, bPersistentFile, bSystemFile, iCorrelationID);
+		return startPutFileStream(is, msg);
+	}
+
 	/**
 	 *
 	 * Used to end an existing PutFileStream that was previously initiated with any PutFileStream method.

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2850,21 +2850,20 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
         }			
 	}
 
-	private boolean startPutFileStream(String sPath, PutFile msg) {
-		if (sdlSession == null) return false;		
+	private RPCStreamController startPutFileStream(String sPath, PutFile msg) {
+		if (sdlSession == null) return null;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
-		if (sdlConn == null) return false;
-		startRPCStream(sPath, msg, SessionType.RPC, sdlSession.getSessionId(), _wiproVersion);
-		return true;
+		if (sdlConn == null) return null;
+		return startRPCStream(sPath, msg, SessionType.RPC, sdlSession.getSessionId(), _wiproVersion);		
 	}
 
-	private boolean startPutFileStream(InputStream is, PutFile msg) {
-		if (sdlSession == null) return false;		
+	private RPCStreamController startPutFileStream(InputStream is, PutFile msg) {
+		if (sdlSession == null) return null;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
-		if (sdlConn == null) return false;
-		if (is == null) return false;
+		if (sdlConn == null) return null;
+		if (is == null) return null;
 		startRPCStream(is, msg, SessionType.RPC, sdlSession.getSessionId(), _wiproVersion);
-		return true;
+		return null;
 	}
 	
 	public boolean startRPCStream(InputStream is, RPCRequest msg) {
@@ -4381,10 +4380,10 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @param bPersistentFile - Indicates if the file is meant to persist between sessions / ignition cycles.
 	 * @param  bSystemFile - Indicates if the file is meant to be passed thru core to elsewhere on the system.
 	 * @param correlationID - A unique ID that correlates each RPCRequest and RPCResponse.
-	 * @return boolean - True if the putfile stream was started successfully, false if an exception occurred during stream creation. 
+	 * @return RPCStreamController - If the putFileStream was not started successfully null is returned, otherwise a valid object reference is returned 
 	 * @throws SdlException
 	*/	
-	public boolean putFileStream(String sPath, String sdlFileName, Integer iOffset, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile, Integer iCorrelationID) throws SdlException 
+	public RPCStreamController putFileStream(String sPath, String sdlFileName, Integer iOffset, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile, Integer iCorrelationID) throws SdlException 
 	{
 		PutFile msg = RPCRequestFactory.buildPutFile(sdlFileName, iOffset, 0, fileType, bPersistentFile, bSystemFile, iCorrelationID);
 		return startPutFileStream(sPath, msg);
@@ -4402,10 +4401,10 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @param bPersistentFile - Indicates if the file is meant to persist between sessions / ignition cycles.
 	 * @param  bSystemFile - Indicates if the file is meant to be passed thru core to elsewhere on the system.
 	 * @param correlationID - A unique ID that correlates each RPCRequest and RPCResponse.
-	 * @return boolean - True if the putfile stream was started successfully, false if an exception occurred during stream creation. 
+	 * @return RPCStreamController - If the putFileStream was not started successfully null is returned, otherwise a valid object reference is returned 
 	 * @throws SdlException
 	*/	
-	public boolean putFileStream(InputStream is, String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile, Integer iCorrelationID) throws SdlException 
+	public RPCStreamController putFileStream(InputStream is, String sdlFileName, Integer iOffset, Integer iLength, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile, Integer iCorrelationID) throws SdlException 
 	{
 		PutFile msg = RPCRequestFactory.buildPutFile(sdlFileName, iOffset, iLength, fileType, bPersistentFile, bSystemFile, iCorrelationID);
 		return startPutFileStream(is, msg);

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
@@ -28,6 +28,7 @@ import com.smartdevicelink.proxy.rpc.OnLockScreenStatus;
 import com.smartdevicelink.proxy.rpc.OnPermissionsChange;
 import com.smartdevicelink.proxy.rpc.OnSystemRequest;
 import com.smartdevicelink.proxy.rpc.OnTBTClientState;
+import com.smartdevicelink.proxy.rpc.OnStreamRPC;
 import com.smartdevicelink.proxy.rpc.OnTouchEvent;
 import com.smartdevicelink.proxy.rpc.OnVehicleData;
 import com.smartdevicelink.proxy.rpc.PerformAudioPassThruResponse;
@@ -43,6 +44,7 @@ import com.smartdevicelink.proxy.rpc.SetMediaClockTimerResponse;
 import com.smartdevicelink.proxy.rpc.ShowResponse;
 import com.smartdevicelink.proxy.rpc.SliderResponse;
 import com.smartdevicelink.proxy.rpc.SpeakResponse;
+import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
 import com.smartdevicelink.proxy.rpc.SubscribeButtonResponse;
 import com.smartdevicelink.proxy.rpc.SubscribeVehicleDataResponse;
 import com.smartdevicelink.proxy.rpc.SystemRequestResponse;
@@ -75,6 +77,9 @@ public interface IProxyListenerBase  {
 	 */
 	public void onProxyClosed(String info, Exception e, SdlDisconnectedReason reason);
 	
+	public void onOnStreamRPC(OnStreamRPC notification);
+	
+	public void onStreamRPCResponse(StreamRPCResponse response);
 	/**
 	 * onProxyError() being called indicates that the SDL Proxy experenced an error.
 	 * 

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/interfaces/IPutFileResponseListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/interfaces/IPutFileResponseListener.java
@@ -1,0 +1,9 @@
+package com.smartdevicelink.proxy.interfaces;
+
+import com.smartdevicelink.proxy.rpc.PutFileResponse;
+
+public interface IPutFileResponseListener {
+	public void onPutFileResponse(PutFileResponse response);
+	
+	public void onPutFileStreamError(Exception e, String info);
+}

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnStreamRPC.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnStreamRPC.java
@@ -1,5 +1,6 @@
 package com.smartdevicelink.proxy.rpc;
 
+import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCNotification;
 
 public class OnStreamRPC extends RPCNotification {
@@ -8,7 +9,7 @@ public class OnStreamRPC extends RPCNotification {
 	public static final String KEY_FILESIZE = "fileSize";
 	
 	public OnStreamRPC() {
-		super("OnStreamRPC");
+		super(FunctionID.ON_STREAM_RPC);
 	}
 		
 	public void setFileName(String fileName) {

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnStreamRPC.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnStreamRPC.java
@@ -1,0 +1,46 @@
+package com.smartdevicelink.proxy.rpc;
+
+import com.smartdevicelink.proxy.RPCNotification;
+
+public class OnStreamRPC extends RPCNotification {
+	public static final String KEY_FILENAME = "fileName";
+	public static final String KEY_BYTESCOMPLETE = "bytesComplete";
+	public static final String KEY_FILESIZE = "fileSize";
+	
+	public OnStreamRPC() {
+		super("OnStreamRPC");
+	}
+		
+	public void setFileName(String fileName) {
+    	if (fileName != null) {
+    		parameters.put(KEY_FILENAME, fileName);
+    	} else {
+    		parameters.remove(KEY_FILENAME);
+    	}
+	}
+	public String getFileName() {
+		return (String) parameters.get(KEY_FILENAME);
+	}	
+	
+	public void setBytesComplete(Integer bytesComplete) {
+    	if (bytesComplete != null) {
+    		parameters.put(KEY_BYTESCOMPLETE, bytesComplete);
+    	} else {
+    		parameters.remove(KEY_BYTESCOMPLETE);
+    	}
+	}
+	public Integer getBytesComplete() {
+		return (Integer) parameters.get(KEY_BYTESCOMPLETE);
+	}
+
+	public void setFileSize(Integer fileSize) {
+    	if (fileSize != null) {
+    		parameters.put(KEY_FILESIZE, fileSize);
+    	} else {
+    		parameters.remove(KEY_FILESIZE);
+    	}
+	}
+	public Integer getFileSize() {
+		return (Integer) parameters.get(KEY_FILESIZE);
+	}
+}

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/StreamRPCResponse.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/StreamRPCResponse.java
@@ -2,6 +2,7 @@ package com.smartdevicelink.proxy.rpc;
 
 import java.util.Hashtable;
 
+import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCResponse;
 
 public class StreamRPCResponse extends RPCResponse {
@@ -9,7 +10,7 @@ public class StreamRPCResponse extends RPCResponse {
 	public static final String KEY_FILESIZE = "fileSize";
 	
     public StreamRPCResponse() {
-        super("StreamRPC");
+        super(FunctionID.STREAM_RPC);
     }
     public StreamRPCResponse(Hashtable<String, Object> hash) {
         super(hash);

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/StreamRPCResponse.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/StreamRPCResponse.java
@@ -1,0 +1,40 @@
+package com.smartdevicelink.proxy.rpc;
+
+import java.util.Hashtable;
+
+import com.smartdevicelink.proxy.RPCResponse;
+
+public class StreamRPCResponse extends RPCResponse {
+	public static final String KEY_FILENAME = "fileName";
+	public static final String KEY_FILESIZE = "fileSize";
+	
+    public StreamRPCResponse() {
+        super("StreamRPC");
+    }
+    public StreamRPCResponse(Hashtable<String, Object> hash) {
+        super(hash);
+    }
+    
+	public void setFileName(String fileName) {
+    	if (fileName != null) {
+    		parameters.put(KEY_FILENAME, fileName);
+    	} else {
+    		parameters.remove(KEY_FILENAME);
+    	}
+	}
+	public String getFileName() {
+		return (String) parameters.get(KEY_FILENAME);
+	}
+	
+	public void setFileSize(Integer fileSize) {
+    	if (fileSize != null) {
+    		parameters.put(KEY_FILESIZE, fileSize);
+    	} else {
+    		parameters.remove(KEY_FILESIZE);
+    	}
+	}
+	public Integer getFileSize() {
+		return (Integer) parameters.get(KEY_FILESIZE);
+	}		
+	
+}

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
@@ -14,7 +14,7 @@ abstract public class AbstractPacketizer {
 	
 	protected SessionType _session = null;
 	protected InputStream is = null;
-	protected byte[] buffer = new byte[1488];
+	protected byte[] buffer = new byte[1000000];
 	protected boolean upts = false;
 	protected RPCRequest _request = null;
 	protected byte _wiproVersion = 1;

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
@@ -14,7 +14,7 @@ abstract public class AbstractPacketizer {
 	
 	protected SessionType _session = null;
 	protected InputStream is = null;
-	protected byte[] buffer = new byte[150000];
+	protected byte[] buffer = new byte[1000000];
 	protected boolean upts = false;
 	protected RPCRequest _request = null;
 	protected byte _wiproVersion = 1;

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
@@ -42,6 +42,10 @@ abstract public class AbstractPacketizer {
 
 	public abstract void stop();
 
+	public abstract void pause();
+
+	public abstract void resume();
+
 	protected static String printBuffer(byte[] buffer, int start,int end) {
 		String str = "";
 		for (int i=start;i<end;i++) str+=","+Integer.toHexString(buffer[i]&0xFF);

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
@@ -14,7 +14,7 @@ abstract public class AbstractPacketizer {
 	
 	protected SessionType _session = null;
 	protected InputStream is = null;
-	protected byte[] buffer = new byte[1000000];
+	protected byte[] buffer = new byte[150000];
 	protected boolean upts = false;
 	protected RPCRequest _request = null;
 	protected byte _wiproVersion = 1;

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/IStreamListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/IStreamListener.java
@@ -1,7 +1,15 @@
 package com.smartdevicelink.streaming;
 
 import com.smartdevicelink.protocol.ProtocolMessage;
+import com.smartdevicelink.protocol.enums.SessionType;
+import com.smartdevicelink.proxy.interfaces.IPutFileResponseListener;
+import com.smartdevicelink.proxy.rpc.OnStreamRPC;
+import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
 
 public interface IStreamListener {
 	void sendStreamPacket(ProtocolMessage pm);
+	
+	void onOnStreamRPC(IPutFileResponseListener puFileListener, OnStreamRPC rpcNote, SessionType sType, byte sessionID);
+	
+	void onStreamRPCResponse(IPutFileResponseListener putFileListener, StreamRPCResponse result, SessionType sType, byte sessionID);	
 }

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/IStreamListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/IStreamListener.java
@@ -8,8 +8,4 @@ import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
 
 public interface IStreamListener {
 	void sendStreamPacket(ProtocolMessage pm);
-	
-	void onOnStreamRPC(IPutFileResponseListener puFileListener, OnStreamRPC rpcNote, SessionType sType, byte sessionID);
-	
-	void onStreamRPCResponse(IPutFileResponseListener putFileListener, StreamRPCResponse result, SessionType sType, byte sessionID);	
 }

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/IStreamListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/IStreamListener.java
@@ -1,10 +1,6 @@
 package com.smartdevicelink.streaming;
 
 import com.smartdevicelink.protocol.ProtocolMessage;
-import com.smartdevicelink.protocol.enums.SessionType;
-import com.smartdevicelink.proxy.interfaces.IPutFileResponseListener;
-import com.smartdevicelink.proxy.rpc.OnStreamRPC;
-import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
 
 public interface IStreamListener {
 	void sendStreamPacket(ProtocolMessage pm);

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/StreamPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/StreamPacketizer.java
@@ -12,6 +12,7 @@ public class StreamPacketizer extends AbstractPacketizer implements Runnable{
 	public final static String TAG = "StreamPacketizer";
 
 	private Thread t = null;
+	private final static int BUFF_READ_SIZE = 1000000;
 
 	public SdlConnection sdlConnection = null;
     private Object mPauseLock;
@@ -57,7 +58,7 @@ public class StreamPacketizer extends AbstractPacketizer implements Runnable{
                     }
                 }
 
-				length = is.read(buffer, 0, 1488);
+				length = is.read(buffer, 0, BUFF_READ_SIZE);
 				
 				if (length >= 0) {
 					ProtocolMessage pm = new ProtocolMessage();

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
@@ -76,7 +76,7 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 		return;	
 	}
 	
-	private void handleStreamException(RPCResponse rpc, Exception e)
+	private void handleStreamException(RPCResponse rpc, Exception e, String error)
 	{
 		StreamRPCResponse result = new StreamRPCResponse();
 		result.setFileName(sFileName);
@@ -96,6 +96,7 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 			if (e != null)
 				sException = sException + " " + e.toString();
 			
+			sException.concat(error);
 			result.setInfo(sException);
 		}
 		if (_proxyListener != null)
@@ -131,6 +132,14 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 			
 			notificationList.clear();			
 			
+			//start reading from the stream at the given offset
+			long iSkipBytes = is.skip(iOffsetCounter);
+
+			if (iOffsetCounter != iSkipBytes)
+			{
+				handleStreamException(null,null," Error, PutFile offset invalid for file: " + sFileName);
+			}
+
 			while (!Thread.interrupted()) {				
 			
 				length = is.read(buffer, 0, BUFF_READ_SIZE);				
@@ -174,7 +183,7 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 				}
 			}
 		} catch (Exception e) {
-			handleStreamException(null, e);
+			handleStreamException(null, e, "");
 		}
 	}
 
@@ -191,7 +200,7 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 		}		
 		else
 		{
-			handleStreamException(response, null);
+			handleStreamException(response, null, "");
 		}		
 		
 		if (response.getSuccess() && streamNote.getBytesComplete().equals(streamNote.getFileSize()) )
@@ -204,6 +213,6 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 	public void onPutFileStreamError(Exception e, String info) 
 	{
 		if (thread != null)
-			handleStreamException(null, e);
+			handleStreamException(null, e, "");
 	}
 }

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
@@ -73,6 +73,7 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 		if (_proxyListener != null)
 			_proxyListener.onStreamRPCResponse(result);
 		stop();
+		_proxy.remPutFileResponseListener(this);
 		return;	
 	}
 	
@@ -104,8 +105,9 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 		if (e != null)
 			e.printStackTrace();
 		stop();
+		_proxy.remPutFileResponseListener(this);
 		return;
-	}	
+	}
 
 	public void run() {
 		int length;

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
@@ -104,7 +104,7 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 			if (e != null)
 				sException = sException + " " + e.toString();
 			
-			sException.concat(error);
+			sException = sException + " " + error;
 			result.setInfo(sException);
 		}
 		if (_proxyListener != null)
@@ -249,6 +249,6 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 	public void onPutFileStreamError(Exception e, String info) 
 	{
 		if (thread != null)
-			handleStreamException(null, e, "");
+			handleStreamException(null, e, info);
 	}
 }

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
@@ -23,7 +23,7 @@ import com.smartdevicelink.proxy.rpc.enums.Result;
 public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileResponseListener, Runnable{
 
 	private Integer iInitialCorrID = 0;
-	public final static int BUFF_READ_SIZE = 150000;
+	private final static int BUFF_READ_SIZE = 1000000;
 	private Hashtable<Integer, OnStreamRPC> notificationList = new Hashtable<Integer, OnStreamRPC>();
 	private Thread thread = null;
 	private long lFileSize = 0;
@@ -152,7 +152,11 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 					pm.setSessionType(_session);
 					pm.setFunctionID(FunctionID.getFunctionID(msg.getFunctionName()));
 					
-					pm.setBulkData(buffer, length);
+					if (buffer.length != length)
+						pm.setBulkData(buffer, length);
+					else
+						pm.setBulkDataNoCopy(buffer);
+
 					pm.setCorrID(msg.getCorrelationID());
 						
 					notification = new OnStreamRPC();

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
@@ -26,7 +26,7 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 	private final static int BUFF_READ_SIZE = 1000000;
 	private Hashtable<Integer, OnStreamRPC> notificationList = new Hashtable<Integer, OnStreamRPC>();
 	private Thread thread = null;
-	private long lFileSize = 0;
+	private int lFileSize = 0;
 	private String sFileName;
 	private SdlProxyBase<IProxyListenerBase> _proxy;
 	private IProxyListenerBase _proxyListener;
@@ -34,9 +34,9 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
     private Object mPauseLock;
     private boolean mPaused;
 
-	public StreamRPCPacketizer(SdlProxyBase<IProxyListenerBase> proxy, IStreamListener streamListener, InputStream is, RPCRequest request, SessionType sType, byte rpcSessionID, byte wiproVersion, long lLength) throws IOException {
+	public StreamRPCPacketizer(SdlProxyBase<IProxyListenerBase> proxy, IStreamListener streamListener, InputStream is, RPCRequest request, SessionType sType, byte rpcSessionID, byte wiproVersion, int iLength) throws IOException {
 		super(streamListener, is, request, sType, rpcSessionID, wiproVersion);
-		lFileSize = lLength;
+		lFileSize = iLength;
 		iInitialCorrID = request.getCorrelationID();
         mPauseLock = new Object();
         mPaused = false;

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
@@ -177,7 +177,8 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 		OnStreamRPC streamNote = notificationList.get(response.getCorrelationID());
 		if (streamNote == null) return;
 
-		_streamListener.onOnStreamRPC(this, streamNote, _session, _rpcSessionID);
+		if (response.getSuccess())
+			_streamListener.onOnStreamRPC(this, streamNote, _session, _rpcSessionID);
 		
 		if (!response.getSuccess())
 		{


### PR DESCRIPTION
:boom: READY FOR REVIEW :boom: 

Related to issue #58 

<h2>Summary</h2>
The PutFile RPC allows a developer to send a PutFile request using an offset and length.  Sending a series of PutFile requests allows a developer to split a large file into smaller blocks.  While having the ability to split large files into chunks is a great feature supported by SDL, the bookkeeping and management of offsets and lengths for each individual file is a cumbersome process that should be abstracted from app developers.  Having a mobile API that creates and sends a stream of PutFile requests reduces a large burden on app developers while working with the PutFile RPC.

<h2>Objective:</h2>
Provide a simple mobile public facing API that allows a developer to send a file via SDL to the vehicle head unit utilizing a stream of PutFile requests.
  
Existing PutFile (request & response) Definition:

```xml
 <function name="PutFile" functionID="PutFileID" messagetype="request">
    <description>
    	Used to push a binary data onto the SYNC module from a mobile device, such as icons and album art
    	Not supported on first generation SYNC vehicles.
    	Binary data is in binary part of hybrid msg.
    </description>

    <param name="syncFileName" type="String" maxlength="255" mandatory="true">
      <description>File reference name.</description>
    </param>

    <param name="fileType" type="FileType" mandatory="true">
      <description>Selected file type.</description>
    </param>

    <param name="persistentFile" type="Boolean" defvalue="false" mandatory="false">
      <description>
      	Indicates if the file is meant to persist between sessions / ignition cycles.
      	If set to TRUE, then the system will aim to persist this file through session / cycles.
      	While files with this designation will have priority over others, they are subject to deletion by the system at any time.
      	In the event of automatic deletion by the system, the app will receive a rejection and have to resend the file.
      	If omitted, the value will be set to false.
      </description>
    </param>

    <param name="systemFile" type="Boolean" defvalue="false" mandatory="false" >
      <description>
      	Indicates if the file is meant to be passed thru core to elsewhere on the system.
      	If set to TRUE, then the system will instead pass the data thru as it arrives to a predetermined area outside of core.
      	If omitted, the value will be set to false.
      </description>
    </param>

    <param name="offset" type="Float" minvalue="0" maxvalue="100000000000" mandatory="false">
      <description>Optional offset in bytes for resuming partial data chunks</description>
    </param>
    <param name="length" type="Float" minvalue="0" maxvalue="100000000000" mandatory="false">
      <description>
      	Optional length in bytes for resuming partial data chunks
      	If offset is set to 0, then length is the total length of the file to be downloaded
      </description>
    </param>  

  </function>

<function name="PutFile" functionID="PutFileID" messagetype="response">
    <description>Response is sent, when the file data was copied (success case). Or when an error occured.</description>
    <description>Not supported on First generation SYNC vehicles. </description>
  	<param name="success" type="Boolean" platform="documentation">
		<description> true, if successful; false, if failed </description>
	</param>
	
    <param name="resultCode" type="Result" platform="documentation">
      <description>See Result</description>
      <element name="SUCCESS"/>
      <element name="INVALID_DATA"/>
      <element name="OUT_OF_MEMORY"/>
      <element name="TOO_MANY_PENDING_REQUESTS"/>
      <element name="APPLICATION_NOT_REGISTERED"/>
      <element name="GENERIC_ERROR"/>      
      <element name="REJECTED"/>
      <element name="UNSUPPORTED_REQUEST"/>                     
    </param>
    
    <param name="spaceAvailable" type="Integer" minvalue="0" maxvalue="2000000000">
          <description>
          	Provides the total local space available in SDL Core for the registered app.
          	If the transfer has systemFile enabled, then the value will be set to 0 automatically.
          </description>
    </param>
    
    <param name="info" type="String" maxlength="1000" mandatory="false" platform="documentation">
      <description>Provides additional human readable info regarding the result.</description>
    </param>
  </function>
```
<h2>Goals:</h2>
- [x] Create a public API that allows developers to provide a path to a particular file on the devices file system, as well as other optional and mandatory putfile parameters (see above).  An automatically calculated stream of putfile requests will then be created utilizing the provided file contents.

Public facing API used to initiate a putfile stream request:
```java
/**
	 * Used to push a stream of putfile RPC's containing binary data from a mobile device to the module.
	 * Responses are captured through callback on IProxyListener.
	 *
	 * @param sPath - The physical file path on the mobile device.
	 * @param sdlFileName - The file reference name used by the putFile RPC.
	 * @param iOffset - The data offset in bytes, a value of zero is used to indicate data starting from the beginging of a file.
	 * A value greater than zero is used for resuming partial data chunks.
	 * @param fileType - The selected file type -- see the FileType enumeration for details
	 * @param bPersistentFile - Indicates if the file is meant to persist between sessions / ignition cycles.
	 * @param  bSystemFile - Indicates if the file is meant to be passed thru core to elsewhere on the system.
	 * @param correlationID - A unique ID that correlates each RPCRequest and RPCResponse.
	 * @return boolean - True if the putfile stream was started successfully, false if an exception occurred during stream creation. 
	 * @throws SdlException
	*/	
	public boolean PutFileStream(String sPath, String sdlFileName, Integer iOffset, FileType fileType, Boolean bPersistentFile, Boolean bSystemFile, Integer iCorrelationID) throws SdlException 

```
- [x] Notify the developer if the PutFileStream was started successfully, on failure log an error to the devices logcat. (accomplished using the api call displayed above available within sdlproxybase.)

- [x] After the stream has started, notify the developer the status of the putfile stream utilizing the OnStreamRPC notification (new).  The notification will include the file name, the bytes completed and the total file size.

- [x] After the stream has finished, notify the developer of the status of the completion (success or failure) using the StreamRPCResponse (new) with a matching correlation id from the initial putfile stream request.

Future enhancements:
- [x] Provide handlers in the new proxy framework to send notifications for each event (start of stream, notification for progress, overall result of stream) via listener interfaces. (To be covered in feature/Framework branch)

PutFileStream Flow
```
App requests a new PutFileStream
proxy.PutFileStream(params)----------->
App receives a status of stream creation
<-----------------PutFileStream success
App receives OnStreamRPC Notifications indicating the current transfer progress
<-----------------OnStreamRPC notification
<-----------------OnStreamRPC notification
<-----------------OnStreamRPC notification
App receives StreamRPCResponse indicating the overall result of the transfer request.
<-----------------StreamRPCResponse response
```

<h3>Other TODO items:</h3>

- [X] The PutFile RPC needs to be updated to accept Longs for setLength and setOffsetValues as we might run into overflows since a Long can store a wider range than an Integer.  A Long is returned for the size of the file from the Android OS, however we have to truncate to an Integer to accommodate the existing PutFile definition.  To be covered in #150 
