### PR TITLE
Feature/audio video streaming services

### DIFF
--- a/sdl_android_lib/AndroidManifest.xml
+++ b/sdl_android_lib/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest package="com.smartdevicelink" xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-sdk android:minSdkVersion="12"/>
+	<uses-sdk android:minSdkVersion="19"/>
    	<!-- Required to use the USB Accessory mode -->
     <uses-feature android:name="android.hardware.usb.accessory"/>
     <application android:debuggable="true"/>

--- a/sdl_android_lib/AndroidManifest.xml
+++ b/sdl_android_lib/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest package="com.smartdevicelink" xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-sdk android:minSdkVersion="19"/>
+	<uses-sdk android:minSdkVersion="8"/>
    	<!-- Required to use the USB Accessory mode -->
     <uses-feature android:name="android.hardware.usb.accessory"/>
     <application android:debuggable="true"/>

--- a/sdl_android_lib/project.properties
+++ b/sdl_android_lib/project.properties
@@ -8,5 +8,5 @@
 # project structure.
 
 # Project target.
-target=android-17
+target=android-18
 android.library=true

--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
@@ -1,7 +1,7 @@
 package com.smartdevicelink.Dispatcher;
 
-public interface IDispatchingStrategy<messageType> {
-	public void dispatch(messageType message);
+public interface IDispatchingStrategy<T> {
+	public void dispatch(T message);
 	
 	public void handleDispatchingError(String info, Exception ex);
 	

--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
@@ -5,17 +5,17 @@ import java.util.concurrent.PriorityBlockingQueue;
 
 import com.smartdevicelink.util.DebugTool;
 
-public class ProxyMessageDispatcher<messageType> {
-	PriorityBlockingQueue<messageType> _queue = null;
+public class ProxyMessageDispatcher<T> {
+	PriorityBlockingQueue<T> _queue = null;
 	private Thread _messageDispatchingThread = null;
-	IDispatchingStrategy<messageType> _strategy = null;
+	IDispatchingStrategy<T> _strategy = null;
 
 	// Boolean to track if disposed
 	private Boolean dispatcherDisposed = false;
 	
-	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<messageType> messageComparator, 
-			IDispatchingStrategy<messageType> strategy) {
-		_queue = new PriorityBlockingQueue<messageType>(10, messageComparator);
+	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<T> messageComparator, 
+			IDispatchingStrategy<T> strategy) {
+		_queue = new PriorityBlockingQueue<T>(10, messageComparator);
 		
 		_strategy = strategy;
 		
@@ -38,7 +38,7 @@ public class ProxyMessageDispatcher<messageType> {
 	private void handleMessages() {
 		
 		try {
-			messageType thisMessage;
+			T thisMessage;
 		
 			while(dispatcherDisposed == false) {
 				thisMessage = _queue.take();
@@ -53,7 +53,7 @@ public class ProxyMessageDispatcher<messageType> {
 		}
 	}
 		
-	public void queueMessage(messageType message) {
+	public void queueMessage(T message) {
 		try {
 			_queue.put(message);
 		} catch(ClassCastException e) { 

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/ISdlConnectionListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/ISdlConnectionListener.java
@@ -10,7 +10,7 @@ public interface ISdlConnectionListener {
 	
 	public void onProtocolMessageReceived(ProtocolMessage msg);
 	
-	public void onProtocolSessionNACKed(SessionType sessionType,
+	public void onProtocolSessionStartedNACKed(SessionType sessionType,
 			byte sessionID, byte version, String correlationID);	
 	
 	public void onProtocolSessionStarted(SessionType sessionType,
@@ -18,6 +18,9 @@ public interface ISdlConnectionListener {
 	
 	public void onProtocolSessionEnded(SessionType sessionType,
 			byte sessionID, String correlationID);
+	
+	public void onProtocolSessionEndedNACKed(SessionType sessionType,
+	byte sessionID, String correlationID);
 	
 	public void onProtocolError(String info, Exception e);
 	

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -1,6 +1,7 @@
 package com.smartdevicelink.SdlConnection;
 
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
@@ -233,8 +234,7 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 	public TransportType getCurrentTransportType() {
 		return _transport.getTransportType();
 	}
-	public void startStream(InputStream is, SessionType sType, byte rpcSessionID) {
-		try {
+	public void startStream(InputStream is, SessionType sType, byte rpcSessionID) throws IOException {
             if (sType.equals(SessionType.NAV))
             {
             	mVideoPacketizer = new StreamPacketizer(this, is, sType, rpcSessionID);
@@ -246,14 +246,10 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
             	mAudioPacketizer = new StreamPacketizer(this, is, sType, rpcSessionID);
             	mAudioPacketizer.sdlConnection = this;
             	mAudioPacketizer.start();            	
-            }            
-		} catch (Exception e) {
-            Log.e("SdlConnection", "Unable to start streaming:" + e.toString());
-        }
+            }
 	}
 	
-	public OutputStream startStream(SessionType sType, byte rpcSessionID) {
-		try {
+	public OutputStream startStream(SessionType sType, byte rpcSessionID) throws IOException {
 			OutputStream os = new PipedOutputStream();
 	        InputStream is = new PipedInputStream((PipedOutputStream) os, BUFF_READ_SIZE);
 			
@@ -276,10 +272,6 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
             	return null;
             }
 			return os;
-		} catch (Exception e) {
-            Log.e("SdlConnection", "Unable to start streaming:" + e.toString());
-        }
-		return null;
 	}
 	
 	
@@ -330,52 +322,64 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 		}
 	}
 	
-	public void stopAudioStream()
+	public boolean stopAudioStream()
 	{
 		if (mAudioPacketizer != null)
 		{
 			mAudioPacketizer.stop();
+			return true;
 		}
+		return false;
 	}
 	
-	public void stopVideoStream()
+	public boolean stopVideoStream()
 	{
 		if (mVideoPacketizer != null)
 		{
 			mVideoPacketizer.stop();
+			return true;
 		}
+		return false;
 	}
 
-	public void pauseAudioStream()
+	public boolean pauseAudioStream()
 	{
 		if (mAudioPacketizer != null)
 		{
 			mAudioPacketizer.pause();
+			return true;
 		}
+		return false;
 	}
 
-	public void pauseVideoStream()
+	public boolean pauseVideoStream()
 	{
 		if (mVideoPacketizer != null)
 		{
 			mVideoPacketizer.pause();
+			return true;
 		}
+		return false;
 	}
 
-	public void resumeAudioStream()
+	public boolean resumeAudioStream()
 	{
 		if (mAudioPacketizer != null)
 		{
 			mAudioPacketizer.resume();
+			return true;
 		}
+		return false;		
 	}
 
-	public void resumeVideoStream()
+	public boolean resumeVideoStream()
 	{
 		if (mVideoPacketizer != null)
 		{
 			mVideoPacketizer.resume();
+			return true;
 		}
+		return false;
 	}
 
 	@Override

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -209,7 +209,7 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 	@Override
 	public void onProtocolSessionNACKed(SessionType sessionType,
 			byte sessionID, byte version, String correlationID) {
-		_connectionListener.onProtocolSessionNACKed(sessionType, sessionID, version, correlationID);
+		_connectionListener.onProtocolSessionStartedNACKed(sessionType, sessionID, version, correlationID);
 	}
 
 	@Override
@@ -444,10 +444,11 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 		}
 
 		@Override
-		public void onProtocolSessionNACKed(SessionType sessionType,
+		public void onProtocolSessionStartedNACKed(SessionType sessionType,
 				byte sessionID, byte version, String correlationID) {
-			for (SdlSession session : listenerList) {
-				session.onProtocolSessionNACKed(sessionType, sessionID, version, correlationID);
+			SdlSession session = findSessionById(sessionID);
+			if (session != null) {
+				session.onProtocolSessionStartedNACKed(sessionType, sessionID, version, correlationID);
 			}			
 		}
 
@@ -455,9 +456,18 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 		public void onHeartbeatTimedOut(byte sessionID) {
 			for (SdlSession session : listenerList) {
 				session.onHeartbeatTimedOut(sessionID);
-			}	
+			}
+		}
+
+		@Override
+		public void onProtocolSessionEndedNACKed(SessionType sessionType, byte sessionID, String correlationID) {
+			SdlSession session = findSessionById(sessionID);
+			if (session != null) {
+				session.onProtocolSessionEndedNACKed(sessionType, sessionID, correlationID);
+			}			
+
 			
-		}				
+		}
 	}
 		
 	public int getRegisterCount() {
@@ -486,5 +496,10 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
         }
     }
 
-
+	@Override
+	public void onProtocolSessionEndedNACKed(SessionType sessionType,
+			byte sessionID, String correlationID) {
+		_connectionListener.onProtocolSessionEndedNACKed(sessionType, sessionID, correlationID);
+		
+	}
 }

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -306,6 +306,22 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 		return null;
 	}
 	
+	public void pauseRPCStream()
+	{
+		if (mRPCPacketizer != null)
+		{
+			mRPCPacketizer.pause();
+		}
+	}
+
+	public void resumeRPCStream()
+	{
+		if (mRPCPacketizer != null)
+		{
+			mRPCPacketizer.resume();
+		}
+	}
+
 	public void stopRPCStream()
 	{
 		if (mRPCPacketizer != null)
@@ -328,8 +344,40 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 		{
 			mVideoPacketizer.stop();
 		}
-	}	
-		
+	}
+
+	public void pauseAudioStream()
+	{
+		if (mAudioPacketizer != null)
+		{
+			mAudioPacketizer.pause();
+		}
+	}
+
+	public void pauseVideoStream()
+	{
+		if (mVideoPacketizer != null)
+		{
+			mVideoPacketizer.pause();
+		}
+	}
+
+	public void resumeAudioStream()
+	{
+		if (mAudioPacketizer != null)
+		{
+			mAudioPacketizer.resume();
+		}
+	}
+
+	public void resumeVideoStream()
+	{
+		if (mVideoPacketizer != null)
+		{
+			mVideoPacketizer.resume();
+		}
+	}
+
 	@Override
 	public void sendStreamPacket(ProtocolMessage pm) {
 		sendMessage(pm);

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -468,9 +468,15 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 		public void onProtocolSessionStarted(SessionType sessionType,
 				byte sessionID, byte version, String correlationID) {
 			for (SdlSession session : listenerList) {
-				if (session.getSessionId() == 0 || sessionType == SessionType.NAV || sessionType == SessionType.PCM) {
+				if (session.getSessionId() == 0) {
 					session.onProtocolSessionStarted(sessionType, sessionID, version, correlationID);
 					break;
+				}
+			}
+			if (sessionType.equals(SessionType.NAV) || sessionType.equals(SessionType.PCM)){
+				SdlSession session = findSessionById(sessionID);
+				if (session != null) {
+					session.onProtocolSessionStarted(sessionType, sessionID, version, correlationID);
 				}
 			}
 		}

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -398,15 +398,21 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 	}
 	
 	public void startEncoder () {
-		mSdlEncoder.startEncoder();
+		if(mSdlEncoder != null) {
+		   mSdlEncoder.startEncoder();
+		}
 	}
 	
 	public void releaseEncoder() {
-		mSdlEncoder.releaseEncoder();
+		if(mSdlEncoder != null) {
+		   mSdlEncoder.releaseEncoder();
+		}
 	}
 	
 	public void drainEncoder(boolean endOfStream) {
-		mSdlEncoder.drainEncoder(endOfStream);
+		if(mSdlEncoder != null) {
+		   mSdlEncoder.drainEncoder(endOfStream);
+		}
 	}
 		
 	@Override

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -8,6 +8,9 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.Vector;
 import android.util.Log;
+import android.view.Surface;
+
+import com.smartdevicelink.encoder.SdlEncoder;
 import com.smartdevicelink.exception.SdlException;
 import com.smartdevicelink.protocol.AbstractProtocol;
 import com.smartdevicelink.protocol.IProtocolListener;
@@ -29,6 +32,7 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 	StreamRPCPacketizer mRPCPacketizer = null;
 	StreamPacketizer mVideoPacketizer = null;
 	StreamPacketizer mAudioPacketizer = null;
+	SdlEncoder mSdlEncoder = null;
 
 	// Thread safety locks
 	Object TRANSPORT_REFERENCE_LOCK = new Object();
@@ -380,8 +384,31 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 			return true;
 		}
 		return false;
+	}	
+	
+	public Surface createOpenGLInputSurface(int frameRate, int iFrameInterval, int width,
+			int height, int bitrate, SessionType sType, byte rpcSessionID) {
+		try {
+			mSdlEncoder = new SdlEncoder(frameRate, iFrameInterval, width,
+					height, bitrate, (PipedOutputStream) startStream(sType, rpcSessionID));
+		} catch (IOException e) {
+			return null;
+		}
+		return mSdlEncoder.prepareEncoder();
 	}
-
+	
+	public void startEncoder () {
+		mSdlEncoder.startEncoder();
+	}
+	
+	public void releaseEncoder() {
+		mSdlEncoder.releaseEncoder();
+	}
+	
+	public void drainEncoder(boolean endOfStream) {
+		mSdlEncoder.drainEncoder(endOfStream);
+	}
+		
 	@Override
 	public void sendStreamPacket(ProtocolMessage pm) {
 		sendMessage(pm);

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -36,6 +36,8 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 	private Object SESSION_LOCK = new Object();
 	private Vector<SdlSession> listenerList = new Vector<SdlSession>();
 	
+	private final static int BUFF_READ_SIZE = 1000000;
+	
 	/**
 	 * Constructor.
 	 * 
@@ -253,7 +255,7 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 	public OutputStream startStream(SessionType sType, byte rpcSessionID) {
 		try {
 			OutputStream os = new PipedOutputStream();
-	        InputStream is = new PipedInputStream((PipedOutputStream) os);
+	        InputStream is = new PipedInputStream((PipedOutputStream) os, BUFF_READ_SIZE);
 			
             if (sType.equals(SessionType.NAV))
             {
@@ -267,7 +269,12 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
             	mAudioPacketizer.sdlConnection = this;
             	mAudioPacketizer.start();            	
             }
-						
+            else
+            {
+            	os.close();
+            	is.close();
+            	return null;
+            }
 			return os;
 		} catch (Exception e) {
             Log.e("SdlConnection", "Unable to start streaming:" + e.toString());
@@ -289,7 +296,7 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 	public OutputStream startRPCStream(RPCRequest request, SessionType sType, byte rpcSessionID, byte wiproVersion) {
 		try {
 			OutputStream os = new PipedOutputStream();
-	        InputStream is = new PipedInputStream((PipedOutputStream) os);
+	        InputStream is = new PipedInputStream((PipedOutputStream) os, BUFF_READ_SIZE);
 	        mRPCPacketizer = new StreamRPCPacketizer(this, is, request, sType, rpcSessionID, wiproVersion);
 	        mRPCPacketizer.start();
 			return os;

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -374,9 +374,9 @@ public class SdlConnection implements IProtocolListener, ITransportListener, ISt
 		public void onProtocolSessionStarted(SessionType sessionType,
 				byte sessionID, byte version, String correlationID) {
 			for (SdlSession session : listenerList) {
-				if (session.getSessionId() == 0 || sessionType == SessionType.NAV) {
+				if (session.getSessionId() == 0 || sessionType == SessionType.NAV || sessionType == SessionType.PCM) {
 					session.onProtocolSessionStarted(sessionType, sessionID, version, correlationID);
-					break; //FIXME: need changes on SDL side, as the sessionID is devided by SDL.
+					break;
 				}
 			}
 		}

--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlSession.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlSession.java
@@ -210,11 +210,15 @@ public class SdlSession implements ISdlConnectionListener, IHeartbeatMonitorList
 	}
 
 	@Override
-	public void onProtocolSessionNACKed(SessionType sessionType,
+	public void onProtocolSessionStartedNACKed(SessionType sessionType,
 			byte sessionID, byte version, String correlationID) {
-		this.sessionListener.onProtocolSessionNACKed(sessionType, sessionID, version, correlationID);		
+		this.sessionListener.onProtocolSessionStartedNACKed(sessionType, sessionID, version, correlationID);		
 	}
 
-
-	
+	@Override
+	public void onProtocolSessionEndedNACKed(SessionType sessionType,
+			byte sessionID, String correlationID) {
+		this.sessionListener.onProtocolSessionEndedNACKed(sessionType, sessionID, correlationID);
+		
+	}
 }

--- a/sdl_android_lib/src/com/smartdevicelink/encoder/SdlEncoder.java
+++ b/sdl_android_lib/src/com/smartdevicelink/encoder/SdlEncoder.java
@@ -1,0 +1,149 @@
+package com.smartdevicelink.encoder;
+
+import java.io.IOException;
+import java.io.PipedOutputStream;
+import java.nio.ByteBuffer;
+
+import android.annotation.TargetApi;
+import android.media.MediaCodec;
+import android.media.MediaCodecInfo;
+import android.media.MediaFormat;
+import android.os.Build;
+import android.view.Surface;
+
+@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+public class SdlEncoder {
+	
+	// parameters for the encoder
+	private static final String _MIME_TYPE = "video/avc"; // H.264/AVC video
+	// private static final String MIME_TYPE = "video/mp4v-es"; //MPEG4 video
+	private static int _FRAME_RATE = 30;
+	private static int _IFRAME_INTERVAL = 5;
+	private static int _FRAME_WIDTH = 800;
+	private static int _FRAME_HEIGHT = 480;
+	private static int _BITRATE = 6000000;
+
+	// encoder state
+	private MediaCodec mEncoder;
+	private PipedOutputStream mOutputStream;
+	
+	// allocate one of these up front so we don't need to do it every time
+	private MediaCodec.BufferInfo mBufferInfo;
+	
+	public SdlEncoder (int frameRate, int iFrameInterval, int width,
+		int height, int bitrate, PipedOutputStream outputStream) {
+		_FRAME_RATE = frameRate;
+		_IFRAME_INTERVAL = iFrameInterval;
+		_FRAME_WIDTH = width;
+		_FRAME_HEIGHT = height;
+		_BITRATE = bitrate;
+		mOutputStream = outputStream;
+	}
+	
+	public Surface prepareEncoder () {
+
+		mBufferInfo = new MediaCodec.BufferInfo();
+
+		MediaFormat format = MediaFormat.createVideoFormat(_MIME_TYPE, _FRAME_WIDTH,
+				_FRAME_HEIGHT);
+
+		// Set some properties. Failing to specify some of these can cause the
+		// MediaCodec
+		// configure() call to throw an unhelpful exception.
+		format.setInteger(MediaFormat.KEY_COLOR_FORMAT,
+				MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface);
+		format.setInteger(MediaFormat.KEY_BIT_RATE, _BITRATE);
+		format.setInteger(MediaFormat.KEY_FRAME_RATE, _FRAME_RATE);
+		format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, _IFRAME_INTERVAL);
+
+		// Create a MediaCodec encoder, and configure it with our format. Get a
+		// Surface
+		// we can use for input and wrap it with a class that handles the EGL
+		// work.
+		//
+		// If you want to have two EGL contexts -- one for display, one for
+		// recording --
+		// you will likely want to defer instantiation of CodecInputSurface
+		// until after the
+		// "display" EGL context is created, then modify the eglCreateContext
+		// call to
+		// take eglGetCurrentContext() as the share_context argument.
+		try {
+			mEncoder = MediaCodec.createEncoderByType(_MIME_TYPE);
+		} catch (Exception e) {e.printStackTrace();}
+		
+		mEncoder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE);
+        return mEncoder.createInputSurface();
+	}
+	
+	public void startEncoder () {
+		mEncoder.start();
+	}
+	
+	/**
+	 * Releases encoder resources.
+	 */
+	public void releaseEncoder() {
+		if (mEncoder != null) {
+			mEncoder.stop();
+			mEncoder.release();
+			mEncoder = null;
+		}
+		if (mOutputStream != null) {
+			try {
+				mOutputStream.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	/**
+	 * Extracts all pending data from the encoder
+	 * <p>
+	 * If endOfStream is not set, this returns when there is no more data to
+	 * drain. If it is set, we send EOS to the encoder, and then iterate until
+	 * we see EOS on the output. Calling this with endOfStream set should be
+	 * done once, right before stopping the muxer.
+	 */
+	public void drainEncoder(boolean endOfStream) {
+		final int TIMEOUT_USEC = 10000;
+
+		if (endOfStream) {
+			mEncoder.signalEndOfInputStream();
+		}
+
+		ByteBuffer[] encoderOutputBuffers = mEncoder.getOutputBuffers();
+		while (true) {
+			int encoderStatus = mEncoder.dequeueOutputBuffer(mBufferInfo,
+					TIMEOUT_USEC);
+			if (encoderStatus == MediaCodec.INFO_TRY_AGAIN_LATER) {
+				// no output available yet
+				if (!endOfStream) {
+					break; // out of while
+				}
+			} else if (encoderStatus == MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED) {
+				// not expected for an encoder
+				encoderOutputBuffers = mEncoder.getOutputBuffers();
+			} else if (encoderStatus == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+			} else if (encoderStatus < 0) {
+			} else {
+				if (mBufferInfo.size != 0) {
+					byte[] dataToWrite = new byte[mBufferInfo.size];
+					encoderOutputBuffers[encoderStatus].get(dataToWrite,
+							mBufferInfo.offset, mBufferInfo.size);
+
+					try {
+						mOutputStream.write(dataToWrite, 0, mBufferInfo.size);
+					} catch (IOException e) {}
+				}
+
+				mEncoder.releaseOutputBuffer(encoderStatus, false);
+
+				if ((mBufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+					break; // out of while
+				}
+			}
+		}
+	}
+}

--- a/sdl_android_lib/src/com/smartdevicelink/encoder/SdlEncoder.java
+++ b/sdl_android_lib/src/com/smartdevicelink/encoder/SdlEncoder.java
@@ -71,13 +71,19 @@ public class SdlEncoder {
 		try {
 			mEncoder = MediaCodec.createEncoderByType(_MIME_TYPE);
 		} catch (Exception e) {e.printStackTrace();}
-		
-		mEncoder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE);
-        return mEncoder.createInputSurface();
+
+		if(mEncoder != null) {
+		   mEncoder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE);
+           return mEncoder.createInputSurface();
+		} else {
+			return null;
+		}
 	}
 	
 	public void startEncoder () {
-		mEncoder.start();
+		if(mEncoder != null) {
+		  mEncoder.start();
+		}
 	}
 	
 	/**
@@ -95,6 +101,7 @@ public class SdlEncoder {
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
+			mOutputStream = null;
 		}
 	}
 
@@ -109,8 +116,11 @@ public class SdlEncoder {
 	public void drainEncoder(boolean endOfStream) {
 		final int TIMEOUT_USEC = 10000;
 
+		if(mEncoder == null || mOutputStream == null) {
+		   return;			
+		}
 		if (endOfStream) {
-			mEncoder.signalEndOfInputStream();
+			  mEncoder.signalEndOfInputStream();
 		}
 
 		ByteBuffer[] encoderOutputBuffers = mEncoder.getOutputBuffers();
@@ -135,7 +145,7 @@ public class SdlEncoder {
 
 					try {
 						mOutputStream.write(dataToWrite, 0, mBufferInfo.size);
-					} catch (IOException e) {}
+					} catch (Exception e) {}
 				}
 
 				mEncoder.releaseOutputBuffer(encoderStatus, false);

--- a/sdl_android_lib/src/com/smartdevicelink/protocol/AbstractProtocol.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/AbstractProtocol.java
@@ -104,6 +104,13 @@ public abstract class AbstractProtocol {
 	
 	// This method handles the end of a protocol session. A callback is 
 	// sent to the protocol listener.
+	protected void handleProtocolSessionEndedNACK(SessionType sessionType,
+			byte sessionID, String correlationID) {
+		_protocolListener.onProtocolSessionEndedNACKed(sessionType, sessionID, correlationID);
+	}	
+	
+	// This method handles the end of a protocol session. A callback is 
+	// sent to the protocol listener.
 	protected void handleProtocolSessionEnded(SessionType sessionType,
 			byte sessionID, String correlationID) {
 		_protocolListener.onProtocolSessionEnded(sessionType, sessionID, correlationID);

--- a/sdl_android_lib/src/com/smartdevicelink/protocol/IProtocolListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/IProtocolListener.java
@@ -18,7 +18,10 @@ public interface IProtocolListener {
 
 	// Called to indicate that a protocol session has ended (from either side)
 	void onProtocolSessionEnded(SessionType sessionType, byte sessionID, String correlationID /*, String info, Exception ex*/);
- 	/**
+ 	
+	void onProtocolSessionEndedNACKed(SessionType sessionType, byte sessionID, String correlationID /*, String info, Exception ex*/);
+	
+	/**
      * Called when a protocol heartbeat ACK message has been received from SDL.
      */
     void onProtocolHeartbeatACK(SessionType sessionType, byte sessionID);

--- a/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
@@ -90,7 +90,7 @@ public class WiProProtocol extends AbstractProtocol {
 		byte sessionID = protocolMsg.getSessionID();
 		
 		byte[] data = null;
-		if (_version > 1 && sessionType != SessionType.NAV) {
+		if (_version > 1 && sessionType != SessionType.NAV && sessionType != SessionType.PCM) {
 			if (protocolMsg.getBulkData() != null) {
 				data = new byte[12 + protocolMsg.getJsonSize() + protocolMsg.getBulkData().length];
 				sessionType = SessionType.Bulk_Data;
@@ -424,7 +424,7 @@ public class WiProProtocol extends AbstractProtocol {
 				if (_version > 1) hashID = header.getMessageID();
 				handleProtocolSessionStarted(header.getSessionType(), header.getSessionID(), _version, "");				
 			} else if (header.getFrameData() == FrameDataControlFrameType.StartSessionNACK.getValue()) {
-				if (header.getSessionType().eq(SessionType.NAV)) {
+				if (header.getSessionType().eq(SessionType.NAV) || header.getSessionType().eq(SessionType.PCM)) {
 					handleProtocolSessionNACKed(header.getSessionType(), header.getSessionID(), _version, "");
 				} else {
 					handleProtocolError("Got StartSessionNACK for protocol sessionID=" + header.getSessionID(), null);

--- a/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
@@ -437,7 +437,10 @@ public class WiProProtocol extends AbstractProtocol {
 				} else handleProtocolSessionEnded(header.getSessionType(), header.getSessionID(), "");
 			} else if (header.getFrameData() == FrameDataControlFrameType.EndSessionACK.getValue()) {
 				handleProtocolSessionEnded(header.getSessionType(), header.getSessionID(), "");
+			} else if (header.getFrameData() == FrameDataControlFrameType.EndSessionNACK.getValue()) {
+				handleProtocolSessionEndedNACK(header.getSessionType(), header.getSessionID(), "");
 			}
+            
 		} // end-method
 				
 		private void handleSingleFrameMessageFrame(ProtocolFrameHeader header, byte[] data) {

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2892,8 +2892,10 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	}	
 	
 	
-	
-	
+	/**
+	 *Opens the video service (serviceType 11) and subsequently streams raw H264 video from an InputStream provided by the app
+	 *@return true if service is opened successfully and stream is started, return false otherwise
+	 */
 	public boolean startH264(InputStream is) {
 		
 		if (sdlSession == null) return false;		
@@ -2914,13 +2916,21 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		fTask = null;
 
 		if (navServiceStartResponse) {
-			sdlConn.startStream(is, SessionType.NAV, sdlSession.getSessionId());
-			return true;
+			try {
+				sdlConn.startStream(is, SessionType.NAV, sdlSession.getSessionId());
+				return true;
+			} catch (Exception e) {
+				return false;
+			}			
 		} else {
 			return false;
 		}
 	}
 	
+	/**
+	 *Opens the video service (serviceType 11) and subsequently provides an OutputStream to the app to use for a raw H264 video stream
+	 *@return OutputStream if service is opened successfully and stream is started, return null otherwise  
+	 */	
 	public OutputStream startH264() {
 
 		if (sdlSession == null) return null;		
@@ -2941,12 +2951,20 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		fTask = null;
 
 		if (navServiceStartResponse) {
-			return sdlConn.startStream(SessionType.NAV, sdlSession.getSessionId());
+			try {
+				return sdlConn.startStream(SessionType.NAV, sdlSession.getSessionId());
+			} catch (Exception e) {
+				return null;
+			}
 		} else {
 			return null;
 		}
 	}	
 	
+	/**
+	 *Closes the opened video service (serviceType 11)
+	 *@return true if the video service is closed successfully, return false otherwise  
+	 */	
 	public boolean endH264() {
 		if (sdlSession == null) return false;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
@@ -2972,42 +2990,59 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 	}
 	
+	/**
+	 *Pauses the stream for the opened audio service (serviceType 10)
+	 *@return true if the audio service stream is paused successfully, return false otherwise  
+	 */		
 	public boolean pausePCM()
 	{
 		if (sdlSession == null) return false;
 		SdlConnection sdlConn = sdlSession.getSdlConnection();
 		if (sdlConn == null) return false;
-		sdlConn.pauseAudioStream();
-		return true;
+		return sdlConn.pauseAudioStream();		
 	}
 
+	/**
+	 *Pauses the stream for the opened video service (serviceType 11)
+	 *@return true if the video service stream is paused successfully, return false otherwise  
+	 */	
 	public boolean pauseH264()
 	{
 		if (sdlSession == null) return false;
 		SdlConnection sdlConn = sdlSession.getSdlConnection();
 		if (sdlConn == null) return false;
-		sdlConn.pauseVideoStream();
-		return true;
+		return sdlConn.pauseVideoStream();		
 	}
 
+	/**
+	 *Resumes the stream for the opened audio service (serviceType 10)
+	 *@return true if the audio service stream is resumed successfully, return false otherwise  
+	 */	
 	public boolean resumePCM()
 	{
 		if (sdlSession == null) return false;
 		SdlConnection sdlConn = sdlSession.getSdlConnection();
 		if (sdlConn == null) return false;
-		sdlConn.resumeAudioStream();
-		return true;
+		return sdlConn.resumeAudioStream();		
 	}
 
+	/**
+	 *Resumes the stream for the opened video service (serviceType 11)
+	 *@return true if the video service is resumed successfully, return false otherwise  
+	 */	
 	public boolean resumeH264()
 	{
 		if (sdlSession == null) return false;
 		SdlConnection sdlConn = sdlSession.getSdlConnection();
 		if (sdlConn == null) return false;
-		sdlConn.resumeVideoStream();
-		return true;
+		return sdlConn.resumeVideoStream();	
 	}
 
+	
+	/**
+	 *Opens the audio service (serviceType 10) and subsequently streams raw PCM audio from an InputStream provided by the app
+	 *@return true if service is opened successfully and stream is started, return false otherwise  
+	 */
 	public boolean startPCM(InputStream is) {
 		if (sdlSession == null) return false;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
@@ -3028,13 +3063,21 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		fTask = null;
 
 		if (pcmServiceStartResponse) {
-			sdlConn.startStream(is, SessionType.PCM, sdlSession.getSessionId());
-			return true;
+			try {
+				sdlConn.startStream(is, SessionType.PCM, sdlSession.getSessionId());
+				return true;
+			} catch (Exception e) {
+				return false;
+			}			
 		} else {
 			return false;
 		}
 	}
 	
+	/**
+	 *Opens the audio service (serviceType 10) and subsequently provides an OutputStream to the app
+	 *@return OutputStream if service is opened successfully and stream is started, return null otherwise  
+	 */		
 	public OutputStream startPCM() {
 		if (sdlSession == null) return null;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
@@ -3053,11 +3096,20 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		fTask = null;
 
 		if (pcmServiceStartResponse) {
-			return sdlConn.startStream(SessionType.PCM, sdlSession.getSessionId());
+			try {
+				return sdlConn.startStream(SessionType.PCM, sdlSession.getSessionId());
+			} catch (Exception e) {
+				return null;
+			}
 		} else {
 			return null;
 		}
 	}
+	
+	/**
+	 *Closes the opened audio service (serviceType 10)
+	 *@return true if the audio service is closed successfully, return false otherwise  
+	 */		
 	public boolean endPCM() {
 		if (sdlSession == null) return false;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -276,12 +276,12 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 
 		@Override
-		public void onProtocolSessionNACKed(SessionType sessionType,
+		public void onProtocolSessionStartedNACKed(SessionType sessionType,
 				byte sessionID, byte version, String correlationID) {
 			if (sessionType.eq(SessionType.NAV)) {
 				
 				Intent sendIntent = createBroadcastIntent();
-				updateBroadcastIntent(sendIntent, "FUNCTION_NAME", "onProtocolSessionNACKed");
+				updateBroadcastIntent(sendIntent, "FUNCTION_NAME", "onProtocolSessionStartedNACKed");
 				updateBroadcastIntent(sendIntent, "COMMENT1", "SessionID: " + sessionID);
 				updateBroadcastIntent(sendIntent, "COMMENT2", " NACK ServiceType: " + sessionType.getName());
 				sendBroadcastIntent(sendIntent);
@@ -290,7 +290,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}
 			else if (sessionType.eq(SessionType.PCM)) {
 				Intent sendIntent = createBroadcastIntent();
-				updateBroadcastIntent(sendIntent, "FUNCTION_NAME", "onProtocolSessionNACKed");
+				updateBroadcastIntent(sendIntent, "FUNCTION_NAME", "onProtocolSessionStartedNACKed");
 				updateBroadcastIntent(sendIntent, "COMMENT1", "SessionID: " + sessionID);
 				updateBroadcastIntent(sendIntent, "COMMENT2", " NACK ServiceType: " + sessionType.getName());
 				sendBroadcastIntent(sendIntent);
@@ -302,8 +302,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		@Override
 		public void onProtocolSessionEnded(SessionType sessionType,
 				byte sessionID, String correlationID) {
-			// How to handle protocol session ended?
-				// How should protocol session management occur? 
+			//set the boolean associated our end request to true
 		}
 
 		@Override
@@ -322,6 +321,13 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			sendBroadcastIntent(sendIntent);	            
             
             notifyProxyClosed(msg, new SdlException(msg, SdlExceptionCause.HEARTBEAT_PAST_DUE), SdlDisconnectedReason.HB_TIMEOUT);
+			
+		}
+
+		@Override
+		public void onProtocolSessionEndedNACKed(SessionType sessionType,
+				byte sessionID, String correlationID) {
+				//set the boolean associated with our end request to false
 			
 		}
 	}

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -30,6 +30,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.telephony.TelephonyManager;
 import android.util.Log;
+import android.view.Surface;
 
 import com.smartdevicelink.proxy.RPCRequestFactory;
 import com.smartdevicelink.proxy.rpc.PutFile;
@@ -3134,6 +3135,58 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			return false;
 		}
 	}
+    
+    public Surface createOpenGLInputSurface(int frameRate, int iFrameInterval, int width,
+                                            int height, int bitrate) {
+        
+        if (sdlSession == null) return null;
+        SdlConnection sdlConn = sdlSession.getSdlConnection();
+        if (sdlConn == null) return null;
+        
+        navServiceStartResponseReceived = false;
+        navServiceStartResponse = false;
+        sdlConn.startService(SessionType.NAV, sdlSession.getSessionId());
+        
+        FutureTask<Void> fTask =  createFutureTask(new CallableMethod(2000));
+        ScheduledExecutorService scheduler = createScheduler();
+        scheduler.execute(fTask);
+        
+        while (!navServiceStartResponseReceived && !fTask.isDone());
+        scheduler.shutdown();
+        scheduler = null;
+        fTask = null;
+        
+        if (navServiceStartResponse) {
+            return sdlConn.createOpenGLInputSurface(frameRate, iFrameInterval, width,
+                                                    height, bitrate, SessionType.NAV, sdlSession.getSessionId());
+        } else {
+            return null;
+        }
+    }
+    
+    public void startEncoder () {
+        if (sdlSession == null) return;
+        SdlConnection sdlConn = sdlSession.getSdlConnection();
+        if (sdlConn == null) return;
+        
+        sdlConn.startEncoder();
+    }
+    
+    public void releaseEncoder() {
+        if (sdlSession == null) return;
+        SdlConnection sdlConn = sdlSession.getSdlConnection();
+        if (sdlConn == null) return;
+        
+        sdlConn.releaseEncoder();
+    }
+    
+    public void drainEncoder(boolean endOfStream) {
+        if (sdlSession == null) return;		
+        SdlConnection sdlConn = sdlSession.getSdlConnection();		
+        if (sdlConn == null) return;
+        
+        sdlConn.drainEncoder(endOfStream);
+    }
 	
 	private void NavServiceStarted() {
 		navServiceStartResponseReceived = true;

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2908,7 +2908,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		ScheduledExecutorService scheduler = createScheduler();
 		scheduler.execute(fTask);
 
-		while (!navServiceStartResponseReceived || !fTask.isDone());
+		while (!navServiceStartResponseReceived && !fTask.isDone());
 		scheduler.shutdown();
 		scheduler = null;
 		fTask = null;
@@ -2935,7 +2935,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		ScheduledExecutorService scheduler = createScheduler();
 		scheduler.execute(fTask);
 
-		while (!navServiceStartResponseReceived  || !fTask.isDone());
+		while (!navServiceStartResponseReceived  && !fTask.isDone());
 		scheduler.shutdown();
 		scheduler = null;
 		fTask = null;
@@ -2960,7 +2960,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		ScheduledExecutorService scheduler = createScheduler();
 		scheduler.execute(fTask);
 
-		while (!navServiceEndResponseReceived || !fTask.isDone());
+		while (!navServiceEndResponseReceived && !fTask.isDone());
 		scheduler.shutdown();
 		scheduler = null;
 		fTask = null;
@@ -3022,7 +3022,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		ScheduledExecutorService scheduler = createScheduler();
 		scheduler.execute(fTask);
 
-		while (!pcmServiceStartResponseReceived  || !fTask.isDone());
+		while (!pcmServiceStartResponseReceived  && !fTask.isDone());
 		scheduler.shutdown();
 		scheduler = null;
 		fTask = null;
@@ -3047,7 +3047,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		ScheduledExecutorService scheduler = createScheduler();
 		scheduler.execute(fTask);
 
-		while (!pcmServiceStartResponseReceived || !fTask.isDone());
+		while (!pcmServiceStartResponseReceived && !fTask.isDone());
 		scheduler.shutdown();
 		scheduler = null;
 		fTask = null;
@@ -3071,7 +3071,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		ScheduledExecutorService scheduler = createScheduler();
 		scheduler.execute(fTask);
 
-		while (!pcmServiceEndResponseReceived || !fTask.isDone());
+		while (!pcmServiceEndResponseReceived && !fTask.isDone());
 		scheduler.shutdown();
 		scheduler = null;
 		fTask = null;

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -53,6 +53,7 @@ import com.smartdevicelink.proxy.callbacks.InternalProxyMessage;
 import com.smartdevicelink.proxy.callbacks.OnError;
 import com.smartdevicelink.proxy.callbacks.OnProxyClosed;
 import com.smartdevicelink.proxy.callbacks.OnServiceEnded;
+import com.smartdevicelink.proxy.callbacks.OnServiceNACKed;
 import com.smartdevicelink.proxy.interfaces.IProxyListenerALM;
 import com.smartdevicelink.proxy.interfaces.IProxyListenerBase;
 import com.smartdevicelink.proxy.rpc.*;
@@ -285,6 +286,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		@Override
 		public void onProtocolSessionStartedNACKed(SessionType sessionType,
 				byte sessionID, byte version, String correlationID) {
+			OnServiceNACKed message = new OnServiceNACKed(sessionType);
+			queueInternalMessage(message);
+			
 			if (sessionType.eq(SessionType.NAV)) {
 				
 				Intent sendIntent = createBroadcastIntent();
@@ -1430,6 +1434,19 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					});
 				} else {
 					_proxyListener.onServiceEnded(msg);
+				}
+			} else if (message.getFunctionName().equals(InternalProxyMessage.OnServiceNACKed)) {
+				final OnServiceNACKed msg = (OnServiceNACKed)message;
+				if (_callbackToUIThread) {
+					// Run in UI thread
+					_mainUIHandler.post(new Runnable() {
+						@Override
+						public void run() {
+							_proxyListener.onServiceNACKed(msg);
+						}
+					});
+				} else {
+					_proxyListener.onServiceNACKed(msg);
 				}
 
 			/**************Start Legacy Specific Call-backs************/

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -117,9 +117,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 	private boolean navServiceResponseReceived = false;
 	private boolean navServiceResponse = false;
-	@SuppressWarnings("unused")
     private boolean pcmServiceResponseReceived = false;
-	@SuppressWarnings("unused")
     private boolean pcmServiceResponse = false;
 	
 	// Device Info for logging
@@ -2757,7 +2755,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		if (sdlSession == null) return;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
 		if (sdlConn == null) return;
-		sdlConn.stopStream();
+		sdlConn.stopRPCStream();
 	}
 	
 	
@@ -2806,7 +2804,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		if (sdlSession == null) return;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
 		if (sdlConn == null) return;
-		sdlConn.endService(SessionType.NAV, sdlSession.getSessionId());
+		sdlConn.stopVideoStream();
 	}
 	
 	public boolean startPCM(InputStream is) {
@@ -2853,7 +2851,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
 		if (sdlConn == null) return;
 		
-		sdlConn.endService(SessionType.PCM, sdlSession.getSessionId());
+		sdlConn.stopAudioStream();
 	}	
 	
 	private void NavServiceStarted() {

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -81,6 +81,7 @@ import com.smartdevicelink.proxy.rpc.enums.SystemContext;
 import com.smartdevicelink.proxy.rpc.enums.TextAlignment;
 import com.smartdevicelink.proxy.rpc.enums.UpdateMode;
 import com.smartdevicelink.proxy.rpc.enums.VrCapabilities;
+import com.smartdevicelink.streaming.StreamRPCPacketizer;
 import com.smartdevicelink.trace.SdlTrace;
 import com.smartdevicelink.trace.TraceDeviceInfo;
 import com.smartdevicelink.trace.enums.InterfaceActivityDirection;
@@ -201,7 +202,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	protected Boolean firstTimeFull = true;
 	protected String _proxyVersionInfo = null;
 	protected Boolean _bResumeSuccess = false;
-	
+	private StreamRPCPacketizer rpcPacketizer = null;
+
 	protected byte _wiproVersion = 1;
 	
 	// Interface broker
@@ -2804,6 +2806,24 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 	}
 	
+	public boolean pausePutFileStream()
+	{
+		if (rpcPacketizer == null)
+			return false;
+		rpcPacketizer.pause();
+
+		return true;
+	}
+
+	public boolean resumePutFileStream()
+	{
+		if (rpcPacketizer == null)
+			return false;
+		rpcPacketizer.resume();
+
+		return true;
+	}
+
 	public boolean startRPCStream(InputStream is, RPCRequest msg) {
 		if (sdlSession == null) return false;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
@@ -2824,6 +2844,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
 		if (sdlConn == null) return;
 		sdlConn.stopRPCStream();
+
+		if (rpcPacketizer != null)
+			rpcPacketizer.stop();
 	}
 	
 
@@ -2932,6 +2955,42 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 	}
 	
+	public boolean pausePCM()
+	{
+		if (sdlSession == null) return false;
+		SdlConnection sdlConn = sdlSession.getSdlConnection();
+		if (sdlConn == null) return false;
+		sdlConn.pauseAudioStream();
+		return true;
+	}
+
+	public boolean pauseH264()
+	{
+		if (sdlSession == null) return false;
+		SdlConnection sdlConn = sdlSession.getSdlConnection();
+		if (sdlConn == null) return false;
+		sdlConn.pauseVideoStream();
+		return true;
+	}
+
+	public boolean resumePCM()
+	{
+		if (sdlSession == null) return false;
+		SdlConnection sdlConn = sdlSession.getSdlConnection();
+		if (sdlConn == null) return false;
+		sdlConn.resumeAudioStream();
+		return true;
+	}
+
+	public boolean resumeH264()
+	{
+		if (sdlSession == null) return false;
+		SdlConnection sdlConn = sdlSession.getSdlConnection();
+		if (sdlConn == null) return false;
+		sdlConn.resumeVideoStream();
+		return true;
+	}
+
 	public boolean startPCM(InputStream is) {
 		if (sdlSession == null) return false;		
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -246,7 +246,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			Intent sendIntent = createBroadcastIntent();
 			updateBroadcastIntent(sendIntent, "FUNCTION_NAME", "onProtocolSessionStarted");
 			updateBroadcastIntent(sendIntent, "COMMENT1", "SessionID: " + sessionID);
-			updateBroadcastIntent(sendIntent, "COMMENT2", " SessionType: " + sessionType.getName());
+			updateBroadcastIntent(sendIntent, "COMMENT2", " ServiceType: " + sessionType.getName());
 			sendBroadcastIntent(sendIntent);	
 			
 			setWiProVersion(version);
@@ -262,7 +262,10 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				startRPCProtocolSession(sessionID, correlationID);
 			} else if (sessionType.eq(SessionType.NAV)) {
 				NavServiceStarted();
-			} else if (_wiproVersion > 1) {
+			} else if (sessionType.eq(SessionType.PCM)) {
+				AudioServiceStarted();
+			} 
+			else if (_wiproVersion > 1) {
 				//If version is 2 or above then don't need to specify a Session Type
 				startRPCProtocolSession(sessionID, correlationID);
 			}  else {
@@ -275,6 +278,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				byte sessionID, byte version, String correlationID) {
 			if (sessionType.eq(SessionType.NAV)) {
 				NavServiceEnded();
+			}
+			else if (sessionType.eq(SessionType.PCM)) {
+				AudioServiceEnded();
 			}
 		}
 
@@ -2795,15 +2801,15 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
 		if (sdlConn == null) return false;		
 		
-		navServiceResponseReceived = false;
-		navServiceResponse = false;
+		pcmServiceResponseReceived = false;
+		pcmServiceResponse = false;
 
 		sdlConn.startService(SessionType.PCM, sdlSession.getSessionId());
 		int infiniteLoopKiller = 0;
-		while (!navServiceResponseReceived && infiniteLoopKiller<2147483647) {
+		while (!pcmServiceResponseReceived && infiniteLoopKiller<2147483647) {
 			infiniteLoopKiller++;
 		}
-		if (navServiceResponse) {
+		if (pcmServiceResponse) {
 			sdlConn.startStream(is, SessionType.PCM, sdlSession.getSessionId());
 			return true;
 		} else {
@@ -2816,14 +2822,14 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		SdlConnection sdlConn = sdlSession.getSdlConnection();		
 		if (sdlConn == null) return null;		
 		
-		navServiceResponseReceived = false;
-		navServiceResponse = false;
+		pcmServiceResponseReceived = false;
+		pcmServiceResponse = false;
 		sdlConn.startService(SessionType.PCM, sdlSession.getSessionId());
 		int infiniteLoopKiller = 0;
-		while (!navServiceResponseReceived && infiniteLoopKiller<2147483647) {
+		while (!pcmServiceResponseReceived && infiniteLoopKiller<2147483647) {
 			infiniteLoopKiller++;
 		}
-		if (navServiceResponse) {
+		if (pcmServiceResponse) {
 			return sdlConn.startStream(SessionType.PCM, sdlSession.getSessionId());
 		} else {
 			return null;
@@ -2847,13 +2853,11 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		navServiceResponse = false;
 	}
 	
-	@SuppressWarnings("unused")
     private void AudioServiceStarted() {
 		pcmServiceResponseReceived = true;
 		pcmServiceResponse = true;
 	}
 	
-	@SuppressWarnings("unused")
     private void AudioServiceEnded() {
 		pcmServiceResponseReceived = true;
 		pcmServiceResponse = false;

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -87,6 +87,10 @@ import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.SiphonServer;
 import com.smartdevicelink.transport.TransportType;
 import com.smartdevicelink.util.DebugTool;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ScheduledExecutorService;
 
 public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase> {
 	// Used for calls to Android Log class.
@@ -2758,6 +2762,33 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		sdlConn.stopRPCStream();
 	}
 	
+
+	
+	private class CallableMethod implements Callable<Void> {
+	private long waitTime;
+
+	public CallableMethod(int timeInMillis){
+		this.waitTime=timeInMillis;
+	}
+	@Override
+	public Void call() {
+		try {
+			Thread.sleep(waitTime);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+	}		
+	public FutureTask<Void> createFutureTask(CallableMethod callMethod){
+			return new FutureTask<Void>(callMethod);
+	}
+	public ScheduledExecutorService createScheduler(){
+		return  Executors.newSingleThreadScheduledExecutor();
+	}	
+	
+	
+	
 	
 	public boolean startH264(InputStream is) {
 		
@@ -2768,10 +2799,16 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		navServiceResponseReceived = false;
 		navServiceResponse = false;
 		sdlConn.startService(SessionType.NAV, sdlSession.getSessionId());
-		int infiniteLoopKiller = 0;
-		while (!navServiceResponseReceived && infiniteLoopKiller<2147483647) {
-			infiniteLoopKiller++;
-		}
+
+		FutureTask<Void> fTask =  createFutureTask(new CallableMethod(2000));
+		ScheduledExecutorService scheduler = createScheduler();
+		scheduler.execute(fTask);
+		
+		while (!navServiceResponseReceived || !fTask.isDone());
+		scheduler.shutdown();
+		scheduler = null;
+		fTask = null;		
+		
 		if (navServiceResponse) {
 			sdlConn.startStream(is, SessionType.NAV, sdlSession.getSessionId());
 			return true;
@@ -2789,10 +2826,16 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		navServiceResponseReceived = false;
 		navServiceResponse = false;
 		sdlConn.startService(SessionType.NAV, sdlSession.getSessionId());
-		int infiniteLoopKiller = 0;
-		while (!navServiceResponseReceived && infiniteLoopKiller<2147483647) {
-			infiniteLoopKiller++;
-		}
+
+		FutureTask<Void> fTask =  createFutureTask(new CallableMethod(2000));
+		ScheduledExecutorService scheduler = createScheduler();
+		scheduler.execute(fTask);
+		
+		while (!navServiceResponseReceived || !fTask.isDone());
+		scheduler.shutdown();
+		scheduler = null;
+		fTask = null;
+		
 		if (navServiceResponse) {
 			return sdlConn.startStream(SessionType.NAV, sdlSession.getSessionId());
 		} else {
@@ -2816,10 +2859,15 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		pcmServiceResponse = false;
 
 		sdlConn.startService(SessionType.PCM, sdlSession.getSessionId());
-		int infiniteLoopKiller = 0;
-		while (!pcmServiceResponseReceived && infiniteLoopKiller<2147483647) {
-			infiniteLoopKiller++;
-		}
+		FutureTask<Void> fTask =  createFutureTask(new CallableMethod(2000));
+		ScheduledExecutorService scheduler = createScheduler();
+		scheduler.execute(fTask);
+		
+		while (!pcmServiceResponseReceived  || !fTask.isDone());
+		scheduler.shutdown();
+		scheduler = null;
+		fTask = null;
+		
 		if (pcmServiceResponse) {
 			sdlConn.startStream(is, SessionType.PCM, sdlSession.getSessionId());
 			return true;
@@ -2836,10 +2884,14 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		pcmServiceResponseReceived = false;
 		pcmServiceResponse = false;
 		sdlConn.startService(SessionType.PCM, sdlSession.getSessionId());
-		int infiniteLoopKiller = 0;
-		while (!pcmServiceResponseReceived && infiniteLoopKiller<2147483647) {
-			infiniteLoopKiller++;
-		}
+		FutureTask<Void> fTask =  createFutureTask(new CallableMethod(2000));
+		ScheduledExecutorService scheduler = createScheduler();
+		scheduler.execute(fTask);
+		
+		while (!pcmServiceResponseReceived  || !fTask.isDone());
+		scheduler.shutdown();
+		scheduler = null;
+		fTask = null;
 		if (pcmServiceResponse) {
 			return sdlConn.startStream(SessionType.PCM, sdlSession.getSessionId());
 		} else {

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -277,9 +277,22 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		public void onProtocolSessionNACKed(SessionType sessionType,
 				byte sessionID, byte version, String correlationID) {
 			if (sessionType.eq(SessionType.NAV)) {
+				
+				Intent sendIntent = createBroadcastIntent();
+				updateBroadcastIntent(sendIntent, "FUNCTION_NAME", "onProtocolSessionNACKed");
+				updateBroadcastIntent(sendIntent, "COMMENT1", "SessionID: " + sessionID);
+				updateBroadcastIntent(sendIntent, "COMMENT2", " NACK ServiceType: " + sessionType.getName());
+				sendBroadcastIntent(sendIntent);
+				
 				NavServiceEnded();
 			}
 			else if (sessionType.eq(SessionType.PCM)) {
+				Intent sendIntent = createBroadcastIntent();
+				updateBroadcastIntent(sendIntent, "FUNCTION_NAME", "onProtocolSessionNACKed");
+				updateBroadcastIntent(sendIntent, "COMMENT1", "SessionID: " + sessionID);
+				updateBroadcastIntent(sendIntent, "COMMENT2", " NACK ServiceType: " + sessionType.getName());
+				sendBroadcastIntent(sendIntent);
+				
 				AudioServiceEnded();
 			}
 		}

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/callbacks/InternalProxyMessage.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/callbacks/InternalProxyMessage.java
@@ -5,6 +5,7 @@ public class InternalProxyMessage {
 	public static final String OnProxyError = "OnProxyError";
 	public static final String OnProxyOpened = "OnProxyOpened";
 	public static final String OnProxyClosed = "OnProxyClosed";
+	public static final String OnServiceEnded = "OnServiceEnded";
 	
 	public InternalProxyMessage(String functionName) {
 		//this(functionName, null, null);

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/callbacks/InternalProxyMessage.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/callbacks/InternalProxyMessage.java
@@ -6,6 +6,7 @@ public class InternalProxyMessage {
 	public static final String OnProxyOpened = "OnProxyOpened";
 	public static final String OnProxyClosed = "OnProxyClosed";
 	public static final String OnServiceEnded = "OnServiceEnded";
+	public static final String OnServiceNACKed = "OnServiceNACKed";	
 	
 	public InternalProxyMessage(String functionName) {
 		//this(functionName, null, null);

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/callbacks/OnServiceEnded.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/callbacks/OnServiceEnded.java
@@ -1,0 +1,21 @@
+package com.smartdevicelink.proxy.callbacks;
+
+import com.smartdevicelink.protocol.enums.SessionType;
+
+public class OnServiceEnded extends InternalProxyMessage {
+	private SessionType sessionType;
+
+	public OnServiceEnded() {
+		super(InternalProxyMessage.OnServiceEnded);
+	}
+
+	public OnServiceEnded(SessionType sessionType) {
+		super(InternalProxyMessage.OnServiceEnded);
+		this.sessionType = sessionType;
+	}
+
+	public SessionType getSessionType() {
+		return this.sessionType;
+	}
+
+}

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/callbacks/OnServiceNACKed.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/callbacks/OnServiceNACKed.java
@@ -1,0 +1,21 @@
+package com.smartdevicelink.proxy.callbacks;
+
+import com.smartdevicelink.protocol.enums.SessionType;
+
+public class OnServiceNACKed extends InternalProxyMessage {
+	private SessionType sessionType;
+
+	public OnServiceNACKed() {
+		super(InternalProxyMessage.OnServiceNACKed);
+	}
+
+	public OnServiceNACKed(SessionType sessionType) {
+		super(InternalProxyMessage.OnServiceNACKed);
+		this.sessionType = sessionType;
+	}
+
+	public SessionType getSessionType() {
+		return this.sessionType;
+	}
+
+}

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
@@ -1,6 +1,7 @@
 package com.smartdevicelink.proxy.interfaces;
 
 import com.smartdevicelink.proxy.callbacks.OnServiceEnded;
+import com.smartdevicelink.proxy.callbacks.OnServiceNACKed;
 import com.smartdevicelink.proxy.rpc.AddCommandResponse;
 import com.smartdevicelink.proxy.rpc.AddSubMenuResponse;
 import com.smartdevicelink.proxy.rpc.AlertResponse;
@@ -77,6 +78,8 @@ public interface IProxyListenerBase  {
 	public void onProxyClosed(String info, Exception e, SdlDisconnectedReason reason);
 
 	public void onServiceEnded(OnServiceEnded serviceEnded);
+	
+	public void onServiceNACKed(OnServiceNACKed serviceNACKed);
 
 	/**
 	 * onProxyError() being called indicates that the SDL Proxy experenced an error.

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/interfaces/IProxyListenerBase.java
@@ -1,5 +1,6 @@
 package com.smartdevicelink.proxy.interfaces;
 
+import com.smartdevicelink.proxy.callbacks.OnServiceEnded;
 import com.smartdevicelink.proxy.rpc.AddCommandResponse;
 import com.smartdevicelink.proxy.rpc.AddSubMenuResponse;
 import com.smartdevicelink.proxy.rpc.AlertResponse;
@@ -74,7 +75,9 @@ public interface IProxyListenerBase  {
 	 * @param e - The exception that occurred. 
 	 */
 	public void onProxyClosed(String info, Exception e, SdlDisconnectedReason reason);
-	
+
+	public void onServiceEnded(OnServiceEnded serviceEnded);
+
 	/**
 	 * onProxyError() being called indicates that the SDL Proxy experenced an error.
 	 * 

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
@@ -9,12 +9,12 @@ import com.smartdevicelink.proxy.RPCRequest;
 abstract public class AbstractPacketizer {
 
 	protected IStreamListener _streamListener = null;
-
+	private final static int BUFF_READ_SIZE = 1000000;
 	protected byte _rpcSessionID = 0;
 	
 	protected SessionType _session = null;
 	protected InputStream is = null;
-	protected byte[] buffer = new byte[1488];
+	protected byte[] buffer = new byte[BUFF_READ_SIZE];
 	protected boolean upts = false;
 	protected RPCRequest _request = null;
 	protected byte _wiproVersion = 1;

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/AbstractPacketizer.java
@@ -42,6 +42,10 @@ abstract public class AbstractPacketizer {
 
 	public abstract void stop();
 
+	public abstract void pause();
+
+	public abstract void resume();
+
 	protected static String printBuffer(byte[] buffer, int start,int end) {
 		String str = "";
 		for (int i=start;i<end;i++) str+=","+Integer.toHexString(buffer[i]&0xFF);

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/StreamPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/StreamPacketizer.java
@@ -10,7 +10,8 @@ import com.smartdevicelink.protocol.enums.SessionType;
 public class StreamPacketizer extends AbstractPacketizer implements Runnable{
 
 	public final static String TAG = "StreamPacketizer";
-
+	private final static int BUFF_READ_SIZE = 1000000;
+	
 	private Thread t = null;
 
 	public SdlConnection sdlConnection = null;
@@ -43,7 +44,7 @@ public class StreamPacketizer extends AbstractPacketizer implements Runnable{
 		{
 			while (t != null && !t.isInterrupted()) 
 			{
-				length = is.read(buffer, 0, 1488);
+				length = is.read(buffer, 0, BUFF_READ_SIZE);
 				
 				if (length >= 0) 
 				{

--- a/sdl_android_lib/src/com/smartdevicelink/streaming/StreamPacketizer.java
+++ b/sdl_android_lib/src/com/smartdevicelink/streaming/StreamPacketizer.java
@@ -3,6 +3,7 @@ package com.smartdevicelink.streaming;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.smartdevicelink.SdlConnection.SdlConnection;
 import com.smartdevicelink.protocol.ProtocolMessage;
 import com.smartdevicelink.protocol.enums.SessionType;
 
@@ -11,6 +12,8 @@ public class StreamPacketizer extends AbstractPacketizer implements Runnable{
 	public final static String TAG = "StreamPacketizer";
 
 	private Thread t = null;
+
+	public SdlConnection sdlConnection = null;
 
 	public StreamPacketizer(IStreamListener streamListener, InputStream is, SessionType sType, byte rpcSessionID) throws IOException {
 		super(streamListener, is, sType, rpcSessionID);
@@ -24,33 +27,48 @@ public class StreamPacketizer extends AbstractPacketizer implements Runnable{
 	}
 
 	public void stop() {
-		try {
-			is.close();
-		} catch (IOException ignore) {}
-		t.interrupt();
-		t = null;
+
+		if (t != null)
+		{
+			t.interrupt();
+			t = null;
+		}
+
 	}
 
 	public void run() {
 		int length;
 
-		try {
-			while (!Thread.interrupted()) {
+		try 
+		{
+			while (t != null && !t.isInterrupted()) 
+			{
 				length = is.read(buffer, 0, 1488);
 				
-				if (length >= 0) {
+				if (length >= 0) 
+				{
 					ProtocolMessage pm = new ProtocolMessage();
 					pm.setSessionID(_rpcSessionID);
 					pm.setSessionType(_session);
 					pm.setFunctionID(0);
 					pm.setCorrID(0);
 					pm.setData(buffer, length);
-					
-			        _streamListener.sendStreamPacket(pm);
+										
+					if (t != null && !t.isInterrupted())
+						_streamListener.sendStreamPacket(pm);
 				}
 			}
-		} catch (IOException e) {
+		} catch (IOException e) 
+		{
 			e.printStackTrace();
+		}
+		finally
+		{
+			 if (sdlConnection != null)
+			 {
+				 sdlConnection.endService(_session, _rpcSessionID);
+			 }
+
 		}
 	}
 }

--- a/sdl_android_lib/src/com/smartdevicelink/transport/TCPTransport.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/TCPTransport.java
@@ -114,7 +114,6 @@ public class TCPTransport extends SdlTransport {
         boolean bResult = false;
 
         if(currentState == TCPTransportState.CONNECTED) {
-            synchronized (this) {
                 if (mOutputStream != null) {
                     logInfo("TCPTransport: sendBytesOverTransport request accepted. Trying to send data");
                     try {
@@ -129,7 +128,7 @@ public class TCPTransport extends SdlTransport {
                     logError("TCPTransport: sendBytesOverTransport request accepted, but output stream is null");
                 }
             }
-        } else {
+        else {
             logInfo("TCPTransport: sendBytesOverTransport request rejected. Transport is not connected");
             bResult = false;
         }

--- a/sdl_android_lib/src/com/smartdevicelink/transport/USBTransport.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/USBTransport.java
@@ -213,7 +213,6 @@ public class USBTransport extends SdlTransport {
         final State state = getState();
         switch (state) {
             case CONNECTED:
-                synchronized (this) {
                     if (mOutputStream != null) {
                         try {
                             mOutputStream.write(msgBytes, offset, length);
@@ -235,7 +234,6 @@ public class USBTransport extends SdlTransport {
                         logW(msg);
                         handleTransportError(msg, null);
                     }
-                }
                 break;
 
             default:


### PR DESCRIPTION
:boom: Ready For Review :boom: 

<h2>Summary</h2>

This PR introduces new and updates existing API’s that provide H.264 video and PCM audio streaming services.  Utilizing startH264 and startPCM API methods, developers can open video and audio services and subsequently stream raw H264 video and raw PCM audio to sdlcore.  A brief overview regarding SDL services is described below:

<h2>SDL Services</h2>

Once an application is registered successfully and has established a session, the app has access to services.  After registration, the app may start and stop video and audio services over the established session. By default, applications that are registered receive access to two basic services, RPC and Hybrid.

Below are various services defined by SmartDeviceLink
<ul> 
<li>RPC Service – (automatically started when the app registers) defines the specific APIs sdlcore must perform on behalf of an application , establishes the application listing within sdlcore, performs control functions, and manages HMI.</li>
<li>Hybrid Service -  (automatically started when the app registers) mimics the RPC Service directly, but includes binary data as part of the RPC service</li>
<li>Audio Service (started after a successful startPCM request has been completed)
Sends raw PCM audio data from the device to sdlcore. </li>
<li>H.264 Service (started after a successful startH264 request has been completed)
Sends raw H264 video data from the device to sdlcore. </li>
</ul>

<h3>TODO</h3>
- [X] Add functional hooks for AudioStreaming Service into proxy layers: Protocol, Connection, Base.
- [X] Update existing incomplete developer facing api’s for startH264, startPCM, endH264, end endPCM methods.
- [X] Increase AbstractPacketizer, StreamPacketizer read buffer sizes for optimal performance
- [X] Increase default PipedInputStream buffer size for optimal performance.
- [X] Add method to perform video encoding internally in proxy making a generic opengl surface available for app developers. 
- [X] Update java documentation to detail usage of developer facing video / audio streaming API's below.
```
public boolean startH264(InputStream is) 

public OutputStream startH264() 

public void endH264() 

public boolean startPCM(InputStream is) 

public OutputStream startPCM() 

public void endPCM() 
```