### PR TITLE
Hotfix/mtu size for v3 & v4 protocols

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
@@ -60,12 +60,12 @@ public class WiProProtocol extends AbstractProtocol {
         } else if (version == 4) {
             this._version = version;
             HEADER_SIZE = 12;
-            MAX_DATA_SIZE = V3_V4_MTU_SIZE; //versions 4 supports 128k MTU
+            MAX_DATA_SIZE = V3_V4_MTU_SIZE - HEADER_SIZE; //versions 4 supports 128k MTU
             _headerBuf = new byte[HEADER_SIZE];
         } else if (version == 3) {
             this._version = version;
             HEADER_SIZE = 12;
-            MAX_DATA_SIZE = V3_V4_MTU_SIZE; //versions 3 supports 128k MTU
+            MAX_DATA_SIZE = V3_V4_MTU_SIZE - HEADER_SIZE; //versions 3 supports 128k MTU
             _headerBuf = new byte[HEADER_SIZE];
         } else if (version == 2) {
             this._version = version;


### PR DESCRIPTION
The mtu size that is specified by core for versions 3 and 4 protocols do not match the value in the mobile library.  Core (and the gen 3 module) set the value to 131072-12 as can be seen in the smartDeviceLink.ini file.  This change updates WiProProtocol.java to match these values.