### PR TITLE
SdlProxyBase Redundancy Cleanup

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/IDispatchingStrategy.java
@@ -1,7 +1,7 @@
 package com.smartdevicelink.Dispatcher;
 
-public interface IDispatchingStrategy<messageType> {
-	public void dispatch(messageType message);
+public interface IDispatchingStrategy<T> {
+	public void dispatch(T message);
 	
 	public void handleDispatchingError(String info, Exception ex);
 	

--- a/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
+++ b/sdl_android_lib/src/com/smartdevicelink/Dispatcher/ProxyMessageDispatcher.java
@@ -5,17 +5,17 @@ import java.util.concurrent.PriorityBlockingQueue;
 
 import com.smartdevicelink.util.DebugTool;
 
-public class ProxyMessageDispatcher<messageType> {
-	PriorityBlockingQueue<messageType> _queue = null;
+public class ProxyMessageDispatcher<T> {
+	PriorityBlockingQueue<T> _queue = null;
 	private Thread _messageDispatchingThread = null;
-	IDispatchingStrategy<messageType> _strategy = null;
+	IDispatchingStrategy<T> _strategy = null;
 
 	// Boolean to track if disposed
 	private Boolean dispatcherDisposed = false;
 	
-	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<messageType> messageComparator, 
-			IDispatchingStrategy<messageType> strategy) {
-		_queue = new PriorityBlockingQueue<messageType>(10, messageComparator);
+	public ProxyMessageDispatcher(String THREAD_NAME, Comparator<T> messageComparator, 
+			IDispatchingStrategy<T> strategy) {
+		_queue = new PriorityBlockingQueue<T>(10, messageComparator);
 		
 		_strategy = strategy;
 		
@@ -38,7 +38,7 @@ public class ProxyMessageDispatcher<messageType> {
 	private void handleMessages() {
 		
 		try {
-			messageType thisMessage;
+			T thisMessage;
 		
 			while(dispatcherDisposed == false) {
 				thisMessage = _queue.take();
@@ -53,7 +53,7 @@ public class ProxyMessageDispatcher<messageType> {
 		}
 	}
 		
-	public void queueMessage(messageType message) {
+	public void queueMessage(T message) {
 		try {
 			_queue.put(message);
 		} catch(ClassCastException e) { 

--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -1068,31 +1068,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		    updateBroadcastIntent(sendIntent, "COMMENT1", sSiphonPortNumber);
 		    sendBroadcastIntent(sendIntent);
 		}
-	}
-
-	
-	
-	/**
-	 *  Public method to enable the Debug Tool
-	 */
-	public static void enableDebugTool() {
-		DebugTool.enableDebugTool();
-	}
-	
-	/**
-	 *  Public method to disable the Debug Tool
-	 */
-	public static void disableDebugTool() {
-		DebugTool.disableDebugTool();
 	}	
-
-	/**
-	* Public method to determine Debug Tool enabled
-	*/
-	public static boolean isDebugEnabled() {
-		return DebugTool.isDebugEnabled();
-	}	
-	
 	
 	@Deprecated
 	public void close() throws SdlException {
@@ -1508,11 +1484,11 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					
 					String sVersionInfo = "SDL Proxy Version: " + _proxyVersionInfo;
 													
-					if (!isDebugEnabled()) 
+					if (!DebugTool.isDebugEnabled()) 
 					{
-						enableDebugTool();
+						DebugTool.enableDebugTool();
 						DebugTool.logInfo(sVersionInfo, false);
-						disableDebugTool();
+						DebugTool.disableDebugTool();
 					}					
 					else
 						DebugTool.logInfo(sVersionInfo, false);
@@ -1656,11 +1632,11 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				
 				_diagModes = msg.getSupportedDiagModes();				
 				
-				if (!isDebugEnabled()) 
+				if (!DebugTool.isDebugEnabled()) 
 				{
-					enableDebugTool();
+					DebugTool.enableDebugTool();
 					DebugTool.logInfo("SDL Proxy Version: " + _proxyVersionInfo);
-					disableDebugTool();
+					DebugTool.disableDebugTool();
 				}					
 				else
 					DebugTool.logInfo("SDL Proxy Version: " + _proxyVersionInfo);				


### PR DESCRIPTION
> _com/smartdevicelink/proxy/SdlProxyBase_

There is a small inconsistency in how the [SdlProxyBase](https://github.com/smartdevicelink/sdl_android/blob/feature/redundency_cleanup/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java) class uses the [DebugTool](https://github.com/smartdevicelink/sdl_android/blob/feature/redundency_cleanup/sdl_android_lib/src/com/smartdevicelink/util/DebugTool.java) classes static methods. In most cases it calls the methods directly where it needs to, but when regarding the enabling, disabling and status checking these calls are unnecessarily encapsulated in another method call.

Making this change will clean up some code in [SdlProxyBase](https://github.com/smartdevicelink/sdl_android/blob/feature/redundency_cleanup/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java)  and keep it using the [DebugTool](https://github.com/smartdevicelink/sdl_android/blob/feature/redundency_cleanup/sdl_android_lib/src/com/smartdevicelink/util/DebugTool.java) class in a manner consistent to making static method calls.

Note : Accidentally targeted the wrong branch in pull request #186 - this is a fix for that.