### PR TITLE
Fix issues with getting the trusted router service list

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -128,13 +128,6 @@ public class RouterServiceValidator {
 			}
 		}//No running service found. Might need to attempt to start one
 		//TODO spin up a known good router service
-		
-		if(context.getPackageName().equalsIgnoreCase(packageName)){
-			Log.d(TAG, "It's our router service running, so time to shut it down");
-			Intent intent = new Intent();
-			intent.setComponent(service);
-			try{context.stopService(intent);}catch(Exception e){}
-		}
 		wakeUpRouterServices();
 		return false;
 	}

--- a/sdl_android_lib/src/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -352,10 +352,18 @@ public class RouterServiceValidator {
 	 * @param context
 	 */
 	public static boolean createTrustedListRequest(final Context context, boolean forceRefresh){
-		return createTrustedListRequest(context,forceRefresh,null);
+		return createTrustedListRequest(context,forceRefresh,null,null);
+	}
+	public static boolean createTrustedListRequest(final Context context, boolean forceRefresh, TrustedListCallback listCallback){Log.d(TAG,"Checking to make sure we have a list");
+		return createTrustedListRequest(context,forceRefresh,null,listCallback);
 	}
 	
+	@Deprecated
 	protected static boolean createTrustedListRequest(final Context context, boolean forceRefresh,HttpRequestTask.HttpRequestTaskCallback cb ){
+		return createTrustedListRequest(context,forceRefresh,cb,null);
+	}
+	
+	protected static boolean createTrustedListRequest(final Context context, boolean forceRefresh,HttpRequestTask.HttpRequestTaskCallback cb, final TrustedListCallback listCallback ){
 		if(context == null){
 			return false;
 		}
@@ -363,6 +371,9 @@ public class RouterServiceValidator {
 		if(!forceRefresh && (System.currentTimeMillis()-getTrustedAppListTimeStamp(context))<REFRESH_TRUSTED_APP_LIST_TIME){ 
 			//Our list should still be ok for now so we will skip the request
 			pendingListRefresh = false;
+			if(listCallback!=null){
+				listCallback.onListObtained(true);
+			}
 			return false;
 		}
 		
@@ -400,6 +411,7 @@ public class RouterServiceValidator {
 					//Log.d(TAG, "APPS! " + response);
 					setTrustedList(context, response);
 					pendingListRefresh = false;
+					if(listCallback!=null){listCallback.onListObtained(true);}
 				}
 
 				@Override
@@ -407,6 +419,7 @@ public class RouterServiceValidator {
 					Log.e(TAG, "Error while requesting trusted app list: "
 							+ statusCode);
 					pendingListRefresh = false;
+					if(listCallback!=null){listCallback.onListObtained(false);}
 				}
 			};
 		}
@@ -565,7 +578,12 @@ public class RouterServiceValidator {
 		}
 		
 	}
-	
-	
+	/**
+	 * This interface is used as a callback to know when we have either obtained a list or at least returned from our attempt.
+	 *
+	 */
+	public static interface TrustedListCallback{
+		public void onListObtained(boolean successful);
+	}
 
 }

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -72,18 +72,27 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			if(intent.hasExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_EXTRA)){	
 				if(intent.getBooleanExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_EXTRA, false)){
 					String packageName = intent.getStringExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_APP_PACKAGE);
-					ComponentName componentName = intent.getParcelableExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_CMP_NAME);
+					final ComponentName componentName = intent.getParcelableExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_CMP_NAME);
 					if(componentName!=null){
-						//Log.v(TAG, "SDL enabled by router service from " + packageName + " compnent package " + componentName.getPackageName()  + " - " + componentName.getClassName());
-						RouterServiceValidator vlad = new RouterServiceValidator(context,componentName);
-						if(vlad.validate()){
-							//Log.d(TAG, "Router service trusted!");
-							queuedService = componentName;
-							intent.setAction("com.sdl.noaction"); //Replace what's there so we do go into some unintended loop
-							onSdlEnabled(context, intent);
-						}else{
-							Log.w(TAG, "RouterService was not trusted. Ignoring intent from : "+ componentName.getClassName());
-						}
+						final Intent finalIntent = intent;
+						final Context finalContext = context;
+						RouterServiceValidator.createTrustedListRequest(context, false, new TrustedListCallback(){
+							@Override
+							public void onListObtained(boolean successful) {
+								//Log.v(TAG, "SDL enabled by router service from " + packageName + " compnent package " + componentName.getPackageName()  + " - " + componentName.getClassName());
+								RouterServiceValidator vlad = new RouterServiceValidator(finalContext,componentName);
+								if(vlad.validate()){
+									//Log.d(TAG, "Router service trusted!");
+									queuedService = componentName;
+									finalIntent.setAction("com.sdl.noaction"); //Replace what's there so we do go into some unintended loop
+									onSdlEnabled(finalContext, finalIntent);
+								}else{
+									Log.w(TAG, "RouterService was not trusted. Ignoring intent from : "+ componentName.getClassName());
+								}
+							}
+							
+						});
+						
 						
 					}
 					


### PR DESCRIPTION
See #357 

- [x] Add  check for the router list during app query for connected routers ([Commit](https://github.com/smartdevicelink/sdl_android/pull/358/commits/8bb3e60c47af20339b7b402218d93c6bc4fa53ec))
- [x] Removed apps from closing their own router services if they weren't on list ([Commit](https://github.com/smartdevicelink/sdl_android/pull/358/commits/8ec3916288f1526abe390432b7698dc69a256fc8))
- [x] Add check for the router list during SDL Enabled broadcast ([Commit](https://github.com/smartdevicelink/sdl_android/pull/358/commits/0c6d17c76d712b2225d905d9615181cf43f99644))
