### PR TITLE
Logging Feedback

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
@@ -1,7 +1,7 @@
 package com.smartdevicelink.Dispatcher;
 
-public interface IDispatchingStrategy<messageType> {
-	public void dispatch(messageType message);
+public interface IDispatchingStrategy<T> {
+	public void dispatch(T message);
 	
 	public void handleDispatchingError(String info, Exception ex);
 	

--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
@@ -5,17 +5,17 @@ import java.util.concurrent.PriorityBlockingQueue;
 
 import com.smartdevicelink.util.DebugTool;
 
-public class ProxyMessageDispatcher<messageType> {
-	PriorityBlockingQueue<messageType> _queue = null;
+public class ProxyMessageDispatcher<T> {
+	PriorityBlockingQueue<T> _queue = null;
 	private Thread _messageDispatchingThread = null;
-	IDispatchingStrategy<messageType> _strategy = null;
+	IDispatchingStrategy<T> _strategy = null;
 
 	// Boolean to track if disposed
 	private Boolean dispatcherDisposed = false;
 	
-	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<messageType> messageComparator, 
-			IDispatchingStrategy<messageType> strategy) {
-		_queue = new PriorityBlockingQueue<messageType>(10, messageComparator);
+	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<T> messageComparator, 
+			IDispatchingStrategy<T> strategy) {
+		_queue = new PriorityBlockingQueue<T>(10, messageComparator);
 		
 		_strategy = strategy;
 		
@@ -38,7 +38,7 @@ public class ProxyMessageDispatcher<messageType> {
 	private void handleMessages() {
 		
 		try {
-			messageType thisMessage;
+			T thisMessage;
 		
 			while(dispatcherDisposed == false) {
 				thisMessage = _queue.take();
@@ -53,7 +53,7 @@ public class ProxyMessageDispatcher<messageType> {
 		}
 	}
 		
-	public void queueMessage(messageType message) {
+	public void queueMessage(T message) {
 		try {
 			_queue.put(message);
 		} catch(ClassCastException e) { 

--- a/sdl_android_lib/src/com/smartdevicelink/trace/SdlTrace.java
+++ b/sdl_android_lib/src/com/smartdevicelink/trace/SdlTrace.java
@@ -139,37 +139,37 @@ public class SdlTrace {
 		// Base64 only available in 2.2, when SmartDeviceLink base is 2.2 use: return Base64.encodeToString(data.getBytes(), Base64.DEFAULT);
 	} // end-method
 	
-	public static void logProxyEvent(String eventText, String token) {
+	public static boolean logProxyEvent(String eventText, String token) {
 		if (DiagLevel.getLevel(Mod.proxy) == DetailLevel.OFF || !token.equals(KeyStr)) {
-			return;
-		} // end-if
+			return false;
+		}
 
 		String msg = SdlTrace.B64EncodeForXML(eventText);
 		String xml = SdlTrace.encodeTraceMessage(SdlTrace.getBaseTicsDelta(), Mod.proxy, InterfaceActivityDirection.None, "<d>" + msg + "</d>");
-		writeXmlTraceMessage(xml);
-	} // end-method
+		return writeXmlTraceMessage(xml);
+	}
 
-	public static void logAppEvent(String eventText) {
+	public static boolean logAppEvent(String eventText) {
 		if (DiagLevel.getLevel(Mod.app) == DetailLevel.OFF) {
-			return;
-		} // end-if
+			return false;
+		}
 
 		long timestamp = SdlTrace.getBaseTicsDelta();
 		String msg = SdlTrace.B64EncodeForXML(eventText);
 		String xml = SdlTrace.encodeTraceMessage(timestamp, Mod.app, InterfaceActivityDirection.None, "<d>" + msg + "</d>");
-		writeXmlTraceMessage(xml);
-	} // end-method
+		return writeXmlTraceMessage(xml);
+	}
 
-	public static void logRPCEvent(InterfaceActivityDirection msgDirection, RPCMessage rpcMsg, String token) {
+	public static boolean logRPCEvent(InterfaceActivityDirection msgDirection, RPCMessage rpcMsg, String token) {
 		DetailLevel dl = DiagLevel.getLevel(Mod.rpc);
 		if (dl == DetailLevel.OFF || !token.equals(KeyStr)) {
-			return;
-		} // end-if
+			return false;
+		}
 
 		long timestamp = SdlTrace.getBaseTicsDelta();
 		String xml = SdlTrace.encodeTraceMessage(timestamp, Mod.rpc, msgDirection, rpc2Xml(dl, rpcMsg));
-		writeXmlTraceMessage(xml);
-	} // end-method
+		return writeXmlTraceMessage(xml);
+	}
 
 	private static String rpc2Xml(DetailLevel dl, RPCMessage rpcMsg) {
 		StringBuilder rpcAsXml = new StringBuilder();
@@ -206,11 +206,11 @@ public class SdlTrace {
 		return rpcAsXml.toString();
 	} // end-method
 
-	public static void logMarshallingEvent(InterfaceActivityDirection msgDirection, byte[] marshalledMessage, String token) {
+	public static boolean logMarshallingEvent(InterfaceActivityDirection msgDirection, byte[] marshalledMessage, String token) {
 		DetailLevel dl = DiagLevel.getLevel(Mod.mar);
 		if (dl == DetailLevel.OFF || !token.equals(KeyStr)) {
-			return;
-		} // end-fif
+			return false;
+		}
 
 		long timestamp = SdlTrace.getBaseTicsDelta();
 		StringBuilder msg = new StringBuilder();
@@ -222,16 +222,16 @@ public class SdlTrace {
 			msg.append(Mime.base64Encode(marshalledMessage));
 			// Base64 only available in 2.2, when SmartDeviceLink base is 2.2 use: msg.append(Base64.encodeToString(marshalledMessage, Base64.DEFAULT));
 			msg.append("</d>");
-		} // end-if
+		}
 		String xml = SdlTrace.encodeTraceMessage(timestamp, Mod.mar, msgDirection, msg.toString());
-		writeXmlTraceMessage(xml);
-	} // end-method
+		return writeXmlTraceMessage(xml);
+	}
 
-	public static void logProtocolEvent(InterfaceActivityDirection frameDirection, ProtocolFrameHeader frameHeader, byte[] frameData, int frameDataOffset, int frameDataLength, String token) {
+	public static boolean logProtocolEvent(InterfaceActivityDirection frameDirection, ProtocolFrameHeader frameHeader, byte[] frameData, int frameDataOffset, int frameDataLength, String token) {
 		DetailLevel dl = DiagLevel.getLevel(Mod.proto);
 		if (dl == DetailLevel.OFF || !token.equals(KeyStr)) {
-			return;
-		} // end-if
+			return false;
+		}
 
 		StringBuffer protoMsg = new StringBuffer();
 		protoMsg.append("<frame>");
@@ -244,12 +244,12 @@ public class SdlTrace {
 				// Base64 only available in 2.2, when SmartDeviceLink base is 2.2 use: bytesInfo = Base64.encodeToString(frameData, frameDataOffset, frameDataLength, Base64.DEFAULT);
 				protoMsg.append(bytesInfo);
 				protoMsg.append("</d>");
-			} // end-if
-		} // end-if
+			}
+		}
 		protoMsg.append("</frame>");
 		String xml = SdlTrace.encodeTraceMessage(SdlTrace.getBaseTicsDelta(), Mod.proto, frameDirection, protoMsg.toString());
-		writeXmlTraceMessage(xml);
-	} // end-method
+		return writeXmlTraceMessage(xml);
+	}
 
 	private static String getProtocolFrameType(FrameType f) {
 		if (f == FrameType.Control)
@@ -337,9 +337,9 @@ public class SdlTrace {
 		return sb.toString();
 	} // end-method
 
-	public static void logTransportEvent(String preamble, String transportSpecificInfoXml, InterfaceActivityDirection msgDirection, byte buf[], int byteLength, String token) {
-		logTransportEvent(preamble, transportSpecificInfoXml, msgDirection, buf, 0, byteLength, token);
-	} // end-method
+	public static boolean logTransportEvent(String preamble, String transportSpecificInfoXml, InterfaceActivityDirection msgDirection, byte buf[], int byteLength, String token) {
+		return logTransportEvent(preamble, transportSpecificInfoXml, msgDirection, buf, 0, byteLength, token);
+	} 
 
 	private static void checkB64(String x, byte[] buf, int offset, int byteLength) {
 		if ((x.length() % 4) != 0) {
@@ -347,20 +347,20 @@ public class SdlTrace {
 		} // end-if
 	} // end-method
 
-	public static void logTransportEvent(String preamble, String transportSpecificInfoXml, InterfaceActivityDirection msgDirection, byte buf[], int offset, int byteLength, String token) {
+	public static boolean logTransportEvent(String preamble, String transportSpecificInfoXml, InterfaceActivityDirection msgDirection, byte buf[], int offset, int byteLength, String token) {
 		if (DiagLevel.getLevel(Mod.tran) == DetailLevel.OFF || !token.equals(KeyStr)) {
-			return;
-		} // end-if
+			return false;
+		}
 
 		StringBuilder msg = new StringBuilder();
 		if (transportSpecificInfoXml != null && transportSpecificInfoXml.length() > 0) {
 			msg.append(transportSpecificInfoXml);
-		} // end-if
+		}
 		if (preamble != null && preamble.length() > 0) {
 			msg.append("<desc>");
 			msg.append(preamble);
 			msg.append("</desc>");
-		} // end-if
+		}
 		if (buf != null) {
 			msg.append("<sz>");
 			msg.append(byteLength);
@@ -373,12 +373,12 @@ public class SdlTrace {
 					checkB64(bytesInfo, buf, offset, byteLength);
 					msg.append(bytesInfo);
 					msg.append("</d>");
-				} // end-if
-			} // end-if
-		} // end-if
+				}
+			}
+		}
 		String xml = SdlTrace.encodeTraceMessage(SdlTrace.getBaseTicsDelta(), Mod.tran, msgDirection, msg.toString());
-		writeXmlTraceMessage(xml);
-	} // end-method
+		return writeXmlTraceMessage(xml);
+	}
 
 	// Package-scoped
 	static long getBaseTicsDelta() {
@@ -394,12 +394,13 @@ public class SdlTrace {
 		return SiphonServer.sendFormattedTraceMessage(info);
 	}
 
-	private static void writeXmlTraceMessage(String msg) {
+	private static boolean writeXmlTraceMessage(String msg) {
 		try {			
 			// Attempt to write formatted message to the Siphon
-			if (false == writeMessageToSiphonServer(msg)) {
+			if (false == writeMessageToSiphonServer(msg)) {				
 				// If writing to the Siphon fails, write to the native log
 				NativeLogTool.logInfo(SdlTrace.SYSTEM_LOG_TAG, msg);
+				return false;
 			}
 			
 			ISTListener localTraceListener = m_appTraceListener;
@@ -409,12 +410,15 @@ public class SdlTrace {
 					localTraceListener.logXmlMsg(msg, KeyStr);
 				} catch (Exception ex) {
 					DebugTool.logError("Failure calling ISTListener: " + ex.toString(), ex);
-				} // end-catch
-			} // end-if
+					return false;
+				}
+			}
 		} catch (Exception ex) {
 			NativeLogTool.logError(SdlTrace.SYSTEM_LOG_TAG, "Failure writing XML trace message: " + ex.toString());
+			return false;
 		}
-	} // end-method
+		return true;
+	}
 	
 	// Package-scoped
 	@SuppressWarnings("deprecation")

--- a/sdl_android_lib/src/com/smartdevicelink/util/NativeLogTool.java
+++ b/sdl_android_lib/src/com/smartdevicelink/util/NativeLogTool.java
@@ -23,52 +23,56 @@ public class NativeLogTool {
 		return logToSystemEnabled;
 	} // end-method
 	
-	public static void logInfo(String message) {
-		logInfo(SdlProxyBase.TAG, message);
+	public static boolean logInfo(String message) {		
+		return logInfo(SdlProxyBase.TAG, message);
 	}
 	
-	public static void logInfo(String tag, String message) {
+	public static boolean logInfo(String tag, String message) {
 		if (logToSystemEnabled) {
-			log(LogTarget.Info, tag, message);
+			return log(LogTarget.Info, tag, message);
 		}
+		return false;
 	}
 	
-	public static void logWarning(String message) {
-		logWarning(SdlProxyBase.TAG, message);
+	public static boolean logWarning(String message) {
+		return logWarning(SdlProxyBase.TAG, message);
 	}
 	
-	public static void logWarning(String tag, String message) {
+	public static boolean logWarning(String tag, String message) {
 		if (logToSystemEnabled) {
-			log(LogTarget.Warning, tag, message);
+			return log(LogTarget.Warning, tag, message);
 		}
+		return false;
 	}
 	
-	public static void logError(String message) {
-		logError(SdlProxyBase.TAG, message);
+	public static boolean logError(String message) {
+		return logError(SdlProxyBase.TAG, message);
 	}
 	
-	public static void logError(String tag, String message) {
+	public static boolean logError(String tag, String message) {
 		if (logToSystemEnabled) {
-			log(LogTarget.Error, tag, message);
+			return log(LogTarget.Error, tag, message);
 		}
+		return false;
 	}
 	
-	public static void logError(String message, Throwable t) {
-		logError(SdlProxyBase.TAG, message, t);
+	public static boolean logError(String message, Throwable t) {
+		return logError(SdlProxyBase.TAG, message, t);
 	}
 	
-	public static void logError(String tag, String message, Throwable t) {
+	public static boolean logError(String tag, String message, Throwable t) {
 		// If the call to logError is passed a throwable, write directly to the system log
 		if (logToSystemEnabled) {
 			Log.e(tag, message, t);
 		}
+		return logToSystemEnabled;
 	}
 	
-	private static void log(LogTarget ltarg, String source, String logMsg) {
+	private static boolean log(LogTarget ltarg, String source, String logMsg) {
 		// Don't log empty messages
 		if (logMsg == null || logMsg.length() == 0) {
-			return;
-		} // end-if
+			return false;
+		}
 
 		int bytesWritten = 0;
 		int substrSize = 0;
@@ -88,13 +92,15 @@ public class NativeLogTool {
 					case Error:
 						bytesWritten = Log.e(tag, chunk);
 						break;
-				} // end-switch
+				}
 				if (bytesWritten < chunk.length()) {
 					Log.e(SdlProxyBase.TAG, "Calling Log.e: msg length=" + chunk.length() + ", bytesWritten=" + bytesWritten);
-				} // end-if
-			} // end-while
+				}
+			}			
 		} catch (Exception ex) {
 			Log.e(SdlProxyBase.TAG, "Failure writing " + ltarg.name() + " fragments to android log:" + ex.toString());
-		} // end-catch
-	} // end-method
+			return false;
+		}		
+		return true;
+	} 
 }


### PR DESCRIPTION
> _com/smartdevicelink/util/NativeLogTool_
>_com/smartdevicelink/trace/SdlTrace_

This is a very simple modification to existing log methods that makes them return a `boolean` value instead of being `void` methods. Since this return value can be ignored by current calling classes it has almost no effect, however, it will let us verify that messages were logged successfully and allow for better unit testing of this class.

Unit tests are (most likely) the only thing this pull request will effect.