### PR TITLE
Add router service version to register client response

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlRouterService.java
@@ -365,9 +365,11 @@ public class SdlRouterService extends Service{
 	                			returnBundle.putString(CONNECTED_DEVICE_STRING_EXTRA_NAME, MultiplexBluetoothTransport.currentlyConnectedDevice);
 	                		}
 	            		}
-	            		if(!returnBundle.isEmpty()){
-	            			message.setData(returnBundle);
-	            		}
+	            		//Add the version of this router service
+	            		returnBundle.putInt(TransportConstants.ROUTER_SERVICE_VERSION, SdlRouterService.ROUTER_SERVICE_VERSION_NUMBER);
+	            		
+	            		message.setData(returnBundle);
+	            		
 	            		int result = app.sendMessage(message);
 	            		if(result == RegisteredApp.SEND_MESSAGE_ERROR_MESSENGER_DEAD_OBJECT){
 	            			synchronized(REGISTERED_APPS_LOCK){

--- a/sdl_android_lib/src/com/smartdevicelink/transport/TransportBroker.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/TransportBroker.java
@@ -154,11 +154,16 @@ public class TransportBroker {
             		case TransportConstants.REGISTRATION_RESPONSE_SUCESS:
             			// yay! we have been registered. Now what?
             			registeredWithRouterService = true;
-            			if(bundle !=null && bundle.containsKey(TransportConstants.HARDWARE_CONNECTED)){
-            				if(bundle.containsKey(TransportConstants.CONNECTED_DEVICE_STRING_EXTRA_NAME)){
-            					//Keep track if we actually get this
+            			if(bundle !=null){
+            				if(bundle.containsKey(TransportConstants.HARDWARE_CONNECTED)){
+            					if(bundle.containsKey(TransportConstants.CONNECTED_DEVICE_STRING_EXTRA_NAME)){
+            						//Keep track if we actually get this
+            					}
+            					onHardwareConnected(TransportType.valueOf(bundle.getString(TransportConstants.HARDWARE_CONNECTED)));
             				}
-            				onHardwareConnected(TransportType.valueOf(bundle.getString(TransportConstants.HARDWARE_CONNECTED)));
+            				/*if(bundle.containsKey(TransportConstants.ROUTER_SERVICE_VERSION)){
+            					//Keep track if we actually get this
+            				}*/
             			}
             			break;
             		case TransportConstants.REGISTRATION_RESPONSE_DENIED_LEGACY_MODE_ENABLED:

--- a/sdl_android_lib/src/com/smartdevicelink/transport/TransportConstants.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/TransportConstants.java
@@ -190,7 +190,8 @@ public class TransportConstants {
 	public static final int PACKET_SENDING_ERROR_NOT_CONNECTED 				= 0x01;
 	public static final int PACKET_SENDING_ERROR_UKNOWN 					= 0xFF;
 	
-	
+	public static final String ROUTER_SERVICE_VERSION						= "router_service_version";
+
 	/**
 	 * Status binder
 	 */


### PR DESCRIPTION
In the future it might be very helpful to have this information. If communication structures change between router service versions the client now has that information. So it will be better to provide this information from the start.

The code for the transport broker is commented out as of right now because there is no use at the moment. 