### PR TITLE
Fix NPE in SdlBroadcastReceiver

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -109,8 +109,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 		}
 		
 	    if (intent.getAction().contains("android.bluetooth.adapter.action.STATE_CHANGED")){
-	      
-	    	int state = intent.getExtras().getInt("android.bluetooth.adapter.extra.STATE");
+	    	int state = intent.getIntExtra("android.bluetooth.adapter.extra.STATE",-1);
 	    		if (state == BluetoothAdapter.STATE_OFF || 
 	    			state == BluetoothAdapter.STATE_TURNING_OFF ){
 	    			//onProtocolDisabled(context);


### PR DESCRIPTION
Fix #361 . Change method call to handle case where the extra doesn’t exist