### PR TITLE
Add travis-ci automated build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: android
+android:
+  components:
+    # The BuildTools version used by your project
+    - build-tools-23.0.2
+
+    # The SDK version used to compile your project
+    - android-18

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: android
 android:
   components:
+    # use the latest revision of Android SDK Tools
+    - platform-tools
+    - tools
+  
     # The BuildTools version used by your project
     - build-tools-23.0.2
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,47 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.1.0'
+    }
+}
+apply plugin: 'com.android.library'
+
+dependencies {
+    compile fileTree(dir: 'libs', include: '*.jar')
+}
+
+android {
+    compileSdkVersion 18
+    buildToolsVersion "23.0.2"
+    
+    lintOptions {
+        // When we start automating build deployments this should be removed
+        abortOnError false
+    }
+
+    sourceSets {
+        main {
+            manifest.srcFile 'sdl_android_lib/AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            aidl.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+
+        // Move the tests to tests/java, tests/res, etc...
+        instrumentTest.setRoot('tests')
+
+        // Move the build types to build-types/<type>
+        // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...
+        // This moves them out of them default location under src/<type>/... which would
+        // conflict with src/ being used by the main source set.
+        // Adding new build types or product flavors should be accompanied
+        // by a similar customization.
+        debug.setRoot('build-types/debug')
+        release.setRoot('build-types/release')
+    }
+}


### PR DESCRIPTION
## Summary

Adds a [travis-ci](https://travis-ci.org/) build configuration to the project. This will allow us to see if committed code builds it will also make sure pull requests build. Eventually we will be able to configure travis-ci to run all of our unit tests.

Builds status can be viewed here: [https://travis-ci.org/smartdevicelink/sdl_android](https://travis-ci.org/smartdevicelink/sdl_android)

**NOTE** This will not work for the `master` branch until the files are merged because travis will not build  a branch unless a `.travis.yml` is present.

## Details

**.travis.yml** is used to tell travis-ci how to build the Android project and eventually it will be configured to run the project's unit tests.

**gradle.build** is only used to tell travis-ci how to build the Android project. It should not affect importing the project.