### PR TITLE
Updated rpcs to v4.0 

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
@@ -1,7 +1,7 @@
 package com.smartdevicelink.Dispatcher;
 
-public interface IDispatchingStrategy<messageType> {
-	public void dispatch(messageType message);
+public interface IDispatchingStrategy<T> {
+	public void dispatch(T message);
 	
 	public void handleDispatchingError(String info, Exception ex);
 	

--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
@@ -5,17 +5,17 @@ import java.util.concurrent.PriorityBlockingQueue;
 
 import com.smartdevicelink.util.DebugTool;
 
-public class ProxyMessageDispatcher<messageType> {
-	PriorityBlockingQueue<messageType> _queue = null;
+public class ProxyMessageDispatcher<T> {
+	PriorityBlockingQueue<T> _queue = null;
 	private Thread _messageDispatchingThread = null;
-	IDispatchingStrategy<messageType> _strategy = null;
+	IDispatchingStrategy<T> _strategy = null;
 
 	// Boolean to track if disposed
 	private Boolean dispatcherDisposed = false;
 	
-	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<messageType> messageComparator, 
-			IDispatchingStrategy<messageType> strategy) {
-		_queue = new PriorityBlockingQueue<messageType>(10, messageComparator);
+	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<T> messageComparator, 
+			IDispatchingStrategy<T> strategy) {
+		_queue = new PriorityBlockingQueue<T>(10, messageComparator);
 		
 		_strategy = strategy;
 		
@@ -38,7 +38,7 @@ public class ProxyMessageDispatcher<messageType> {
 	private void handleMessages() {
 		
 		try {
-			messageType thisMessage;
+			T thisMessage;
 		
 			while(dispatcherDisposed == false) {
 				thisMessage = _queue.take();
@@ -53,7 +53,7 @@ public class ProxyMessageDispatcher<messageType> {
 		}
 	}
 		
-	public void queueMessage(messageType message) {
+	public void queueMessage(T message) {
 		try {
 			_queue.put(message);
 		} catch(ClassCastException e) { 

--- a/sdl_android_lib/src/com/smartdevicelink/protocol/enums/FunctionID.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/enums/FunctionID.java
@@ -66,6 +66,7 @@ public class FunctionID {
 	public static final String ON_SDL_CHOICE_CHOSEN = "OnSdlChoiceChosen";
 	
 	public static final String SEND_LOCATION = "SendLocation";
+	public static final String DIAL_NUMBER_ID = "DialNumberID";
 
     public FunctionID() {
     }
@@ -144,7 +145,7 @@ public class FunctionID {
             put(FunctionID.DIAGNOSTIC_MESSAGE, 37);
             put(FunctionID.SYSTEM_REQUEST, 38);
             put(FunctionID.SEND_LOCATION, 39);
-
+            put(FunctionID.DIAL_NUMBER_ID, 40);
             /*
                 Base Notifications
                 Range = 0x 0000 8000 - 0x 0000 FFFF

--- a/sdl_android_lib/src/com/smartdevicelink/protocol/enums/FunctionID.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/enums/FunctionID.java
@@ -66,7 +66,7 @@ public class FunctionID {
 	public static final String ON_SDL_CHOICE_CHOSEN = "OnSdlChoiceChosen";
 	
 	public static final String SEND_LOCATION = "SendLocation";
-	public static final String DIAL_NUMBER_ID = "DialNumberID";
+	public static final String DIAL_NUMBER = "DialNumber";
 
     public FunctionID() {
     }
@@ -145,7 +145,7 @@ public class FunctionID {
             put(FunctionID.DIAGNOSTIC_MESSAGE, 37);
             put(FunctionID.SYSTEM_REQUEST, 38);
             put(FunctionID.SEND_LOCATION, 39);
-            put(FunctionID.DIAL_NUMBER_ID, 40);
+            put(FunctionID.DIAL_NUMBER, 40);
             /*
                 Base Notifications
                 Range = 0x 0000 8000 - 0x 0000 FFFF

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2247,6 +2247,36 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
    					_proxyListener.onSystemRequestResponse((SystemRequestResponse)msg);	
    				}
             }
+            else if (functionName.equals(FunctionID.SEND_LOCATION)) {
+
+   				final SendLocationResponse msg = new SendLocationResponse(hash);
+   				if (_callbackToUIThread) {
+   					// Run in UI thread
+   					_mainUIHandler.post(new Runnable() {
+   						@Override
+   						public void run() {
+   							_proxyListener.onSendLocationResponse(msg);
+   						}
+   					});
+   				} else {
+   					_proxyListener.onSendLocationResponse(msg);	
+   				}
+            }
+            else if (functionName.equals(FunctionID.DIAL_NUMBER)) {
+
+   				final DialNumberResponse msg = new DialNumberResponse(hash);
+   				if (_callbackToUIThread) {
+   					// Run in UI thread
+   					_mainUIHandler.post(new Runnable() {
+   						@Override
+   						public void run() {
+   							_proxyListener.onDialNumberResponse(msg);
+   						}
+   					});
+   				} else {
+   					_proxyListener.onDialNumberResponse(msg);	
+   				}
+            }
 			else {
 				if (_sdlMsgVersion != null) {
 					DebugTool.logError("Unrecognized response Message: " + functionName.toString() + 

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
@@ -10,6 +10,7 @@ import com.smartdevicelink.proxy.rpc.DeleteFileResponse;
 import com.smartdevicelink.proxy.rpc.DeleteInteractionChoiceSetResponse;
 import com.smartdevicelink.proxy.rpc.DeleteSubMenuResponse;
 import com.smartdevicelink.proxy.rpc.DiagnosticMessageResponse;
+import com.smartdevicelink.proxy.rpc.DialNumberResponse;
 import com.smartdevicelink.proxy.rpc.EndAudioPassThruResponse;
 import com.smartdevicelink.proxy.rpc.GenericResponse;
 import com.smartdevicelink.proxy.rpc.GetDTCsResponse;
@@ -36,6 +37,7 @@ import com.smartdevicelink.proxy.rpc.PutFileResponse;
 import com.smartdevicelink.proxy.rpc.ReadDIDResponse;
 import com.smartdevicelink.proxy.rpc.ResetGlobalPropertiesResponse;
 import com.smartdevicelink.proxy.rpc.ScrollableMessageResponse;
+import com.smartdevicelink.proxy.rpc.SendLocationResponse;
 import com.smartdevicelink.proxy.rpc.SetAppIconResponse;
 import com.smartdevicelink.proxy.rpc.SetDisplayLayoutResponse;
 import com.smartdevicelink.proxy.rpc.SetGlobalPropertiesResponse;
@@ -297,4 +299,8 @@ public interface IProxyListenerBase  {
 	public void onGetDTCsResponse(GetDTCsResponse response);
 	
 	public void onOnLockScreenNotification(OnLockScreenStatus notification);
+	
+	public void onDialNumberResponse(DialNumberResponse response);
+	
+	public void onSendLocationResponse(SendLocationResponse response);
 }

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/DialNumber.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/DialNumber.java
@@ -1,0 +1,51 @@
+package com.smartdevicelink.proxy.rpc;
+
+import java.util.Hashtable;
+
+import com.smartdevicelink.protocol.enums.FunctionID;
+import com.smartdevicelink.proxy.RPCRequest;
+
+/**
+ * Dials a phone number and switches to phone application.
+ *
+ * @since SmartDeviceLink 4.0
+ */
+public class DialNumber extends RPCRequest {
+	public static final String KEY_NUMBER = "number";
+
+
+	public DialNumber(){
+        super(FunctionID.DIAL_NUMBER_ID);
+	}
+	
+	public DialNumber(Hashtable<String, Object> hash) {
+		super(hash);
+	}
+
+	/**
+	 * Sets a number to dial
+	 * 
+	 * @param sdlFileName
+	 *             a phone number is a string, which can be up to 40 chars.
+	 *            <p>
+	 *            <b>Notes: </b>Maxlength=40<p>
+	 *             All characters shall be stripped from string except digits 0-9 and * # , ; +
+	 */
+    public void setNumber(String number) {
+        if (number != null) {
+        	number = number.replaceAll("[^0-9*#,;+]", ""); //This will sanitize the input
+            parameters.put(KEY_NUMBER, number);
+        } else {
+        	parameters.remove(KEY_NUMBER);
+        }
+    }
+
+	/**
+	 * Gets a number to dial
+	 * 
+	 * @return String - a String value representing a number to dial
+	 */
+    public String getNumber() {
+        return (String) parameters.get(KEY_NUMBER);
+    }
+}

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/DialNumber.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/DialNumber.java
@@ -15,7 +15,7 @@ public class DialNumber extends RPCRequest {
 
 
 	public DialNumber(){
-        super(FunctionID.DIAL_NUMBER_ID);
+        super(FunctionID.DIAL_NUMBER);
 	}
 	
 	public DialNumber(Hashtable<String, Object> hash) {
@@ -25,7 +25,7 @@ public class DialNumber extends RPCRequest {
 	/**
 	 * Sets a number to dial
 	 * 
-	 * @param sdlFileName
+	 * @param number
 	 *             a phone number is a string, which can be up to 40 chars.
 	 *            <p>
 	 *            <b>Notes: </b>Maxlength=40<p>

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/DialNumberResponse.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/DialNumberResponse.java
@@ -1,0 +1,23 @@
+package com.smartdevicelink.proxy.rpc;
+
+import java.util.Hashtable;
+
+import com.smartdevicelink.protocol.enums.FunctionID;
+import com.smartdevicelink.proxy.RPCResponse;
+
+/**
+ * Dial Number Response is sent, when DialNumber has been called
+ * 
+ * @since SmartDeviceLink 4.0
+ */
+public class DialNumberResponse extends RPCResponse {
+
+    public DialNumberResponse() {
+        super(FunctionID.DIAL_NUMBER_ID);
+    }
+    
+	public DialNumberResponse(Hashtable<String, Object> hash) {
+		super(hash);
+	}
+
+}

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/DialNumberResponse.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/DialNumberResponse.java
@@ -13,7 +13,7 @@ import com.smartdevicelink.proxy.RPCResponse;
 public class DialNumberResponse extends RPCResponse {
 
     public DialNumberResponse() {
-        super(FunctionID.DIAL_NUMBER_ID);
+        super(FunctionID.DIAL_NUMBER);
     }
     
 	public DialNumberResponse(Hashtable<String, Object> hash) {

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/HMICapabilities.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/HMICapabilities.java
@@ -1,0 +1,49 @@
+package com.smartdevicelink.proxy.rpc;
+
+import java.util.Hashtable;
+
+import com.smartdevicelink.proxy.RPCStruct;
+
+public class HMICapabilities extends RPCStruct{
+    public static final String KEY_NAVIGATION = "navigation";
+    public static final String KEY_PHONE_CALL = "phoneCall";
+	
+	 public HMICapabilities() { }
+	  
+	 public HMICapabilities(Hashtable<String, Object> hash) {
+		 super(hash);
+	 }
+	 
+	 public boolean isNavigationAvailable(){
+		 Object available = store.get(KEY_NAVIGATION);
+		 if(available == null){
+			 return false;
+		 }
+		 return (Boolean)available;
+	 }
+	 
+	 public void setNavigationAvilable(Boolean available){
+		 if (available) {
+	            store.put(KEY_NAVIGATION, available);
+	        } else {
+	        	store.remove(KEY_NAVIGATION);
+	        }
+	 }
+	 
+	 public boolean isPhoneCallAvailable(){
+		 Object available = store.get(KEY_PHONE_CALL);
+		 if(available == null){
+			 return false;
+		 }
+		 return (Boolean)available;
+	 }
+	 
+	 public void setPhoneCallAvilable(Boolean available){
+		 if (available) {
+	            store.put(KEY_PHONE_CALL, available);
+	        } else {
+	        	store.remove(KEY_PHONE_CALL);
+	        }
+	 }
+
+}

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
@@ -224,6 +224,18 @@ public class OnSystemRequest extends RPCNotification {
         }
     }
 
+    /**
+     * @deprecated as of SmartDeviceLink 4.0
+     * @param offset
+     */
+    public void setOffset(Integer offset) {
+    	if(offset == null){
+    		setOffset((Long)null);
+    	}else{
+    		setOffset(offset.longValue());
+    	}
+    }
+    
     public Long getOffset() {
         final Object o = parameters.get(KEY_OFFSET);
         
@@ -283,6 +295,18 @@ public class OnSystemRequest extends RPCNotification {
         return null;
     }
 
+    /**
+     * @deprecated as of SmartDeviceLink 4.0
+     * @param length
+     */
+    public void setLength(Integer length) {
+    	if(length == null){
+    		setLength((Long)null);
+    	}else{
+    		setLength(length.longValue());
+    	}
+    }
+    
     public void setLength(Long length) {
         if (length != null) {
             parameters.put(KEY_LENGTH, length);

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
@@ -224,18 +224,22 @@ public class OnSystemRequest extends RPCNotification {
         }
     }
 
-    public Integer getOffset() {
+    public Long getOffset() {
         final Object o = parameters.get(KEY_OFFSET);
         
-        if (o == null) return null;
+        if (o == null){
+        	return null;
+        }
         
         if (o instanceof Integer) {
-            return (Integer) o;
+            return ((Integer) o).longValue();
+        }else if(o instanceof Long){
+        	return (Long) o;
         }
         return null;
     }
 
-    public void setOffset(Integer offset) {
+    public void setOffset(Long offset) {
         if (offset != null) {
             parameters.put(KEY_OFFSET, offset);
         } else {
@@ -264,18 +268,22 @@ public class OnSystemRequest extends RPCNotification {
             parameters.remove(KEY_TIMEOUT);
         }
     }    
-
-    public Integer getLength() {
+    
+    public Long getLength() {
         final Object o = parameters.get(KEY_LENGTH);
-        if (o == null) return null;
+        if (o == null){
+        	return null;
+        }
         		
         if (o instanceof Integer) {
-            return (Integer) o;
+            return ((Integer) o).longValue();
+        }else if(o instanceof Long){
+        	return (Long) o;
         }
         return null;
     }
 
-    public void setLength(Integer length) {
+    public void setLength(Long length) {
         if (length != null) {
             parameters.put(KEY_LENGTH, length);
         } else {

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/PutFile.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/PutFile.java
@@ -141,7 +141,19 @@ public class PutFile extends RPCRequest {
         return getBulkData();
     }
     
+    /**
+     * @deprecated as of SmartDeviceLink 4.0
+     * @param offset
+     */
     public void setOffset(Integer offset) {
+    	if(offset == null){
+    		setOffset((Long)null);
+    	}else{
+    		setOffset(offset.longValue());
+    	}
+    }
+    
+    public void setOffset(Long offset) {
         if (offset != null) {
             parameters.put(KEY_OFFSET, offset);
         } else {
@@ -149,16 +161,34 @@ public class PutFile extends RPCRequest {
         }
     }
 
-    public Integer getOffset() {
+    public Long getOffset() {
         final Object o = parameters.get(KEY_OFFSET);
-        if (o instanceof Integer) {
-            return (Integer) o;
+        if (o == null){
+        	return null;
         }
+        if (o instanceof Integer) {
+            return ((Integer) o).longValue();
+        }else if(o instanceof Long){
+        	return (Long) o;
+        }
+
 
         return null;
     }
 
+    /**
+     * @deprecated as of SmartDeviceLink 4.0
+     * @param length
+     */
     public void setLength(Integer length) {
+    	if(length == null){
+    		setLength((Long)null);
+    	}else{
+    		setLength(length.longValue());
+    	}
+    }
+    
+    public void setLength(Long length) {
         if (length != null) {
             parameters.put(KEY_LENGTH, length);
         } else {
@@ -166,10 +196,15 @@ public class PutFile extends RPCRequest {
         }
     }
 
-    public Integer getLength() {
+    public Long getLength() {
         final Object o = parameters.get(KEY_LENGTH);
+        if (o == null){
+        	return null;
+        }
         if (o instanceof Integer) {
-            return (Integer) o;
+            return ((Integer) o).longValue();
+        }else if(o instanceof Long){
+        	return (Long) o;
         }
 
         return null;

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
@@ -20,20 +20,25 @@ import com.smartdevicelink.util.DebugTool;
  * @since SmartDeviceLink 1.0
  */
 public class RegisterAppInterfaceResponse extends RPCResponse {
-	public static final String KEY_VEHICLE_TYPE = "vehicleType";
-	public static final String KEY_SPEECH_CAPABILITIES = "speechCapabilities";
-	public static final String KEY_VR_CAPABILITIES = "vrCapabilities";
+	public static final String KEY_VEHICLE_TYPE 				= "vehicleType";
+	public static final String KEY_SPEECH_CAPABILITIES 			= "speechCapabilities";
+	public static final String KEY_VR_CAPABILITIES 				= "vrCapabilities";
 	public static final String KEY_AUDIO_PASS_THRU_CAPABILITIES = "audioPassThruCapabilities";
-	public static final String KEY_HMI_ZONE_CAPABILITIES = "hmiZoneCapabilities";
-    public static final String KEY_PRERECORDED_SPEECH = "prerecordedSpeech";
-    public static final String KEY_SUPPORTED_DIAG_MODES = "supportedDiagModes";
-    public static final String KEY_SDL_MSG_VERSION = "syncMsgVersion";
-    public static final String KEY_LANGUAGE = "language";
-    public static final String KEY_BUTTON_CAPABILITIES = "buttonCapabilities";
-    public static final String KEY_DISPLAY_CAPABILITIES = "displayCapabilities";
-    public static final String KEY_HMI_DISPLAY_LANGUAGE = "hmiDisplayLanguage";
-    public static final String KEY_SOFT_BUTTON_CAPABILITIES = "softButtonCapabilities";
-    public static final String KEY_PRESET_BANK_CAPABILITIES = "presetBankCapabilities";
+	public static final String KEY_HMI_ZONE_CAPABILITIES 		= "hmiZoneCapabilities";
+    public static final String KEY_PRERECORDED_SPEECH 			= "prerecordedSpeech";
+    public static final String KEY_SUPPORTED_DIAG_MODES 		= "supportedDiagModes";
+    public static final String KEY_SDL_MSG_VERSION 				= "syncMsgVersion";
+    public static final String KEY_LANGUAGE 					= "language";
+    public static final String KEY_BUTTON_CAPABILITIES 			= "buttonCapabilities";
+    public static final String KEY_DISPLAY_CAPABILITIES 		= "displayCapabilities";
+    public static final String KEY_HMI_DISPLAY_LANGUAGE 		= "hmiDisplayLanguage";
+    public static final String KEY_SOFT_BUTTON_CAPABILITIES 	= "softButtonCapabilities";
+    public static final String KEY_PRESET_BANK_CAPABILITIES 	= "presetBankCapabilities";
+    public static final String KEY_HMI_CAPABILITIES 			= "hmiCapabilities"; //As of v4.0
+    public static final String KEY_SDL_VERSION 					= "sdlVersion"; //As of v4.0
+    public static final String KEY_SYSTEM_SOFTWARE_VERSION		= "systemSoftwareVersion"; //As of v4.0
+
+    
 	/**
 	 * Constructs a new RegisterAppInterfaceResponse object
 	 */
@@ -566,5 +571,48 @@ public class RegisterAppInterfaceResponse extends RPCResponse {
         	}
         }
         return null;
-    }          
+    }
+    
+    public void setHmiCapabilities(HMICapabilities hmiCapabilities) {
+        if (hmiCapabilities != null) {
+        	parameters.put(KEY_HMI_CAPABILITIES, hmiCapabilities);
+        }else{
+        	parameters.remove(KEY_HMI_CAPABILITIES);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public HMICapabilities getHmiCapabilities() {
+    	Object obj = parameters.get(KEY_HMI_CAPABILITIES);
+        if (obj instanceof HMICapabilities) {
+        	return (HMICapabilities)obj;
+        } else if (obj instanceof Hashtable) {
+        	return new HMICapabilities((Hashtable<String, Object>)obj);
+        }
+        return null;
+    }  
+    
+    public void setSdlVersion(String sdlVersion) {
+        if (sdlVersion != null) {
+        	parameters.put(KEY_SDL_VERSION, sdlVersion);
+        }else{
+        	parameters.remove(KEY_SDL_VERSION);
+        }
+    }
+
+    public String getSdlVersion() {    
+    	 return (String) parameters.get(KEY_SDL_VERSION);
+    } 
+    
+    public void setSystemSoftwareVersion(String systemSoftwareVersion) {
+        if (systemSoftwareVersion != null) {
+        	parameters.put(KEY_SYSTEM_SOFTWARE_VERSION, systemSoftwareVersion);
+        }else{
+        	parameters.remove(KEY_SYSTEM_SOFTWARE_VERSION);
+        }
+    }
+
+    public String getSystemSoftwareVersion() {    
+    	 return (String) parameters.get(KEY_SYSTEM_SOFTWARE_VERSION);
+    } 
 }

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/TouchEvent.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/TouchEvent.java
@@ -10,41 +10,55 @@ public class TouchEvent extends RPCStruct {
     public static final String KEY_ID = "id";
     public static final String KEY_TS = "ts";
     public static final String KEY_C = "c";
+    
     public TouchEvent() { }
   
     public TouchEvent(Hashtable<String, Object> hash) {
         super(hash);
     }
+    
     public void setId(Integer id) {
         if (id != null) {
             store.put(KEY_ID, id);
         } else {
         	store.remove(KEY_ID);
         }
-    }    
+    }
+    
     public Integer getId() {
         return (Integer) store.get(KEY_ID);
-    }    
+    }
+    
     @SuppressWarnings("unchecked")
-    public List<Integer> getTs() {
+    public List<Long> getTs() {
     	if(store.get(KEY_TS) instanceof List<?>){
     		List<?> list = (List<?>)store.get(KEY_TS);
     		if(list != null && list.size()>0){
         		Object obj = list.get(0);
-        		if(obj instanceof Integer){
-        			return (List<Integer>) list;
-        		}
-    		}
+        		if(obj instanceof Integer){ //Backwards case
+        			int size = list.size();
+        			List<Integer> listOfInt = (List<Integer>) list;
+        			List<Long> listofLongs = new ArrayList<Long>(size);
+        			for(int i = 0; i<size;i++){
+        				listofLongs.add(listOfInt.get(i).longValue());
+        			}
+        			return listofLongs;
+        		}else if(obj instanceof Long){
+        			return (List<Long>) list;
+        		}    		
+        	}
     	}
         return null;
     }
-    public void setTs(List<Integer> ts) {
+    
+    public void setTs(List<Long> ts) {
         if (ts != null) {
             store.put(KEY_TS, ts);
         } else {
         	store.remove(KEY_TS);
         }
     }
+    
     @SuppressWarnings("unchecked")
     public List<TouchCoord> getC() {
         if (store.get(KEY_C) instanceof List<?>) {
@@ -64,6 +78,7 @@ public class TouchEvent extends RPCStruct {
         }
         return null;
     } 
+    
     public void setC( List<TouchCoord> c ) {
         if (c != null) {
             store.put(KEY_C, c );

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/AppInterfaceUnregisteredReason.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/AppInterfaceUnregisteredReason.java
@@ -81,7 +81,8 @@ public enum AppInterfaceUnregisteredReason {
 	 * 
 	 * @since SmartDeviceLink 4.0
 	 */
-	PROTOCOL_VIOLATION;
+	PROTOCOL_VIOLATION,
+	;
 
     public static AppInterfaceUnregisteredReason valueForString(String value) {
         try{

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/AppInterfaceUnregisteredReason.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/AppInterfaceUnregisteredReason.java
@@ -75,7 +75,13 @@ public enum AppInterfaceUnregisteredReason {
 	 * 
 	 * @since SmartDeviceLink 2.0
 	 */
-	APP_UNAUTHORIZED;
+	APP_UNAUTHORIZED,
+	/**
+	 * The app has committed a protocol violation.
+	 * 
+	 * @since SmartDeviceLink 4.0
+	 */
+	PROTOCOL_VIOLATION;
 
     public static AppInterfaceUnregisteredReason valueForString(String value) {
         try{

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/ImageFieldName.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/ImageFieldName.java
@@ -11,7 +11,14 @@ public enum ImageFieldName {
 	appIcon,
 	graphic,
 	showConstantTBTIcon,
-	showConstantTBTNextTurnIcon;
+	showConstantTBTNextTurnIcon,
+	/**
+     * The optional image of a destination / location
+     * 
+     * @since SmartDeviceLink 4.0
+     */
+	locationImage,
+	;
     
 	public static ImageFieldName valueForString(String value) {
         try{

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/KeyboardEvent.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/KeyboardEvent.java
@@ -5,7 +5,12 @@ public enum KeyboardEvent {
     KEYPRESS,
     ENTRY_SUBMITTED,
     ENTRY_CANCELLED,
-    ENTRY_ABORTED;
+    ENTRY_ABORTED,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    ENTRY_VOICE,
+    ;
 
     public static KeyboardEvent valueForString(String value) {
         try{

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/LayoutMode.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/LayoutMode.java
@@ -2,9 +2,23 @@ package com.smartdevicelink.proxy.rpc.enums;
 
 public enum LayoutMode {
     ICON_ONLY,
+    /**
+     * @deprecated As of SmartDeviceLink 4.0
+     */
     ICON_WITH_SEARCH,
+    /**
+	 * @since SmartDeviceLink 4.0
+     */
+    ICONS_WITH_SEARCH,
     LIST_ONLY,
+    /**
+     * @deprecated As of SmartDeviceLink 4.0
+     */
     LIST_WITH_SEARCH,
+    /**
+	 * @since SmartDeviceLink 4.0
+     */
+    LISTS_WITH_SEARCH,
     KEYBOARD;
 
     public static LayoutMode valueForString(String value) {

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/LayoutMode.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/LayoutMode.java
@@ -2,23 +2,9 @@ package com.smartdevicelink.proxy.rpc.enums;
 
 public enum LayoutMode {
     ICON_ONLY,
-    /**
-     * @deprecated As of SmartDeviceLink 4.0
-     */
     ICON_WITH_SEARCH,
-    /**
-	 * @since SmartDeviceLink 4.0
-     */
-    ICONS_WITH_SEARCH,
     LIST_ONLY,
-    /**
-     * @deprecated As of SmartDeviceLink 4.0
-     */
     LIST_WITH_SEARCH,
-    /**
-	 * @since SmartDeviceLink 4.0
-     */
-    LISTS_WITH_SEARCH,
     KEYBOARD;
 
     public static LayoutMode valueForString(String value) {

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/RequestType.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/RequestType.java
@@ -7,7 +7,64 @@ public enum RequestType {
 	AUTH_REQUEST,
 	AUTH_CHALLENGE,
 	AUTH_ACK,
-	PROPRIETARY;
+	PROPRIETARY,
+	/** 
+     * @since SmartDeviceLink 4.0
+     */
+	QUERY_APPS,
+	/** 
+     * @since SmartDeviceLink 4.0
+     */
+    LAUNCH_APP,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    LOCK_SCREEN_ICON_URL,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    TRAFFIC_MESSAGE_CHANNEL,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    DRIVER_PROFILE,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    VOICE_SEARCH, 
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    NAVIGATION,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    PHONE,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    CLIMATE,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    SETTINGS,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    VEHICLE_DIAGNOSTICS,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    EMERGENCY,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    MEDIA,
+    /** 
+     * @since SmartDeviceLink 4.0
+     */
+    FOTA,
+	;
      
     public static RequestType valueForString(String value) {
         try{

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/Result.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/Result.java
@@ -88,9 +88,12 @@ public enum Result {
 	 */
 	IN_USE,
 	/**
-	 * There is already an existing subscription for this item
+	 *The user has turned off access to vehicle data, and it is globally unavailable to mobile applications.
 	 */
     VEHICLE_DATA_NOT_ALLOWED,
+    /**
+     * The requested vehicle data is not available on this vehicle or is not published.
+     */
 	VEHICLE_DATA_NOT_AVAILABLE,
 	/**
 	 * The requested operation was rejected. No attempt was made to perform the
@@ -114,18 +117,57 @@ public enum Result {
 	 * information on supported buttons on the currently connected SDL platform
 	 */
     UNSUPPORTED_RESOURCE,
+    /**
+     * A specified file could not be found on Sync.
+     */
     FILE_NOT_FOUND,
+    /**
+     * Provided data is valid but something went wrong in the lower layers.
+     */
     GENERIC_ERROR,
+    /**
+     * RPC is not authorized in local policy table.
+     */
     DISALLOWED,
+    /**
+     * RPC is included in a functional group explicitly blocked by the user.
+     */
     USER_DISALLOWED,
+    /**
+     * Overlay reached the maximum timeout and closed.
+     */
     TIMED_OUT,
+    /**
+     * User selected to Cancel Route.
+     */
     CANCEL_ROUTE,
+    /**
+     * The RPC (e.g. ReadDID) executed successfully but the data exceeded the platform maximum threshold and thus, only part of the data is available.
+     */
     TRUNCATED_DATA,
+    /**
+     * The user interrupted the RPC (e.g. PerformAudioPassThru) and indicated to start over.  Note, the app must issue the new RPC.
+     */
     RETRY,
+    /**
+     * The RPC (e.g. SubscribeVehicleData) executed successfully but one or more items have a warning or failure.
+     */
     WARNINGS,
+    /**
+     * The RPC (e.g. Slider) executed successfully and the user elected to save the current position / value.
+     */
     SAVED,
+    /**
+     * The certificate provided during authentication is invalid.
+     */
     INVALID_CERT,
+    /**
+     * The certificate provided during authentication is expired.
+     */
     EXPIRED_CERT,
+    /**
+     * The provided hash ID does not match the hash of the current set of registered data or the core could not resume the previous data.
+     */
     RESUME_FAILED;
 
     public static Result valueForString(String value) {

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/TextFieldName.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/TextFieldName.java
@@ -24,7 +24,32 @@ public enum TextFieldName {
     menuName,
     secondaryText,
     tertiaryText,
-    menuTitle;
+    menuTitle,
+    /**
+     * Optional name / title of intended location for SendLocation.
+     * 
+     * @since SmartDeviceLink 4.0
+     */
+    locationName,
+    /**
+     * Optional description of intended location / establishment (if applicable) for SendLocation
+     * 
+     * @since SmartDeviceLink 4.0
+     */
+    locationDescription,
+    /**
+     * Optional location address (if applicable) for SendLocation.
+     * 
+     * @since SmartDeviceLink 4.0
+     */
+    addressLines,
+    /**
+     * Optional hone number of intended location / establishment (if applicable) for SendLocation.
+     * 
+     * @since SmartDeviceLink 4.0
+     */
+    phoneNumber,
+    ;
 
     public static TextFieldName valueForString(String value) {
         try{

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/VehicleDataResultCode.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/rpc/enums/VehicleDataResultCode.java
@@ -2,6 +2,12 @@ package com.smartdevicelink.proxy.rpc.enums;
 
 public enum VehicleDataResultCode {
 	SUCCESS,
+	/**
+     *DTC / DID request successful, however, not all active DTCs or full contents of DID location available
+     * 
+     * @since SmartDeviceLink 4.0
+     */
+	TRUNCATED_DATA,
 	DISALLOWED,
 	USER_DISALLOWED,
 	INVALID_ID,

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/StreamRPCPacketizer.java
@@ -44,7 +44,7 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements Runnable{
 			
 			int iCorrID = 0;
 			PutFile msg = (PutFile) _request;
-			int iOffsetCounter = msg.getOffset();
+			long iOffsetCounter = msg.getOffset();
 			
 			while (!Thread.interrupted()) {				
 			
@@ -56,7 +56,7 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements Runnable{
 				if (length >= 0) {
 			        
 					if (msg.getOffset() != 0)
-			        	msg.setLength(null); //only need to send length when offset 0
+			        	msg.setLength((Long)null); //only need to send length when offset 0
 
 					byte[] msgBytes = JsonRPCMarshaller.marshall(msg, _wiproVersion);					
 					ProtocolMessage pm = new ProtocolMessage();


### PR DESCRIPTION
:cat2: Ready for review :cat2: 

The following enums need to be updated to match the latest version of the 4.0 mobile api spec:

- [x] LayoutMode (Add and deprecate)
- [x] AppInterfaceUnregisteredReason
- [x] TextFieldName
- [x] ImageFieldName
- [ ] AmbientLightStatus (Did not see updates needed)
- [x] VehicleDataResultCode
- [x] KeyboardEvent
- [x] RequestType
- [ ] Result (Didn't see updates needed, added descriptions to existing values)

The following classes need to be updated to match the latest version of the 4.0 mobile api spec:

- [x] TouchEvent    (Changed timestamp (ts) to use Long instead of Integers)
- [x] HMICapabilities (new)
- [x] FunctionID
- [x] RegisterAppInterface (response)
- [x] PutFile (request)  (Changed offset and length to use Long instead of Integers)
- [x] DialNumber (new - request, response)
- [x] OnSystemRequest (notification) (Changed offset and length to use Long instead of Integers)