### PR TITLE
Return null instead of throwing an exception when reverse-lookup fails in DisplayType

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/DisplayType.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/DisplayType.java
@@ -25,7 +25,7 @@ public enum DisplayType {
             }
         }
 
-        throw new IllegalArgumentException("Unknown value " + value);
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Fixes #79.  Return null instead of throwing an exception when reverse-lookup fails

Signed-off-by: Mike Burke <mike@livioconnect.com>