### PR TITLE
Correct disconnect logic when bluetooth adapter is being turned off 

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlRouterService.java
@@ -1086,8 +1086,8 @@ public class SdlRouterService extends Service{
 	            		case MultiplexBluetoothTransport.STATE_NONE:
 	            			// We've just lost the connection
 	            			storeConnectedStatus(false);
-	            			if(!connectAsClient && !closing){
-	            				if(!legacyModeEnabled){
+	            			if(!connectAsClient ){
+	            				if(!legacyModeEnabled && !closing){
 	            					initBluetoothSerialService();
 	            				}
 	            				onTransportDisconnected(TransportType.BLUETOOTH);


### PR DESCRIPTION
Some model phones display a race condition where they received the STATE_CHANGE disconnect intent before the RFCOMM/SPP channel disconnects. This would cause the handler for the RFCOMM channel to skip over the lifecycle call for transport disconnect. 

This PR moves the logic for checking if the service is closing just to the scope of whether or not it should restart its bluetooth transport to listen for connections. It will now call the correct disconnect lifecycle methods.