### PR TITLE
Removed hardcoded string usage for "activity"

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -176,7 +176,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			return false;
 		}
 		Log.d(TAG, "Looking for Service: "+ SDL_ROUTER_SERVICE_CLASS_NAME);
-		ActivityManager manager = (ActivityManager) context.getSystemService("activity");
+		ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
 	    for (RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
 	    	//We will check to see if it contains this name, should be pretty specific
 	    	//Log.d(TAG, "Found Service: "+ service.service.getClassName());

--- a/sdl_android_lib/src/com/smartdevicelink/transport/TransportBroker.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/TransportBroker.java
@@ -397,7 +397,7 @@ public class TransportBroker {
 				
 				return false;
 			}
-			ActivityManager manager = (ActivityManager) context.getSystemService("activity");
+			ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
 		    for (RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
 		    	//We will check to see if it contains this name, should be pretty specific
 		    	if ((service.service.getClassName()).toLowerCase(Locale.US).contains(SdlBroadcastReceiver.SDL_ROUTER_SERVICE_CLASS_NAME)) { 


### PR DESCRIPTION
Removes the hardcoded strings and now references the Android Context's static string constant instead.

Made changes in two classes:

1. [SdlBroadcastReceiver](https://github.com/smartdevicelink/sdl_android/blob/bugfix/issue_310/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java#L179)
2. [TransportBroker](https://github.com/smartdevicelink/sdl_android/blob/bugfix/issue_310/sdl_android_lib/src/com/smartdevicelink/transport/TransportBroker.java#L400) 