### PR TITLE
Add protection against incorrect implementations of SdlRouterService

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -4,6 +4,8 @@ import java.util.Locale;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import com.smartdevicelink.util.AndroidTools;
+
 import android.app.ActivityManager;
 import android.app.ActivityManager.RunningServiceInfo;
 import android.bluetooth.BluetoothAdapter;
@@ -182,7 +184,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 	    for (RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
 	    	//We will check to see if it contains this name, should be pretty specific
 	    	//Log.d(TAG, "Found Service: "+ service.service.getClassName());
-	    	if ((service.service.getClassName()).toLowerCase(Locale.US).contains(SDL_ROUTER_SERVICE_CLASS_NAME)) {
+	    	if ((service.service.getClassName()).toLowerCase(Locale.US).contains(SDL_ROUTER_SERVICE_CLASS_NAME) && AndroidTools.isServiceExported(context, service.service)) {
 	    		
 	    		runningBluetoothServicePackage.add(service.service);	//Store which instance is running
 	            if(pingService){

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlRouterStatusProvider.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlRouterStatusProvider.java
@@ -2,11 +2,16 @@ package com.smartdevicelink.transport;
 
 import java.lang.ref.WeakReference;
 
+import com.smartdevicelink.util.AndroidTools;
+
 import android.annotation.SuppressLint;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.content.pm.PackageManager;
+import android.content.pm.ServiceInfo;
+import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
@@ -70,7 +75,7 @@ public class SdlRouterStatusProvider {
 		this.flags = flags;
 	}
 	public void checkIsConnected(){
-		if(!bindToService()){
+		if(!AndroidTools.isServiceExported(context,routerService) || !bindToService()){
 			//We are unable to bind to service
 			cb.onConnectionStatusUpdate(false, routerService, context);
 			unBindFromService();
@@ -86,6 +91,9 @@ public class SdlRouterStatusProvider {
 	private boolean bindToService(){
 		if(isBound){
 			return true;
+		}
+		if(clientMessenger == null){
+			return false;
 		}
 		Intent bindingIntent = new Intent();
 		bindingIntent.setClassName(this.routerService.getPackageName(), this.routerService.getClassName());//This sets an explicit intent

--- a/sdl_android_lib/src/com/smartdevicelink/util/AndroidTools.java
+++ b/sdl_android_lib/src/com/smartdevicelink/util/AndroidTools.java
@@ -1,0 +1,25 @@
+package com.smartdevicelink.util;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.pm.ServiceInfo;
+import android.content.pm.PackageManager.NameNotFoundException;
+
+public class AndroidTools {
+	/**
+	 * Check to see if a component is exported
+	 * @param Context object used to retrieve the package manager
+	 * @param componentName of the component in question
+	 * @return true if this component is tagged as exported
+	 */
+	public static boolean isServiceExported(Context context, ComponentName name) {
+	    try {
+	        ServiceInfo serviceInfo = context.getPackageManager().getServiceInfo(name, PackageManager.GET_META_DATA);
+	        return serviceInfo.exported;
+	    } catch (NameNotFoundException e) {
+	        e.printStackTrace();
+	    }
+	    return false;
+	}
+}


### PR DESCRIPTION
Adding checks to ensure the SdlRouterService is exported and prevent crashes when attempting to connect to non exported services.

Fixes #353 
- [x]  Do not put in router service list during query ([Code](https://github.com/smartdevicelink/sdl_android/pull/354/files#diff-0747fd9644c9c3286ed1f43a819f0024R187))
- [x] Do not store as newer service in router service newest service check. ([Code](https://github.com/smartdevicelink/sdl_android/pull/354/files#diff-830b16347cdc2876a69c4a7cc2404bc0R230))
- [x]  Force SdlRouterService to shut down if not exported ([Code](https://github.com/smartdevicelink/sdl_android/pull/354/files#diff-830b16347cdc2876a69c4a7cc2404bc0R777))
- [x] Protect against misc connections to non exported services ([Code](https://github.com/smartdevicelink/sdl_android/pull/354/files#diff-311893dc1fd03ff5aa4ee8873953e2adR78))
