### PR TITLE
Fixed ClassCastException in openConnection

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/BTTransport.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/BTTransport.java
@@ -187,7 +187,7 @@ public class BTTransport extends SdlTransport {
 				throw new SdlException("Bluetooth adapter must be on to instantiate a SdlProxy object.", SdlExceptionCause.BLUETOOTH_DISABLED);
 			}
 
-			if(((SdlException) ex).getSdlExceptionCause() == SdlExceptionCause.BLUETOOTH_SOCKET_UNAVAILABLE) {
+			if(ex instanceof SdlException && ((SdlException) ex).getSdlExceptionCause() == SdlExceptionCause.BLUETOOTH_SOCKET_UNAVAILABLE) {
 				SdlConnection.enableLegacyMode(false, null);
 				throw new SdlException("Could not open connection to SDL.", SdlExceptionCause.BLUETOOTH_SOCKET_UNAVAILABLE);
 


### PR DESCRIPTION

From the crash reports in PlayStore I receive some ClassCastExceptions every now and then on devices (seems to be exclusive to tablets) running Android 4.1 and 4.2.
The exceptions occur in BTTransport.openConnection when some exception is cast to SdlException.

The reports contain no line numbers ... I suspect line 190 to be the cause of the error, since this is the only line containing an unchecked cast to SdlException.