### PR TITLE
Correct abstract class type in SdlBroadcastReceiver

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -247,13 +247,12 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 	}
 	
 	/**
-	 * We need to define this for local copy of the Sdl Bluetooth Service class.
-	 * It will be the main point of connection for Sdl Connected apps
+	 * We need to define this for local copy of the Sdl Router Service class.
+	 * It will be the main point of connection for Sdl enabled apps
 	 * @return Return the local copy of SdlRouterService.class
 	 * {@inheritDoc}
 	 */
-	@SuppressWarnings("rawtypes")
-	public abstract Class defineLocalSdlRouterClass();
+	public abstract Class<SdlRouterService> defineLocalSdlRouterClass();
 
 	
 	

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -252,7 +252,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 	 * @return Return the local copy of SdlRouterService.class
 	 * {@inheritDoc}
 	 */
-	public abstract Class<SdlRouterService> defineLocalSdlRouterClass();
+	public abstract Class<? extends SdlRouterService> defineLocalSdlRouterClass();
 
 	
 	


### PR DESCRIPTION
Fixes #319 

The return type Class should have been parameterized to the correct type instead of just using a raw type.

This will help reduce dev's implementing the library as well as being the best practice overall. 