### PR TITLE
[WIP] SdlManager (lifecycle)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,61 +1,20 @@
-##############################
-# Project Specific
-##############################
+/.settings/
+/bin/
+/gen/
+/libs/
+/project.properties
+/.classpath
+/.project
+/lint.xml
+/proguard-project.txt
 
-
-##############################
-# OS generated files 
-##############################
-.DS_Store
-.DS_Store?
-._*
-.Spotlight-V100
-.Trashes
-ehthumbs.db
-Thumbs.db
-
-##############################
-# built application files
-##############################
-*.apk
-*.ap_
-
-##############################
-# files for the dex VM
-##############################
-*.dex
-
-##############################
-# Java class files
-##############################
-*.class
-
-##############################
-# Generated files
-##############################
-bin/
-gen/
-
-##############################
-# Local configuration file
-##############################
+# Android Studio
+*.gradle
+.idea/
+*.iml
+build/
+gradle*
 local.properties
 
-##############################
-# Eclipse project files
-##############################
-.classpath
-.project
-
-##############################
-# Proguard folder (Eclipse)
-##############################
-proguard/
-
-##############################
-# Intellij project files
-##############################
-*.iml
-*.ipr
-*.iws
-.idea/
+# OSX garbage
+.DS_Store

--- a/sdl_android_lib/AndroidManifest.xml
+++ b/sdl_android_lib/AndroidManifest.xml
@@ -2,5 +2,6 @@
 	<uses-sdk android:minSdkVersion="8"/>
    	<!-- Required to use the USB Accessory mode -->
     <uses-feature android:name="android.hardware.usb.accessory"/>
-    <application android:debuggable="true"/>
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <application/>
 </manifest>

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/ISdlLifecycleService.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/ISdlLifecycleService.java
@@ -1,0 +1,9 @@
+package com.smartdevicelink.lifecycle;
+
+public interface ISdlLifecycleService {
+
+    void onSdlConnected();
+
+    void onSdlDisconnected();
+
+}

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SDLBluetoothReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SDLBluetoothReceiver.java
@@ -1,0 +1,15 @@
+package com.smartdevicelink.lifecycle;
+
+import android.bluetooth.BluetoothDevice;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class SDLBluetoothReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if(intent.getAction().compareTo(BluetoothDevice.ACTION_ACL_CONNECTED) == 0){
+            SdlManager.getInstance().connect(context);
+        }
+    }
+}

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SDLBluetoothReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SDLBluetoothReceiver.java
@@ -9,7 +9,7 @@ public final class SDLBluetoothReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if(intent.getAction().compareTo(BluetoothDevice.ACTION_ACL_CONNECTED) == 0){
-            SdlManager.getInstance().connect();
+            SdlManager.getInstance().connect(context);
         }
     }
 }

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SDLBluetoothReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SDLBluetoothReceiver.java
@@ -5,11 +5,11 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
-public class SDLBluetoothReceiver extends BroadcastReceiver {
+public final class SDLBluetoothReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if(intent.getAction().compareTo(BluetoothDevice.ACTION_ACL_CONNECTED) == 0){
-            SdlManager.getInstance().connect(context);
+            SdlManager.getInstance().connect();
         }
     }
 }

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SDLBluetoothReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SDLBluetoothReceiver.java
@@ -4,12 +4,17 @@ import android.bluetooth.BluetoothDevice;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.util.Log;
 
 public final class SDLBluetoothReceiver extends BroadcastReceiver {
+
+    private static final String TAG = SDLBluetoothReceiver.class.getSimpleName();
+
     @Override
     public void onReceive(Context context, Intent intent) {
+        Log.d(TAG, intent.getAction());
         if(intent.getAction().compareTo(BluetoothDevice.ACTION_ACL_CONNECTED) == 0){
-            SdlManager.getInstance().connect(context);
+            SdlManager.getInstance().connect();
         }
     }
 }

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlActivity.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlActivity.java
@@ -1,0 +1,85 @@
+package com.smartdevicelink.lifecycle;
+
+public abstract class SdlActivity {
+
+    private LifecycleState currentState = LifecycleState.PRECREATE;
+
+    SdlLifecycleService mLifecycleService;
+
+    SdlActivity(SdlLifecycleService service){
+        mLifecycleService = service;
+    }
+
+    public void onCreate(){
+
+    }
+
+    public void onStart(){
+
+    }
+
+    public void onRestart(){
+
+    }
+
+    public void onResume(){
+
+    }
+
+    public void onObscured(){
+
+    }
+
+    public void onBackground(){
+
+    }
+
+    public void onExit(){
+
+    }
+
+    public void onDestroy(){
+
+    }
+
+    public void startSdlActivity(Class<? extends SdlActivity> activity){
+        mLifecycleService.startSdlActivity(activity);
+    }
+
+    final void notifyStateChange(LifecycleState targetState){
+
+        switch (currentState){
+            case PRECREATE:
+                break;
+            case POSTCREATE:
+                break;
+            case STARTED:
+                break;
+            case ACTIVE:
+                break;
+            case OBSCURED:
+                break;
+            case BACKGROUND:
+                break;
+            case EXIT:
+                break;
+        }
+
+        if(currentState != targetState){
+            notifyStateChange(targetState);
+        }
+
+
+    }
+
+    enum LifecycleState{
+        PRECREATE,
+        POSTCREATE,
+        STARTED,
+        ACTIVE,
+        OBSCURED,
+        BACKGROUND,
+        EXIT
+    }
+
+}

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlActivity.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlActivity.java
@@ -6,80 +6,172 @@ public abstract class SdlActivity {
 
     SdlLifecycleService mLifecycleService;
 
-    SdlActivity(SdlLifecycleService service){
+    protected SdlActivity(SdlLifecycleService service){
         mLifecycleService = service;
     }
 
-    public void onCreate(){
-
+    protected void onCreate(){
     }
 
-    public void onStart(){
-
+    protected void onStart(){
     }
 
-    public void onRestart(){
-
+    protected void onRestart(){
     }
 
-    public void onResume(){
-
+    protected void onForeground(){
     }
 
-    public void onObscured(){
-
+    protected void onVisible(){
     }
 
-    public void onBackground(){
-
+    protected void onObscured(){
     }
 
-    public void onExit(){
-
+    protected void onBackground(){
     }
 
-    public void onDestroy(){
+    protected void onStop(){
+    }
 
+    protected void onDestroy(){
     }
 
     public void startSdlActivity(Class<? extends SdlActivity> activity){
         mLifecycleService.startSdlActivity(activity);
     }
 
-    final void notifyStateChange(LifecycleState targetState){
+    /**
+     * Method for driving activity state transitions. Handles state book keeping and makes all
+     * lifecycle calls.
+     * @param targetState The state that the activity should transition to.
+     * @return Returns true if the activity ended in the desired state.
+     */
+    final synchronized boolean notifyStateChange(LifecycleState targetState){
+
+        if(currentState == targetState){
+            return true;
+        }
 
         switch (currentState){
+
             case PRECREATE:
+                if(targetState.ordinal() > LifecycleState.PRECREATE.ordinal()) {
+                    onCreate();
+                    currentState = LifecycleState.POSTCREATE;
+                } else {
+                    return false;
+                }
                 break;
+
             case POSTCREATE:
+                if(targetState != LifecycleState.RESTARTING &&
+                        targetState.ordinal() > LifecycleState.POSTCREATE.ordinal()) {
+                    onStart();
+                    currentState = LifecycleState.STARTED;
+                } else {
+                    return false;
+                }
                 break;
+
+            case RESTARTING:
+                if(targetState.ordinal() > LifecycleState.RESTARTING.ordinal()) {
+                    onStart();
+                    currentState = LifecycleState.STARTED;
+                } else {
+                    return false;
+                }
+                break;
+
             case STARTED:
+                if(targetState.ordinal() > LifecycleState.STARTED.ordinal()) {
+                    onForeground();
+                    currentState = LifecycleState.FOREGROUND;
+                } else {
+                    return false;
+                }
                 break;
+
+            case FOREGROUND:
+                if(targetState.ordinal() > LifecycleState.FOREGROUND.ordinal()) {
+                    onVisible();
+                    currentState = LifecycleState.ACTIVE;
+                } else {
+                    return false;
+                }
+                break;
+
             case ACTIVE:
+                if(targetState.ordinal() > LifecycleState.ACTIVE.ordinal()) {
+                    onObscured();
+                    currentState = LifecycleState.OBSCURED;
+                } else {
+                    return false;
+                }
                 break;
+
             case OBSCURED:
+                if(targetState.ordinal() > LifecycleState.FOREGROUND.ordinal() &&
+                        targetState.ordinal() <= LifecycleState.ACTIVE.ordinal()){
+                    onVisible();
+                    currentState = LifecycleState.ACTIVE;
+                } else if (targetState.ordinal() > LifecycleState.OBSCURED.ordinal()){
+                    onBackground();
+                    currentState = LifecycleState.BACKGROUND;
+                } else {
+                    return false;
+                }
                 break;
+
             case BACKGROUND:
+                if(targetState.ordinal() > LifecycleState.STARTED.ordinal() &&
+                        targetState.ordinal() <= LifecycleState.ACTIVE.ordinal()){
+                    onForeground();
+                    currentState = LifecycleState.FOREGROUND;
+                } else if (targetState.ordinal() > LifecycleState.BACKGROUND.ordinal()){
+                    onStop();
+                    currentState = LifecycleState.STOPPED;
+                } else {
+                    return false;
+                }
                 break;
-            case EXIT:
+
+            case STOPPED:
+                if(targetState.ordinal() > LifecycleState.POSTCREATE.ordinal() &&
+                        targetState.ordinal() <= LifecycleState.ACTIVE.ordinal()){
+                    onRestart();
+                    currentState = LifecycleState.RESTARTING;
+                } else if (targetState.ordinal() > LifecycleState.STOPPED.ordinal()){
+                    onDestroy();
+                    currentState = LifecycleState.EXITED;
+                } else {
+                    return false;
+                }
                 break;
+
+            case EXITED:
+                return false;
         }
 
         if(currentState != targetState){
-            notifyStateChange(targetState);
+            return notifyStateChange(targetState);
+        } else {
+            return true;
         }
-
-
     }
 
     enum LifecycleState{
+        // ORDER MATTERS. States must be arranged from start to end of lifecycle when added.
         PRECREATE,
         POSTCREATE,
+        RESTARTING,
         STARTED,
+        FOREGROUND,
         ACTIVE,
         OBSCURED,
         BACKGROUND,
-        EXIT
+        STOPPED,
+        EXITED
     }
 
 }

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlConnectionConfig.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlConnectionConfig.java
@@ -1,0 +1,113 @@
+package com.smartdevicelink.lifecycle;
+
+import com.smartdevicelink.proxy.SdlProxyConfigurationResources;
+import com.smartdevicelink.proxy.interfaces.IProxyListenerBase;
+import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
+import com.smartdevicelink.proxy.rpc.TTSChunk;
+import com.smartdevicelink.proxy.rpc.enums.AppHMIType;
+import com.smartdevicelink.proxy.rpc.enums.Language;
+import com.smartdevicelink.transport.BTTransportConfig;
+import com.smartdevicelink.transport.BaseTransportConfig;
+
+import java.util.Vector;
+
+public class SdlConnectionConfig {
+    // Required handled by constructor
+    IProxyListenerBase listener;
+    String appName;
+    String appID;
+
+    // Optional set by setters
+    boolean isMediaApp;
+    SdlProxyConfigurationResources sdlProxyConfigurationResources;
+    boolean enableAdvancedLifecycleManagement;
+    Vector<TTSChunk> ttsName;
+    String ngnMediaScreenAppName;
+    Vector<String> vrSynonyms;
+    SdlMsgVersion sdlMsgVersion;
+    Language languageDesired;
+    Language hmiDisplayLanguageDesired;
+    Vector<AppHMIType> appType;
+    String autoActivateID;
+    boolean callbackToUIThread;
+    boolean preRegister;
+    String sHashID;
+    Boolean bEnableResume;
+    BaseTransportConfig transportConfig;
+
+    public SdlConnectionConfig(IProxyListenerBase listener, String appID, String appName){
+        this.listener = listener;
+        this.appID = appID;
+        this.appName = appName;
+        this.isMediaApp = false;
+        this.languageDesired = this.hmiDisplayLanguageDesired = Language.EN_US;
+
+        this.enableAdvancedLifecycleManagement = false;
+        this.transportConfig = new BTTransportConfig();
+    }
+
+    public void setIsMediaApp(boolean isMediaApp) {
+        this.isMediaApp = isMediaApp;
+    }
+
+    public void setSdlProxyConfigurationResources(SdlProxyConfigurationResources sdlProxyConfigurationResources) {
+        this.sdlProxyConfigurationResources = sdlProxyConfigurationResources;
+    }
+
+    public void setEnableAdvancedLifecycleManagement(boolean enableAdvancedLifecycleManagement) {
+        this.enableAdvancedLifecycleManagement = enableAdvancedLifecycleManagement;
+    }
+
+    public void setTtsName(Vector<TTSChunk> ttsName) {
+        this.ttsName = ttsName;
+    }
+
+    public void setShortAppName(String shortAppName) {
+        this.ngnMediaScreenAppName = shortAppName;
+    }
+
+    public void setVrSynonyms(Vector<String> vrSynonyms) {
+        this.vrSynonyms = vrSynonyms;
+    }
+
+    public void setSdlMsgVersion(SdlMsgVersion sdlMsgVersion) {
+        this.sdlMsgVersion = sdlMsgVersion;
+    }
+
+    public void setTtsLanguageDesired(Language languageDesired) {
+        this.languageDesired = languageDesired;
+    }
+
+    public void setHmiDisplayLanguageDesired(Language hmiDisplayLanguageDesired) {
+        this.hmiDisplayLanguageDesired = hmiDisplayLanguageDesired;
+    }
+
+    public void setAppType(Vector<AppHMIType> appType) {
+        this.appType = appType;
+    }
+
+    public void setAutoActivateID(String autoActivateID) {
+        this.autoActivateID = autoActivateID;
+    }
+
+    public void setCallbackToUIThread(boolean callbackToUIThread) {
+        this.callbackToUIThread = callbackToUIThread;
+    }
+
+    public void setPreRegister(boolean preRegister) {
+        this.preRegister = preRegister;
+    }
+
+    public void setsHashID(String sHashID) {
+        this.sHashID = sHashID;
+    }
+
+    public void setbEnableResume(Boolean bEnableResume) {
+        this.bEnableResume = bEnableResume;
+    }
+
+    public void setTransportConfig(BaseTransportConfig transportConfig) {
+        this.transportConfig = transportConfig;
+    }
+
+}

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlConnectionConfig.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlConnectionConfig.java
@@ -1,7 +1,6 @@
 package com.smartdevicelink.lifecycle;
 
 import com.smartdevicelink.proxy.SdlProxyConfigurationResources;
-import com.smartdevicelink.proxy.interfaces.IProxyListenerBase;
 import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
 import com.smartdevicelink.proxy.rpc.TTSChunk;
 import com.smartdevicelink.proxy.rpc.enums.AppHMIType;
@@ -13,7 +12,6 @@ import java.util.Vector;
 
 public class SdlConnectionConfig {
     // Required handled by constructor
-    IProxyListenerBase listener;
     String appName;
     String appID;
 
@@ -37,8 +35,7 @@ public class SdlConnectionConfig {
 
     Class<? extends SdlLifecycleService> serviceClass;
 
-    public SdlConnectionConfig(IProxyListenerBase listener, String appID, String appName){
-        this.listener = listener;
+    public SdlConnectionConfig(String appID, String appName){
         this.appID = appID;
         this.appName = appName;
         this.isMediaApp = false;

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlConnectionConfig.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlConnectionConfig.java
@@ -35,6 +35,8 @@ public class SdlConnectionConfig {
     Boolean bEnableResume;
     BaseTransportConfig transportConfig;
 
+    Class<? extends SdlLifecycleService> serviceClass;
+
     public SdlConnectionConfig(IProxyListenerBase listener, String appID, String appName){
         this.listener = listener;
         this.appID = appID;
@@ -44,6 +46,7 @@ public class SdlConnectionConfig {
 
         this.enableAdvancedLifecycleManagement = false;
         this.transportConfig = new BTTransportConfig();
+        this.serviceClass = SdlLifecycleService.class;
     }
 
     public void setIsMediaApp(boolean isMediaApp) {
@@ -80,6 +83,10 @@ public class SdlConnectionConfig {
 
     public void setHmiDisplayLanguageDesired(Language hmiDisplayLanguageDesired) {
         this.hmiDisplayLanguageDesired = hmiDisplayLanguageDesired;
+    }
+
+    public void setServiceClass(Class<? extends SdlLifecycleService> serviceClass) {
+        this.serviceClass = serviceClass;
     }
 
     public void setAppType(Vector<AppHMIType> appType) {

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleBinder.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleBinder.java
@@ -1,0 +1,9 @@
+package com.smartdevicelink.lifecycle;
+
+import android.os.Binder;
+
+public abstract class SdlLifecycleBinder extends Binder{
+
+    abstract ISdlLifecycleService getSdlPersistentService();
+
+}

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleListener.java
@@ -7,9 +7,9 @@ public interface SdlLifecycleListener {
 
     void onSdlConnected();
 
-    void onHmiStatusChanged(HMILevel level);
-
     void onLockScreenStatusChanged(LockScreenStatus lockScreenStatus);
+
+    void onHmiStatusChanged(HMILevel level);
 
     void onSdlDisconnected();
 

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleListener.java
@@ -1,0 +1,4 @@
+package com.smartdevicelink.lifecycle;
+
+public interface SdlLifecycleListener {
+}

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleListener.java
@@ -1,4 +1,16 @@
 package com.smartdevicelink.lifecycle;
 
+import com.smartdevicelink.proxy.rpc.enums.HMILevel;
+import com.smartdevicelink.proxy.rpc.enums.LockScreenStatus;
+
 public interface SdlLifecycleListener {
+
+    void onSdlConnected();
+
+    void onHmiStatusChanged(HMILevel level);
+
+    void onLockScreenStatus(LockScreenStatus lockScreenStatus);
+
+    void onSdlDisconnected();
+
 }

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleListener.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleListener.java
@@ -9,7 +9,7 @@ public interface SdlLifecycleListener {
 
     void onHmiStatusChanged(HMILevel level);
 
-    void onLockScreenStatus(LockScreenStatus lockScreenStatus);
+    void onLockScreenStatusChanged(LockScreenStatus lockScreenStatus);
 
     void onSdlDisconnected();
 

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleService.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleService.java
@@ -1,0 +1,39 @@
+package com.smartdevicelink.lifecycle;
+
+import android.app.Notification;
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+import android.support.v4.app.NotificationCompat;
+
+public class SdlLifecycleService extends Service implements ISdlLifecycleService{
+
+    private final SdlLifecycleBinder mBinder = new SdlLifecycleBinder() {
+        @Override
+        public ISdlLifecycleService getSdlPersistentService() {
+            return SdlLifecycleService.this;
+        }
+    };
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return mBinder;
+    }
+
+
+    @Override
+    public void onSdlConnected() {
+        Notification notification = new NotificationCompat.Builder(this)
+                .setContentTitle("SDL Connected")
+                .setContentText("SDL Connected")
+                .build();
+        startForeground(1990, notification);
+    }
+
+    @Override
+    public void onSdlDisconnected() {
+        stopForeground(true);
+    }
+}

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleService.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleService.java
@@ -7,7 +7,12 @@ import android.os.IBinder;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 
+import java.lang.reflect.Constructor;
+import java.util.Stack;
+
 public class SdlLifecycleService extends Service implements ISdlLifecycleService{
+
+    private Stack<SdlActivity> mSdlActivityStack = new Stack<>();
 
     private final SdlLifecycleBinder mBinder = new SdlLifecycleBinder() {
         @Override
@@ -35,5 +40,30 @@ public class SdlLifecycleService extends Service implements ISdlLifecycleService
     @Override
     public void onSdlDisconnected() {
         stopForeground(true);
+    }
+
+    void startSdlActivity(Class<? extends SdlActivity> activity){
+
+        SdlActivity activityInstance;
+
+        try {
+            Constructor<? extends SdlActivity> constructor = activity.getConstructor(SdlLifecycleService.class);
+            activityInstance = constructor.newInstance(this);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Unable to launch "
+                    + activity.getClass().getName() + " as an SdlActivity.", e);
+        }
+
+        SdlActivity currentActivity = mSdlActivityStack.peek();
+
+        if(currentActivity != null){
+            currentActivity
+        }
+
+        activityInstance.onCreate();
+
+        mSdlActivityStack.push(activityInstance);
+
     }
 }

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleService.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlLifecycleService.java
@@ -58,7 +58,6 @@ public class SdlLifecycleService extends Service implements ISdlLifecycleService
         SdlActivity currentActivity = mSdlActivityStack.peek();
 
         if(currentActivity != null){
-            currentActivity
         }
 
         activityInstance.onCreate();

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlManager.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlManager.java
@@ -10,7 +10,7 @@ import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.proxy.SdlProxyALM;
 import com.smartdevicelink.proxy.callbacks.OnServiceEnded;
 import com.smartdevicelink.proxy.callbacks.OnServiceNACKed;
-import com.smartdevicelink.proxy.interfaces.IProxyListenerALM;
+import com.smartdevicelink.proxy.interfaces.IProxyListenerBase;
 import com.smartdevicelink.proxy.rpc.AddCommandResponse;
 import com.smartdevicelink.proxy.rpc.AddSubMenuResponse;
 import com.smartdevicelink.proxy.rpc.AlertManeuverResponse;
@@ -69,11 +69,12 @@ import com.smartdevicelink.proxy.rpc.UpdateTurnListResponse;
 import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
 
-public class SdlManager implements IProxyListenerALM{
+public class SdlManager implements IProxyListenerBase {
 
     private static SdlManager mInstance = new SdlManager();
-    private static SdlProxyALM mProxyALM;
+    private static SdlConnectionConfig mConnectionConfig;
     private static SdlLifecycleListener mLifecycleListener;
+    private static SdlProxyALM mProxyALM;
 
     // Connection maintenance objects
     private boolean isConnected;
@@ -88,13 +89,15 @@ public class SdlManager implements IProxyListenerALM{
     private SdlManager() {
     }
 
-    void startSdlProxy(Context context){
+    void connect(Context context){
 
     }
 
+    public static void setSdlConfig(SdlConnectionConfig config){
+        mConnectionConfig = config;
+    }
 
-
-    void stopSdlProxy(){
+    void disconnect(){
         if(mProxyALM != null){
             try {
                 mProxyALM.dispose();

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlManager.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlManager.java
@@ -1,12 +1,419 @@
 package com.smartdevicelink.lifecycle;
 
-public class SdlManager {
+import android.util.SparseArray;
+
+import com.smartdevicelink.exception.SdlException;
+import com.smartdevicelink.protocol.enums.FunctionID;
+import com.smartdevicelink.proxy.RPCRequest;
+import com.smartdevicelink.proxy.SdlProxyALM;
+import com.smartdevicelink.proxy.callbacks.OnServiceEnded;
+import com.smartdevicelink.proxy.callbacks.OnServiceNACKed;
+import com.smartdevicelink.proxy.interfaces.IProxyListenerALM;
+import com.smartdevicelink.proxy.rpc.AddCommandResponse;
+import com.smartdevicelink.proxy.rpc.AddSubMenuResponse;
+import com.smartdevicelink.proxy.rpc.AlertManeuverResponse;
+import com.smartdevicelink.proxy.rpc.AlertResponse;
+import com.smartdevicelink.proxy.rpc.ChangeRegistrationResponse;
+import com.smartdevicelink.proxy.rpc.CreateInteractionChoiceSetResponse;
+import com.smartdevicelink.proxy.rpc.DeleteCommandResponse;
+import com.smartdevicelink.proxy.rpc.DeleteFileResponse;
+import com.smartdevicelink.proxy.rpc.DeleteInteractionChoiceSetResponse;
+import com.smartdevicelink.proxy.rpc.DeleteSubMenuResponse;
+import com.smartdevicelink.proxy.rpc.DiagnosticMessageResponse;
+import com.smartdevicelink.proxy.rpc.DialNumberResponse;
+import com.smartdevicelink.proxy.rpc.EndAudioPassThruResponse;
+import com.smartdevicelink.proxy.rpc.GenericResponse;
+import com.smartdevicelink.proxy.rpc.GetDTCsResponse;
+import com.smartdevicelink.proxy.rpc.GetVehicleDataResponse;
+import com.smartdevicelink.proxy.rpc.ListFilesResponse;
+import com.smartdevicelink.proxy.rpc.OnAudioPassThru;
+import com.smartdevicelink.proxy.rpc.OnButtonEvent;
+import com.smartdevicelink.proxy.rpc.OnButtonPress;
+import com.smartdevicelink.proxy.rpc.OnCommand;
+import com.smartdevicelink.proxy.rpc.OnDriverDistraction;
+import com.smartdevicelink.proxy.rpc.OnHMIStatus;
+import com.smartdevicelink.proxy.rpc.OnHashChange;
+import com.smartdevicelink.proxy.rpc.OnKeyboardInput;
+import com.smartdevicelink.proxy.rpc.OnLanguageChange;
+import com.smartdevicelink.proxy.rpc.OnLockScreenStatus;
+import com.smartdevicelink.proxy.rpc.OnPermissionsChange;
+import com.smartdevicelink.proxy.rpc.OnStreamRPC;
+import com.smartdevicelink.proxy.rpc.OnSystemRequest;
+import com.smartdevicelink.proxy.rpc.OnTBTClientState;
+import com.smartdevicelink.proxy.rpc.OnTouchEvent;
+import com.smartdevicelink.proxy.rpc.OnVehicleData;
+import com.smartdevicelink.proxy.rpc.PerformAudioPassThruResponse;
+import com.smartdevicelink.proxy.rpc.PerformInteractionResponse;
+import com.smartdevicelink.proxy.rpc.PutFileResponse;
+import com.smartdevicelink.proxy.rpc.ReadDIDResponse;
+import com.smartdevicelink.proxy.rpc.ResetGlobalPropertiesResponse;
+import com.smartdevicelink.proxy.rpc.ScrollableMessageResponse;
+import com.smartdevicelink.proxy.rpc.SendLocationResponse;
+import com.smartdevicelink.proxy.rpc.SetAppIconResponse;
+import com.smartdevicelink.proxy.rpc.SetDisplayLayoutResponse;
+import com.smartdevicelink.proxy.rpc.SetGlobalPropertiesResponse;
+import com.smartdevicelink.proxy.rpc.SetMediaClockTimerResponse;
+import com.smartdevicelink.proxy.rpc.ShowConstantTbtResponse;
+import com.smartdevicelink.proxy.rpc.ShowResponse;
+import com.smartdevicelink.proxy.rpc.SliderResponse;
+import com.smartdevicelink.proxy.rpc.SpeakResponse;
+import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
+import com.smartdevicelink.proxy.rpc.SubscribeButtonResponse;
+import com.smartdevicelink.proxy.rpc.SubscribeVehicleDataResponse;
+import com.smartdevicelink.proxy.rpc.SystemRequestResponse;
+import com.smartdevicelink.proxy.rpc.UnsubscribeButtonResponse;
+import com.smartdevicelink.proxy.rpc.UnsubscribeVehicleDataResponse;
+import com.smartdevicelink.proxy.rpc.UpdateTurnListResponse;
+import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
+import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
+
+public class SdlManager implements IProxyListenerALM{
+
     private static SdlManager mInstance = new SdlManager();
+    private static SdlProxyALM mProxyALM;
+    private static SdlLifecycleListener mLifecycleListener;
+
+    private static SparseArray<OnRPCResponseListener> mNotificationListeners = new SparseArray<>();
 
     public static synchronized SdlManager getInstance() {
         return mInstance;
     }
 
     private SdlManager() {
+    }
+
+    void startSdlProxy(){
+
+    }
+
+    void stopSdlProxy(){
+        if(mProxyALM != null){
+            try {
+                mProxyALM.dispose();
+            } catch (SdlException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public void addNotificationListener(FunctionID id, OnRPCResponseListener listener){
+        mNotificationListeners.append(id.getId(), listener);
+    }
+
+    public void setLifeCycleListener(SdlLifecycleListener listner){
+        mLifecycleListener = listner;
+    }
+
+    public void sendRpc(RPCRequest request){
+        if(mProxyALM != null){
+            try {
+                mProxyALM.sendRPCRequest(request);
+            } catch (SdlException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public void onProxyClosed(String info, Exception e, SdlDisconnectedReason reason) {
+
+    }
+
+    @Override
+    public void onError(String info, Exception e) {
+
+    }
+
+    // TODO: Don't think these are needed
+    @Override
+    public void onServiceEnded(OnServiceEnded serviceEnded) {
+
+    }
+
+    @Override
+    public void onServiceNACKed(OnServiceNACKed serviceNACKed) {
+
+    }
+
+    @Override
+    public void onServiceDataACK() {
+
+    }
+
+    // Everything below here is covered by OnRPCNotificationListener
+    @Override
+    public void onOnStreamRPC(OnStreamRPC notification) {
+
+    }
+
+    @Override
+    public void onOnHMIStatus(OnHMIStatus notification) {
+
+    }
+
+    @Override
+    public void onOnCommand(OnCommand notification) {
+
+    }
+
+    @Override
+    public void onOnButtonEvent(OnButtonEvent notification) {
+
+    }
+
+    @Override
+    public void onOnButtonPress(OnButtonPress notification) {
+
+    }
+
+    @Override
+    public void onOnLanguageChange(OnLanguageChange notification) {
+
+    }
+
+    @Override
+    public void onOnHashChange(OnHashChange notification) {
+
+    }
+
+    @Override
+    public void onOnPermissionsChange(OnPermissionsChange notification) {
+
+    }
+
+    @Override
+    public void onOnVehicleData(OnVehicleData notification) {
+
+    }
+
+    @Override
+    public void onOnAudioPassThru(OnAudioPassThru notification) {
+
+    }
+
+    @Override
+    public void onOnDriverDistraction(OnDriverDistraction notification) {
+
+    }
+
+    @Override
+    public void onOnTBTClientState(OnTBTClientState notification) {
+
+    }
+
+    @Override
+    public void onOnSystemRequest(OnSystemRequest notification) {
+
+    }
+
+    @Override
+    public void onOnKeyboardInput(OnKeyboardInput notification) {
+
+    }
+
+    @Override
+    public void onOnTouchEvent(OnTouchEvent notification) {
+
+    }
+
+    @Override
+    public void onOnLockScreenNotification(OnLockScreenStatus notification) {
+
+    }
+
+    // Everything below here is covered by OnRPCResponseListener
+    @Override
+    public void onStreamRPCResponse(StreamRPCResponse response) {
+
+    }
+
+    @Override
+    public void onGenericResponse(GenericResponse response) {
+
+    }
+
+    @Override
+    public void onAddCommandResponse(AddCommandResponse response) {
+
+    }
+
+    @Override
+    public void onAddSubMenuResponse(AddSubMenuResponse response) {
+
+    }
+
+    @Override
+    public void onCreateInteractionChoiceSetResponse(CreateInteractionChoiceSetResponse response) {
+
+    }
+
+    @Override
+    public void onAlertResponse(AlertResponse response) {
+
+    }
+
+    @Override
+    public void onDeleteCommandResponse(DeleteCommandResponse response) {
+
+    }
+
+    @Override
+    public void onDeleteInteractionChoiceSetResponse(DeleteInteractionChoiceSetResponse response) {
+
+    }
+
+    @Override
+    public void onDeleteSubMenuResponse(DeleteSubMenuResponse response) {
+
+    }
+
+    @Override
+    public void onPerformInteractionResponse(PerformInteractionResponse response) {
+
+    }
+
+    @Override
+    public void onResetGlobalPropertiesResponse(ResetGlobalPropertiesResponse response) {
+
+    }
+
+    @Override
+    public void onSetGlobalPropertiesResponse(SetGlobalPropertiesResponse response) {
+
+    }
+
+    @Override
+    public void onSetMediaClockTimerResponse(SetMediaClockTimerResponse response) {
+
+    }
+
+    @Override
+    public void onShowResponse(ShowResponse response) {
+
+    }
+
+    @Override
+    public void onSpeakResponse(SpeakResponse response) {
+
+    }
+
+    @Override
+    public void onSubscribeButtonResponse(SubscribeButtonResponse response) {
+
+    }
+
+    @Override
+    public void onUnsubscribeButtonResponse(UnsubscribeButtonResponse response) {
+
+    }
+
+    @Override
+    public void onSubscribeVehicleDataResponse(SubscribeVehicleDataResponse response) {
+
+    }
+
+    @Override
+    public void onUnsubscribeVehicleDataResponse(UnsubscribeVehicleDataResponse response) {
+
+    }
+
+    @Override
+    public void onGetVehicleDataResponse(GetVehicleDataResponse response) {
+
+    }
+
+    @Override
+    public void onPerformAudioPassThruResponse(PerformAudioPassThruResponse response) {
+
+    }
+
+    @Override
+    public void onEndAudioPassThruResponse(EndAudioPassThruResponse response) {
+
+    }
+
+    @Override
+    public void onPutFileResponse(PutFileResponse response) {
+
+    }
+
+    @Override
+    public void onDeleteFileResponse(DeleteFileResponse response) {
+
+    }
+
+    @Override
+    public void onListFilesResponse(ListFilesResponse response) {
+
+    }
+
+    @Override
+    public void onSetAppIconResponse(SetAppIconResponse response) {
+
+    }
+
+    @Override
+    public void onScrollableMessageResponse(ScrollableMessageResponse response) {
+
+    }
+
+    @Override
+    public void onChangeRegistrationResponse(ChangeRegistrationResponse response) {
+
+    }
+
+    @Override
+    public void onSetDisplayLayoutResponse(SetDisplayLayoutResponse response) {
+
+    }
+
+    @Override
+    public void onSliderResponse(SliderResponse response) {
+
+    }
+
+    @Override
+    public void onSystemRequestResponse(SystemRequestResponse response) {
+
+    }
+
+    @Override
+    public void onDiagnosticMessageResponse(DiagnosticMessageResponse response) {
+
+    }
+
+    @Override
+    public void onReadDIDResponse(ReadDIDResponse response) {
+
+    }
+
+    @Override
+    public void onGetDTCsResponse(GetDTCsResponse response) {
+
+    }
+
+    @Override
+    public void onDialNumberResponse(DialNumberResponse response) {
+
+    }
+
+    @Override
+    public void onSendLocationResponse(SendLocationResponse response) {
+
+    }
+
+    @Override
+    public void onShowConstantTbtResponse(ShowConstantTbtResponse response) {
+
+    }
+
+    @Override
+    public void onAlertManeuverResponse(AlertManeuverResponse response) {
+
+    }
+
+    @Override
+    public void onUpdateTurnListResponse(UpdateTurnListResponse response) {
+
     }
 }

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlManager.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlManager.java
@@ -1,5 +1,7 @@
 package com.smartdevicelink.lifecycle;
 
+import android.content.Context;
+import android.os.PowerManager.WakeLock;
 import android.util.SparseArray;
 
 import com.smartdevicelink.exception.SdlException;
@@ -73,6 +75,10 @@ public class SdlManager implements IProxyListenerALM{
     private static SdlProxyALM mProxyALM;
     private static SdlLifecycleListener mLifecycleListener;
 
+    // Connection maintenance objects
+    private boolean isConnected;
+    private WakeLock mWakeLock;
+
     private static SparseArray<OnRPCResponseListener> mNotificationListeners = new SparseArray<>();
 
     public static synchronized SdlManager getInstance() {
@@ -82,14 +88,17 @@ public class SdlManager implements IProxyListenerALM{
     private SdlManager() {
     }
 
-    void startSdlProxy(){
+    void startSdlProxy(Context context){
 
     }
+
+
 
     void stopSdlProxy(){
         if(mProxyALM != null){
             try {
                 mProxyALM.dispose();
+                mProxyALM = null;
             } catch (SdlException e) {
                 e.printStackTrace();
             }
@@ -111,6 +120,13 @@ public class SdlManager implements IProxyListenerALM{
             } catch (SdlException e) {
                 e.printStackTrace();
             }
+        }
+    }
+
+    @Override
+    public void onOnHMIStatus(OnHMIStatus notification) {
+        if(!isConnected){
+
         }
     }
 
@@ -143,11 +159,6 @@ public class SdlManager implements IProxyListenerALM{
     // Everything below here is covered by OnRPCNotificationListener
     @Override
     public void onOnStreamRPC(OnStreamRPC notification) {
-
-    }
-
-    @Override
-    public void onOnHMIStatus(OnHMIStatus notification) {
 
     }
 

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlManager.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlManager.java
@@ -1,0 +1,12 @@
+package com.smartdevicelink.lifecycle;
+
+public class SdlManager {
+    private static SdlManager mInstance = new SdlManager();
+
+    public static synchronized SdlManager getInstance() {
+        return mInstance;
+    }
+
+    private SdlManager() {
+    }
+}

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlProxyLCM.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlProxyLCM.java
@@ -1,0 +1,31 @@
+package com.smartdevicelink.lifecycle;
+
+import com.smartdevicelink.exception.SdlException;
+import com.smartdevicelink.proxy.SdlProxyBase;
+import com.smartdevicelink.proxy.interfaces.IProxyListenerBase;
+
+class SdlProxyLCM extends SdlProxyBase<IProxyListenerBase>{
+
+    SdlProxyLCM(SdlConnectionConfig config) throws SdlException{
+        super(config.listener,
+                config.sdlProxyConfigurationResources,
+                config.enableAdvancedLifecycleManagement,
+                config.appName,
+                config.ttsName,
+                config.ngnMediaScreenAppName,
+                config.vrSynonyms,
+                config.isMediaApp,
+                config.sdlMsgVersion,
+                config.languageDesired,
+                config.hmiDisplayLanguageDesired,
+                config.appType,
+                config.appID,
+                config.autoActivateID,
+                config.callbackToUIThread,
+                config.preRegister,
+                config.sHashID,
+                config.bEnableResume,
+                config.transportConfig);
+    }
+
+}

--- a/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlProxyLCM.java
+++ b/sdl_android_lib/src/com/smartdevicelink/lifecycle/SdlProxyLCM.java
@@ -1,31 +1,30 @@
 package com.smartdevicelink.lifecycle;
 
 import com.smartdevicelink.exception.SdlException;
+import com.smartdevicelink.proxy.IProxyListener;
 import com.smartdevicelink.proxy.SdlProxyBase;
-import com.smartdevicelink.proxy.interfaces.IProxyListenerBase;
 
-class SdlProxyLCM extends SdlProxyBase<IProxyListenerBase>{
+class SdlProxyLCM extends SdlProxyBase<IProxyListener> {
 
-    SdlProxyLCM(SdlConnectionConfig config) throws SdlException{
-        super(config.listener,
-                config.sdlProxyConfigurationResources,
-                config.enableAdvancedLifecycleManagement,
-                config.appName,
-                config.ttsName,
-                config.ngnMediaScreenAppName,
-                config.vrSynonyms,
-                config.isMediaApp,
-                config.sdlMsgVersion,
-                config.languageDesired,
-                config.hmiDisplayLanguageDesired,
-                config.appType,
-                config.appID,
-                config.autoActivateID,
-                config.callbackToUIThread,
-                config.preRegister,
-                config.sHashID,
-                config.bEnableResume,
-                config.transportConfig);
-    }
-
+        SdlProxyLCM(IProxyListener listener, SdlConnectionConfig config) throws SdlException {
+                super(listener,
+                        config.sdlProxyConfigurationResources,
+                        config.enableAdvancedLifecycleManagement,
+                        config.appName,
+                        config.ttsName,
+                        config.ngnMediaScreenAppName,
+                        config.vrSynonyms,
+                        config.isMediaApp,
+                        config.sdlMsgVersion,
+                        config.languageDesired,
+                        config.hmiDisplayLanguageDesired,
+                        config.appType,
+                        config.appID,
+                        config.autoActivateID,
+                        config.callbackToUIThread,
+                        config.preRegister,
+                        config.sHashID,
+                        config.bEnableResume,
+                        config.transportConfig);
+        }
 }

--- a/sdl_android_lib/tests/java/com/smartdevicelink/lifecycle/TestSdlActivity.java
+++ b/sdl_android_lib/tests/java/com/smartdevicelink/lifecycle/TestSdlActivity.java
@@ -1,0 +1,767 @@
+package com.smartdevicelink.lifecycle;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+
+@RunWith(AndroidJUnit4.class)
+public class TestSdlActivity{
+
+    // Create tests
+
+    @Test(timeout=100)
+    public void activityTransition_create(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate
+            // postcreate
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity) aut).lifecycleHistory);
+    }
+
+    @Test(timeout=100)
+    public void activityTransition_createActive(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible
+            // active
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity) aut).lifecycleHistory);
+    }
+
+    @Test(timeout=100)
+    public void activityTransition_createDestroy(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            LifecycleMethod.onStop,
+            LifecycleMethod.onDestroy
+            // exited
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    // Obscured tests
+
+    @Test(timeout=100)
+    public void activityTransition_createObscured(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured
+            // obscured
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    @Test(timeout=100)
+    public void activityTransition_createObscuredActive(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            // obscured
+            LifecycleMethod.onVisible
+            // active
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    @Test(timeout=100)
+    public void activityTransition_createObscuredBackground(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            // obscured
+            LifecycleMethod.onBackground
+            // background
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    @Test(timeout=100)
+    public void activityTransition_createObscuredDestroy(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            // obscured
+            LifecycleMethod.onBackground,
+            LifecycleMethod.onStop,
+            LifecycleMethod.onDestroy
+            // exited
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    // Background Tests
+
+    @Test(timeout=100)
+    public void activityTransition_createBackground(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground
+            // background
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    @Test(timeout=100)
+    public void activityTransition_createBackgroundActive(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            // background
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible
+            // active
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    @Test(timeout=100)
+    public void activityTransition_createBackgroundDestroy(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            // background
+            LifecycleMethod.onStop,
+            LifecycleMethod.onDestroy
+            // exited
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    @Test(timeout=100)
+    public void activityTransition_createBackgroundStop(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            // background
+            LifecycleMethod.onStop
+            // stopped
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    // Stop tests
+
+    @Test(timeout=100)
+    public void activityTransition_createStop(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            LifecycleMethod.onStop
+            // stopped
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    @Test(timeout=100)
+    public void activityTransition_createStopActive(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            LifecycleMethod.onStop,
+            // stopped
+            LifecycleMethod.onRestart,
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible
+            // active
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    @Test(timeout=100)
+    public void activityTransition_createStopDestroy(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            LifecycleMethod.onStop,
+            // stopped
+            LifecycleMethod.onDestroy
+            // exited
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    @Test(timeout=100)
+    public void activityTransition_navigationCycle(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            // obscured
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            // background
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            LifecycleMethod.onStop,
+            // stopped
+            LifecycleMethod.onRestart,
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            LifecycleMethod.onStop,
+            LifecycleMethod.onDestroy
+            // exited
+        };
+
+        boolean stateChanged;
+
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
+        Assert.assertTrue(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+
+
+    @Test(timeout=100)
+    public void activityTransition_errorRejection(){
+        SdlActivity aut = new TestActivity(null);
+
+        LifecycleMethod[] targetHistory = {
+            // precreate
+            LifecycleMethod.onCreate,
+            // postcreate
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            // obscured
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            // background
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            LifecycleMethod.onStop,
+            // stopped
+            LifecycleMethod.onRestart,
+            LifecycleMethod.onStart,
+            LifecycleMethod.onForeground,
+            LifecycleMethod.onVisible,
+            // active
+            LifecycleMethod.onObscured,
+            LifecycleMethod.onBackground,
+            LifecycleMethod.onStop,
+            LifecycleMethod.onDestroy
+            // exited
+        };
+        
+        boolean stateChanged;
+
+        // State change POSTCREATE
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        // Double state call -- should not call on create twice
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertTrue(stateChanged);
+        // Back navigation -- Should not leave
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
+        Assert.assertFalse(stateChanged);
+
+        // State change ACTIVE
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        // Double state call -- should not call any methods
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+        // Back navigation -- Sould not leave
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.RESTARTING);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STARTED);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.FOREGROUND);
+        Assert.assertFalse(stateChanged);
+
+        // State change OBSCURED
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
+        Assert.assertTrue(stateChanged);
+        // Double state call -- should not call any methods
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
+        Assert.assertTrue(stateChanged);
+        // Back navigation -- Sould not leave
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.RESTARTING);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STARTED);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.FOREGROUND);
+        Assert.assertFalse(stateChanged);
+
+
+        // State change ACTIVE -- already tested
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+
+        // State change BACKGROUND
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
+        Assert.assertTrue(stateChanged);
+        // Double state call -- should not call any methods
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
+        Assert.assertTrue(stateChanged);
+        // Back navigation -- Sould not leave
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.RESTARTING);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STARTED);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
+        Assert.assertFalse(stateChanged);
+
+        // State change ACTIVE -- already tested
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+
+        // State change STOPPED
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
+        Assert.assertTrue(stateChanged);
+        // Double state call -- should not call any methods
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
+        Assert.assertTrue(stateChanged);
+        // Back navigation -- Sould not leave
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
+        Assert.assertFalse(stateChanged);
+
+        // State change ACTIVE -- already tested
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertTrue(stateChanged);
+
+        // State change EXITED
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
+        Assert.assertTrue(stateChanged);
+        // Double state call -- should not call any methods
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
+        Assert.assertTrue(stateChanged);
+        // All states should be trapped
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.RESTARTING);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STARTED);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.FOREGROUND);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
+        Assert.assertFalse(stateChanged);
+        stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
+        Assert.assertFalse(stateChanged);
+
+        testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
+    }
+
+    private void testStateHistory(LifecycleMethod[] target, ArrayList<LifecycleMethod> actual){
+
+        for(int i = 0; i < target.length; i++){
+            Assert.assertEquals(target[i], actual.get(i));
+            if(target[i] != actual.get(i)){
+                break;
+            }
+        }
+
+        Assert.assertEquals(target.length, actual.size());
+    }
+
+
+    private final class TestActivity extends SdlActivity {
+
+        ArrayList<LifecycleMethod> lifecycleHistory = new ArrayList<>();
+
+        protected TestActivity(SdlLifecycleService service) {
+            super(service);
+        }
+
+        @Override
+        protected void onCreate() {
+            super.onCreate();
+            lifecycleHistory.add(LifecycleMethod.onCreate);
+        }
+
+        @Override
+        protected void onStart() {
+            super.onStart();
+            lifecycleHistory.add(LifecycleMethod.onStart);
+        }
+
+        @Override
+        protected void onRestart() {
+            super.onRestart();
+            lifecycleHistory.add(LifecycleMethod.onRestart);
+        }
+
+        @Override
+        protected void onForeground(){
+            super.onForeground();
+            lifecycleHistory.add(LifecycleMethod.onForeground);
+        }
+
+        @Override
+        protected void onVisible() {
+            super.onVisible();
+            lifecycleHistory.add(LifecycleMethod.onVisible);
+        }
+
+        @Override
+        protected void onObscured() {
+            super.onObscured();
+            lifecycleHistory.add(LifecycleMethod.onObscured);
+        }
+
+        @Override
+        protected void onBackground() {
+            super.onBackground();
+            lifecycleHistory.add(LifecycleMethod.onBackground);
+        }
+
+        @Override
+        protected void onStop() {
+            super.onStop();
+            lifecycleHistory.add(LifecycleMethod.onStop);
+        }
+
+        @Override
+        protected void onDestroy() {
+            super.onDestroy();
+            lifecycleHistory.add(LifecycleMethod.onDestroy);
+        }
+
+    }
+
+    enum LifecycleMethod{
+        onCreate,
+        onStart,
+        onRestart,
+        onForeground,
+        onVisible,
+        onObscured,
+        onBackground,
+        onStop,
+        onDestroy
+    }
+	
+}

--- a/sdl_android_lib/tests/java/com/smartdevicelink/lifecycle/TestSdlActivity.java
+++ b/sdl_android_lib/tests/java/com/smartdevicelink/lifecycle/TestSdlActivity.java
@@ -2,12 +2,12 @@ package com.smartdevicelink.lifecycle;
 
 import android.support.test.runner.AndroidJUnit4;
 
-import junit.framework.Assert;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+
+import static org.junit.Assert.*;
 
 @RunWith(AndroidJUnit4.class)
 public class TestSdlActivity{
@@ -27,7 +27,7 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity) aut).lifecycleHistory);
     }
@@ -49,9 +49,9 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity) aut).lifecycleHistory);
     }
@@ -78,11 +78,11 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -108,11 +108,11 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -138,13 +138,13 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -169,13 +169,13 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -203,13 +203,13 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -236,11 +236,11 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -268,13 +268,13 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -302,13 +302,13 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -335,13 +335,13 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -369,11 +369,11 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -404,13 +404,13 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -438,13 +438,13 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -490,23 +490,23 @@ public class TestSdlActivity{
         boolean stateChanged;
 
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
@@ -555,136 +555,134 @@ public class TestSdlActivity{
 
         // State change POSTCREATE
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // Double state call -- should not call on create twice
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // Back navigation -- Should not leave
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
 
         // State change ACTIVE
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // Double state call -- should not call any methods
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // Back navigation -- Sould not leave
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.RESTARTING);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STARTED);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.FOREGROUND);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
 
         // State change OBSCURED
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // Double state call -- should not call any methods
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // Back navigation -- Sould not leave
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.RESTARTING);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STARTED);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.FOREGROUND);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
 
 
         // State change ACTIVE -- already tested
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         // State change BACKGROUND
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // Double state call -- should not call any methods
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // Back navigation -- Sould not leave
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.RESTARTING);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STARTED);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
 
         // State change ACTIVE -- already tested
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         // State change STOPPED
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // Double state call -- should not call any methods
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // Back navigation -- Sould not leave
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
 
         // State change ACTIVE -- already tested
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
 
         // State change EXITED
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // Double state call -- should not call any methods
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.EXITED);
-        Assert.assertTrue(stateChanged);
+        assertTrue(stateChanged);
         // All states should be trapped
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.PRECREATE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.POSTCREATE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.RESTARTING);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STARTED);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.FOREGROUND);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.ACTIVE);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.OBSCURED);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.BACKGROUND);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
         stateChanged = aut.notifyStateChange(SdlActivity.LifecycleState.STOPPED);
-        Assert.assertFalse(stateChanged);
+        assertFalse(stateChanged);
 
         testStateHistory(targetHistory, ((TestActivity)aut).lifecycleHistory);
     }
 
     private void testStateHistory(LifecycleMethod[] target, ArrayList<LifecycleMethod> actual){
 
-        for(int i = 0; i < target.length; i++){
-            Assert.assertEquals(target[i], actual.get(i));
-            if(target[i] != actual.get(i)){
-                break;
-            }
-        }
+        LifecycleMethod[] actualArray = new LifecycleMethod[actual.size()];
+        actualArray = actual.toArray(actualArray);
 
-        Assert.assertEquals(target.length, actual.size());
+        assertArrayEquals(target, actualArray);
+
+        assertEquals(target.length, actual.size());
     }
 
 


### PR DESCRIPTION
[Work in Progress]

Creating a package to enable better/automatic management of the SDL lifecycle. 

SdlManager will manage the proxy connection. Set up will be based on a configuration given to the manager by the developer. Drives lifecycle callbacks for LifecycleService/SdlActivity

SdlLifecycleService will act as the primary lifecycle controller for the developer's functionality for the life of the app on the head unit. (Analogous to Application in android environment.)

Developer will need to create "SdlActivity" that will implement the functionality and set up views. (Analogous to Application in android environment). Is not a child of android.app.Activity. SdlActivity should encapsulate related views and functionality.