### PR TITLE
DebugTool Variable Consolidation

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
@@ -1,7 +1,7 @@
 package com.smartdevicelink.Dispatcher;
 
-public interface IDispatchingStrategy<messageType> {
-	public void dispatch(messageType message);
+public interface IDispatchingStrategy<T> {
+	public void dispatch(T message);
 	
 	public void handleDispatchingError(String info, Exception ex);
 	

--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
@@ -5,17 +5,17 @@ import java.util.concurrent.PriorityBlockingQueue;
 
 import com.smartdevicelink.util.DebugTool;
 
-public class ProxyMessageDispatcher<messageType> {
-	PriorityBlockingQueue<messageType> _queue = null;
+public class ProxyMessageDispatcher<T> {
+	PriorityBlockingQueue<T> _queue = null;
 	private Thread _messageDispatchingThread = null;
-	IDispatchingStrategy<messageType> _strategy = null;
+	IDispatchingStrategy<T> _strategy = null;
 
 	// Boolean to track if disposed
 	private Boolean dispatcherDisposed = false;
 	
-	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<messageType> messageComparator, 
-			IDispatchingStrategy<messageType> strategy) {
-		_queue = new PriorityBlockingQueue<messageType>(10, messageComparator);
+	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<T> messageComparator, 
+			IDispatchingStrategy<T> strategy) {
+		_queue = new PriorityBlockingQueue<T>(10, messageComparator);
 		
 		_strategy = strategy;
 		
@@ -38,7 +38,7 @@ public class ProxyMessageDispatcher<messageType> {
 	private void handleMessages() {
 		
 		try {
-			messageType thisMessage;
+			T thisMessage;
 		
 			while(dispatcherDisposed == false) {
 				thisMessage = _queue.take();
@@ -53,7 +53,7 @@ public class ProxyMessageDispatcher<messageType> {
 		}
 	}
 		
-	public void queueMessage(messageType message) {
+	public void queueMessage(T message) {
 		try {
 			_queue.put(message);
 		} catch(ClassCastException e) { 

--- a/sdl_android_lib/src/com/smartdevicelink/util/DebugTool.java
+++ b/sdl_android_lib/src/com/smartdevicelink/util/DebugTool.java
@@ -10,30 +10,19 @@ import com.smartdevicelink.transport.SiphonServer;
 
 public class DebugTool {
 	
-
 	public static final String TAG = "SdlProxy";
-
-	private static boolean isErrorEnabled = false;
-	private static boolean isWarningEnabled = false;
-	private static boolean isInfoEnabled = false;
+	private static boolean isEnabled = false;
 	
 	public static void enableDebugTool() {
-		isErrorEnabled = true;
-		isWarningEnabled = true;
-		isInfoEnabled = true;
+		isEnabled = true;
 	}
 
 	public static void disableDebugTool() {
-		isErrorEnabled = true;
-		isWarningEnabled = false;
-		isInfoEnabled = false;
+		isEnabled = false;
 	}
 	
-	public static boolean isDebugEnabled() 
-	{
-		if (isWarningEnabled && isInfoEnabled) return true;
-		
-		return false;		
+	public static boolean isDebugEnabled() {
+		return isEnabled;	
 	}
 	
 	private static String prependProxyVersionNumberToString(String string) {
@@ -52,7 +41,7 @@ public class DebugTool {
 		
 		wasWritten = logToSiphon(msg);
 		
-		if (isErrorEnabled && !wasWritten) {
+		if (!wasWritten) {
 			NativeLogTool.logError(TAG, msg);
 		}
 	}
@@ -68,7 +57,7 @@ public class DebugTool {
 			wasWritten = logToSiphon(msg);
 		}
 		
-		if (isErrorEnabled && !wasWritten) {
+		if (!wasWritten) {
 			NativeLogTool.logError(TAG, msg, ex);
 		}
 	}
@@ -80,7 +69,7 @@ public class DebugTool {
 		
 		wasWritten = logToSiphon(msg);
 		
-		if (isWarningEnabled && !wasWritten) {
+		if (!wasWritten) {
 			NativeLogTool.logWarning(TAG, msg);
 		}
 	}
@@ -92,7 +81,7 @@ public class DebugTool {
 		
 		wasWritten = logToSiphon(msg);
 		
-		if (isInfoEnabled && !wasWritten) {
+		if (isEnabled && !wasWritten) {
 			NativeLogTool.logInfo(TAG, msg);
 		}
 	}
@@ -104,7 +93,7 @@ public class DebugTool {
 		
 		wasWritten = logToSiphon(msg);
 		
-		if (isInfoEnabled && !wasWritten) {
+		if (isEnabled && !wasWritten) {
 			NativeLogTool.logInfo(TAG, msg);
 		}
 	}
@@ -139,11 +128,7 @@ public class DebugTool {
 		return toPrint;
 	}
 
-
 	protected static Vector<IConsole> consoleListenerList = new Vector<IConsole>();
-
-	protected final static boolean isTransportEnabled = false;
-	protected final static boolean isRPCEnabled = false;
 
 	public static void addConsole(IConsole console) {
 		synchronized(consoleListenerList) {
@@ -164,21 +149,21 @@ public class DebugTool {
 	}
 	
 	public static void logTransport(String msg) {
-		if (isTransportEnabled) {
+		if (isEnabled) {
 			Log.d(TAG, msg);
 			logInfoToConsole(msg);
 		}
 	}
 
 	public static void logRPCSend(String rpcMsg) {
-		if (isRPCEnabled) {
+		if (isEnabled) {
 			Log.d(TAG, "Sending RPC message: " + rpcMsg);
 			logRPCSendToConsole(rpcMsg);
 		}
 	}
 
 	public static void logRPCReceive(String rpcMsg) {
-		if (isRPCEnabled) {
+		if (isEnabled) {
 			Log.d(TAG, "Received RPC message: " + rpcMsg);
 			logRPCSendToConsole(rpcMsg);
 		}

--- a/sdl_android_lib/src/com/smartdevicelink/util/DebugTool.java
+++ b/sdl_android_lib/src/com/smartdevicelink/util/DebugTool.java
@@ -69,7 +69,7 @@ public class DebugTool {
 		
 		wasWritten = logToSiphon(msg);
 		
-		if (!wasWritten) {
+		if (isEnabled && !wasWritten) {
 			NativeLogTool.logWarning(TAG, msg);
 		}
 	}


### PR DESCRIPTION
> _com/smartdevicelink/util/DebugTool_

Based on how the tool is currently being handled, there is no need for multiple boolean flags indicating if logging is enabled, since they are all set to the same value with the exception of error logging which cannot be disabled.

This pull requests just consolidates those flags into one.