### PR TITLE
Refactor fuel level state methods to conform to Java naming conventions

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/GetVehicleData.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/GetVehicleData.java
@@ -78,14 +78,26 @@ public class GetVehicleData extends RPCRequest {
     public Boolean getFuelLevel() {
         return (Boolean) parameters.get(KEY_FUEL_LEVEL);
     }
+    @Deprecated
     public void setFuelLevel_State(Boolean fuelLevel_State) {
         if (fuelLevel_State != null) {
             parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevel_State);
         } else {
-        	parameters.remove(KEY_FUEL_LEVEL_STATE);
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
         }
     }
+    @Deprecated
     public Boolean getFuelLevel_State() {
+        return (Boolean) parameters.get(KEY_FUEL_LEVEL_STATE);
+    }
+    public void setFuelLevelState(Boolean fuelLevelState) {
+        if (fuelLevelState != null) {
+            parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevelState);
+        } else {
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
+        }
+    }
+    public Boolean getFuelLevelState() {
         return (Boolean) parameters.get(KEY_FUEL_LEVEL_STATE);
     }
     public void setInstantFuelConsumption(Boolean instantFuelConsumption) {

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/GetVehicleDataResponse.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/GetVehicleDataResponse.java
@@ -98,23 +98,47 @@ public class GetVehicleDataResponse extends RPCResponse {
     public Double getFuelLevel() {
     	return (Double) parameters.get(KEY_FUEL_LEVEL);
     }
+    @Deprecated
     public void setFuelLevel_State(ComponentVolumeStatus fuelLevel_State) {
-    	if (fuelLevel_State != null) {
-    		parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevel_State);
-    	} else {
-    		parameters.remove(KEY_FUEL_LEVEL_STATE);
-    	}
+        if (fuelLevel_State != null) {
+            parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevel_State);
+        } else {
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
+        }
     }
+    @Deprecated
     public ComponentVolumeStatus getFuelLevel_State() {
         Object obj = parameters.get(KEY_FUEL_LEVEL_STATE);
         if (obj instanceof ComponentVolumeStatus) {
             return (ComponentVolumeStatus) obj;
         } else if (obj instanceof String) {
-        	ComponentVolumeStatus theCode = null;
+            ComponentVolumeStatus theCode = null;
             try {
                 theCode = ComponentVolumeStatus.valueForString((String) obj);
             } catch (Exception e) {
-            	DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_FUEL_LEVEL_STATE, e);
+                DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_FUEL_LEVEL_STATE, e);
+            }
+            return theCode;
+        }
+        return null;
+    }
+    public void setFuelLevelState(ComponentVolumeStatus fuelLevelState) {
+        if (fuelLevelState != null) {
+            parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevelState);
+        } else {
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
+        }
+    }
+    public ComponentVolumeStatus getFuelLevelState() {
+        Object obj = parameters.get(KEY_FUEL_LEVEL_STATE);
+        if (obj instanceof ComponentVolumeStatus) {
+            return (ComponentVolumeStatus) obj;
+        } else if (obj instanceof String) {
+            ComponentVolumeStatus theCode = null;
+            try {
+                theCode = ComponentVolumeStatus.valueForString((String) obj);
+            } catch (Exception e) {
+                DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_FUEL_LEVEL_STATE, e);
             }
             return theCode;
         }

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnVehicleData.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnVehicleData.java
@@ -96,23 +96,47 @@ public class OnVehicleData extends RPCNotification {
     public Double getFuelLevel() {
     	return (Double) parameters.get(KEY_FUEL_LEVEL);
     }
+    @Deprecated
     public void setFuelLevel_State(ComponentVolumeStatus fuelLevel_State) {
-    	if (fuelLevel_State != null) {
-    		parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevel_State);
-    	} else {
-    		parameters.remove(KEY_FUEL_LEVEL_STATE);
-    	}
+        if (fuelLevel_State != null) {
+            parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevel_State);
+        } else {
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
+        }
     }
+    @Deprecated
     public ComponentVolumeStatus getFuelLevel_State() {
         Object obj = parameters.get(KEY_FUEL_LEVEL_STATE);
         if (obj instanceof ComponentVolumeStatus) {
             return (ComponentVolumeStatus) obj;
         } else if (obj instanceof String) {
-        	ComponentVolumeStatus theCode = null;
+            ComponentVolumeStatus theCode = null;
             try {
                 theCode = ComponentVolumeStatus.valueForString((String) obj);
             } catch (Exception e) {
-            	DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_FUEL_LEVEL_STATE, e);
+                DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_FUEL_LEVEL_STATE, e);
+            }
+            return theCode;
+        }
+        return null;
+    }
+    public void setFuelLevelState(ComponentVolumeStatus fuelLevelState) {
+        if (fuelLevelState != null) {
+            parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevelState);
+        } else {
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
+        }
+    }
+    public ComponentVolumeStatus getFuelLevelState() {
+        Object obj = parameters.get(KEY_FUEL_LEVEL_STATE);
+        if (obj instanceof ComponentVolumeStatus) {
+            return (ComponentVolumeStatus) obj;
+        } else if (obj instanceof String) {
+            ComponentVolumeStatus theCode = null;
+            try {
+                theCode = ComponentVolumeStatus.valueForString((String) obj);
+            } catch (Exception e) {
+                DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_FUEL_LEVEL_STATE, e);
             }
             return theCode;
         }

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/SubscribeVehicleData.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/SubscribeVehicleData.java
@@ -163,28 +163,55 @@ public class SubscribeVehicleData extends RPCRequest {
         return (Boolean) parameters.get(KEY_FUEL_LEVEL);
     }
 
-	/**
-	 * Sets a boolean value. If true, subscribes fuelLevel_State data
-	 * 
-	 * @param fuelLevel_State
-	 *            a boolean value
-	 */
+    /**
+     * Sets a boolean value. If true, subscribes fuelLevel_State data
+     * 
+     * @param fuelLevel_State
+     *            a boolean value
+     */
+    @Deprecated
     public void setFuelLevel_State(Boolean fuelLevel_State) {
         if (fuelLevel_State != null) {
             parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevel_State);
         } else {
-        	parameters.remove(KEY_FUEL_LEVEL_STATE);
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
         }
     }
 
-	/**
-	 * Gets a boolean value. If true, means the fuelLevel_State data has been
-	 * subscribed.
-	 * 
-	 * @return Boolean -a Boolean value. If true, means the fuelLevel_State data
-	 *         has been subscribed.
-	 */
+    /**
+     * Gets a boolean value. If true, means the fuelLevel_State data has been
+     * subscribed.
+     * 
+     * @return Boolean -a Boolean value. If true, means the fuelLevel_State data
+     *         has been subscribed.
+     */
+    @Deprecated
     public Boolean getFuelLevel_State() {
+        return (Boolean) parameters.get(KEY_FUEL_LEVEL_STATE);
+    }
+
+    /**
+     * Sets a boolean value. If true, subscribes fuelLevelState data
+     * 
+     * @param fuelLevelState
+     *            a boolean value
+     */
+    public void setFuelLevelState(Boolean fuelLevelState) {
+        if (fuelLevelState != null) {
+            parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevelState);
+        } else {
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
+        }
+    }
+
+    /**
+     * Gets a boolean value. If true, means the fuelLevelState data has been
+     * subscribed.
+     * 
+     * @return Boolean -a Boolean value. If true, means the fuelLevelState data
+     *         has been subscribed.
+     */
+    public Boolean getFuelLevelState() {
         return (Boolean) parameters.get(KEY_FUEL_LEVEL_STATE);
     }
 

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/SubscribeVehicleDataResponse.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/SubscribeVehicleDataResponse.java
@@ -175,11 +175,42 @@ public class SubscribeVehicleDataResponse extends RPCResponse {
      * Sets Fuel Level State
      * @param fuelLevel_State
      */
+    @Deprecated
     public void setFuelLevel_State(VehicleDataResult fuelLevel_State) {
         if (fuelLevel_State != null) {
             parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevel_State);
         } else {
-        	parameters.remove(KEY_FUEL_LEVEL_STATE);
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
+        }
+    }
+    /**
+     * Gets Fuel Level State
+     * @return VehicleDataResult 
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public VehicleDataResult getFuelLevel_State() {
+        Object obj = parameters.get(KEY_FUEL_LEVEL_STATE);
+        if (obj instanceof VehicleDataResult) {
+            return (VehicleDataResult) obj;
+        } else if (obj instanceof Hashtable) {
+            try {
+                return new VehicleDataResult((Hashtable<String, Object>) obj);
+            } catch (Exception e) {
+                DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_FUEL_LEVEL_STATE, e);
+            }
+        }
+        return null;
+    }
+    /**
+     * Sets Fuel Level State
+     * @param fuelLevelState
+     */
+    public void setFuelLevelState(VehicleDataResult fuelLevelState) {
+        if (fuelLevelState != null) {
+            parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevelState);
+        } else {
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
         }
     }
     /**
@@ -187,16 +218,12 @@ public class SubscribeVehicleDataResponse extends RPCResponse {
      * @return VehicleDataResult 
      */
     @SuppressWarnings("unchecked")
-    public VehicleDataResult getFuelLevel_State() {
-    	Object obj = parameters.get(KEY_FUEL_LEVEL_STATE);
+    public VehicleDataResult getFuelLevelState() {
+        Object obj = parameters.get(KEY_FUEL_LEVEL_STATE);
         if (obj instanceof VehicleDataResult) {
             return (VehicleDataResult) obj;
         } else if (obj instanceof Hashtable) {
-        	try {
-        		return new VehicleDataResult((Hashtable<String, Object>) obj);
-            } catch (Exception e) {
-            	DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_FUEL_LEVEL_STATE, e);
-            }
+            return new VehicleDataResult((Hashtable<String, Object>) obj);
         }
         return null;
     }

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
@@ -161,28 +161,55 @@ public class UnsubscribeVehicleData extends RPCRequest {
         return (Boolean) parameters.get(KEY_FUEL_LEVEL);
     }
 
-	/**
-	 * Sets a boolean value. If true, unsubscribes fuelLevel_State data
-	 * 
-	 * @param fuelLevel_State
-	 *            a boolean value
-	 */
+    /**
+     * Sets a boolean value. If true, unsubscribes fuelLevel_State data
+     * 
+     * @param fuelLevel_State
+     *            a boolean value
+     */
+    @Deprecated
     public void setFuelLevel_State(Boolean fuelLevel_State) {
         if (fuelLevel_State != null) {
             parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevel_State);
         } else {
-        	parameters.remove(KEY_FUEL_LEVEL_STATE);
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
         }
     }
 
-	/**
-	 * Gets a boolean value. If true, means the fuelLevel_State data has been
-	 * unsubscribed.
-	 * 
-	 * @return Boolean -a Boolean value. If true, means the fuelLevel_State data
-	 *         has been unsubscribed.
-	 */
+    /**
+     * Gets a boolean value. If true, means the fuelLevel_State data has been
+     * unsubscribed.
+     * 
+     * @return Boolean -a Boolean value. If true, means the fuelLevel_State data
+     *         has been unsubscribed.
+     */
+    @Deprecated
     public Boolean getFuelLevel_State() {
+        return (Boolean) parameters.get(KEY_FUEL_LEVEL_STATE);
+    }
+
+    /**
+     * Sets a boolean value. If true, unsubscribes fuelLevelState data
+     * 
+     * @param fuelLevelState
+     *            a boolean value
+     */
+    public void setFuelLevelState(Boolean fuelLevelState) {
+        if (fuelLevelState != null) {
+            parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevelState);
+        } else {
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
+        }
+    }
+
+    /**
+     * Gets a boolean value. If true, means the fuelLevel_State data has been
+     * unsubscribed.
+     * 
+     * @return Boolean -a Boolean value. If true, means the fuelLevelState data
+     *         has been unsubscribed.
+     */
+    public Boolean getFuelLevelState() {
         return (Boolean) parameters.get(KEY_FUEL_LEVEL_STATE);
     }
 

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleDataResponse.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleDataResponse.java
@@ -175,11 +175,42 @@ public class UnsubscribeVehicleDataResponse extends RPCResponse {
      * Sets Fuel Level State
      * @param fuelLevel_State
      */
+    @Deprecated
     public void setFuelLevel_State(VehicleDataResult fuelLevel_State) {
         if (fuelLevel_State != null) {
             parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevel_State);
         } else {
-        	parameters.remove(KEY_FUEL_LEVEL_STATE);
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
+        }
+    }
+    /**
+     * Gets Fuel Level State
+     * @return VehicleDataResult
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public VehicleDataResult getFuelLevel_State() {
+        Object obj = parameters.get(KEY_FUEL_LEVEL_STATE);
+        if (obj instanceof VehicleDataResult) {
+            return (VehicleDataResult) obj;
+        } else if (obj instanceof Hashtable) {
+            try {
+                return new VehicleDataResult((Hashtable<String, Object>) obj);
+            } catch (Exception e) {
+                DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_FUEL_LEVEL_STATE, e);
+            }
+        }
+        return null;
+    }
+    /**
+     * Sets Fuel Level State
+     * @param fuelLevel_State
+     */
+    public void setFuelLevelState(VehicleDataResult fuelLevelState) {
+        if (fuelLevelState != null) {
+            parameters.put(KEY_FUEL_LEVEL_STATE, fuelLevelState);
+        } else {
+            parameters.remove(KEY_FUEL_LEVEL_STATE);
         }
     }
     /**
@@ -187,16 +218,12 @@ public class UnsubscribeVehicleDataResponse extends RPCResponse {
      * @return VehicleDataResult
      */
     @SuppressWarnings("unchecked")
-    public VehicleDataResult getFuelLevel_State() {
-    	Object obj = parameters.get(KEY_FUEL_LEVEL_STATE);
+    public VehicleDataResult getFuelLevelState() {
+        Object obj = parameters.get(KEY_FUEL_LEVEL_STATE);
         if (obj instanceof VehicleDataResult) {
             return (VehicleDataResult) obj;
         } else if (obj instanceof Hashtable) {
-        	try {
-        		return new VehicleDataResult((Hashtable<String, Object>) obj);
-            } catch (Exception e) {
-            	DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_FUEL_LEVEL_STATE, e);
-            }
+            return new VehicleDataResult((Hashtable<String, Object>) obj);
         }
         return null;
     }


### PR DESCRIPTION
Fixes #84.  Deprecated fuelLevel_State methods and created fuelLevelState methods to follow Java naming conventions

Signed-off-by: Mike Burke <mike@livioconnect.com>