### PR TITLE
Refactor binary data calls in OnAudioPassThru

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnAudioPassThru.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnAudioPassThru.java
@@ -4,7 +4,6 @@ import java.util.Hashtable;
 
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCNotification;
-import com.smartdevicelink.proxy.RPCStruct;
 
 /**
  * Binary data is in binary part of hybrid msg.
@@ -56,13 +55,9 @@ public class OnAudioPassThru extends RPCNotification {
         super(hash);
     }
     public void setAPTData(byte[] aptData) {
-        if (aptData != null) {
-            store.put(RPCStruct.KEY_BULK_DATA, aptData);
-        } else {
-        	store.remove(RPCStruct.KEY_BULK_DATA);
-        }
+        setBulkData(aptData);
     }
     public byte[] getAPTData() {
-        return (byte[]) store.get(RPCStruct.KEY_BULK_DATA);
+        return getBulkData();
     }
 }


### PR DESCRIPTION
Fixes #85. Forward calls to setAPTData to setBulkData and getAPTData to getBulkData.

Signed-off-by: Mike Burke <mike@livioconnect.com>