### PR TITLE
Changed return type of getMaxDuration in PerformAudioPassThru class

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/PerformAudioPassThru.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/PerformAudioPassThru.java
@@ -218,7 +218,7 @@ public class PerformAudioPassThru extends RPCRequest {
 	 * @return int -an int value representing the maximum duration of audio
 	 *         recording in milliseconds
 	 */
-    public int getMaxDuration() {
+    public Integer getMaxDuration() {
     	return (Integer) parameters.get(KEY_MAX_DURATION);
     }
 


### PR DESCRIPTION
Fixes #80.  Changed return type of getMaxDuration from int to Integer.

Signed-off-by: Mike Burke <mike@livioconnect.com>