### PR TITLE
[Hotfix] RSVP Improvements

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android_lib/src/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -556,12 +556,19 @@ public class SdlConnection implements IProtocolListener, ITransportListener {
 			if(cachedMultiConfig!=null){
 				//We are in legacy mode, but just received a force connect. The router service should never be pointing us here if we are truely in legacy mode
 				ComponentName tempCompName = SdlBroadcastReceiver.consumeQueuedRouterService();
-				cachedMultiConfig.setService(tempCompName);
-				//We are not connected yet so we should be able to close down
-				_transport.disconnect(); //This will force us into the 
+				RouterServiceValidator vlad = new RouterServiceValidator(cachedMultiConfig.getContext(),tempCompName);
+				if(vlad.validate()){
+					cachedMultiConfig.setService(tempCompName);
+					//We are not connected yet so we should be able to close down
+					_transport.disconnect(); //This will force us into the 
+				}else{
+					//Log.d(TAG, "Router service not trusted during force connect. Ignoring.");
+					return;
+				}
 			}else{
-				Log.i(TAG, "No cached multiplexing config, transport error being called");
-				_transport.disconnect();
+				//Log.i(TAG, "No cached multiplexing config, ignoring");
+				//_transport.disconnect();
+				return;
 			}
 			Log.w(TAG, "Using own transport, but not connected. Attempting to join multiplexing");		
 		}else{

--- a/sdl_android_lib/src/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -51,7 +51,7 @@ public class RouterServiceValidator {
 	private static final String JSON_APP_VERSION_TAG = "version";
 
 	
-	private static final long REFRESH_TRUSTED_APP_LIST_TIME 	= 3600000 * 24; // 24 hours in ms
+	private static final long REFRESH_TRUSTED_APP_LIST_TIME 	= 3600000 * 24 * 7; // A week in ms
 	
 	private static final String SDL = "sdl";
 	private static final String SDL_PACKAGE_LIST = "sdl_package_list";

--- a/sdl_android_lib/src/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -40,7 +40,7 @@ public class RouterServiceValidator {
 
 	private static final String REQUEST_PREFIX = "https://woprjr.smartdevicelink.com/api/1/applications/queryTrustedRouters"; 
 
-	private static final String DEFAULT_APP_LIST = "{\"response\": {\"com.livio.sdl\" : { \"versionBlacklist\":[] }, \"com.lexus.tcapp\" : { \"versionBlacklist\":[] }, \"com.toyota.tcapp\" : { \"versionBlacklist\": [] } , \"com.sdl.router\":{\"versionBlacklist\": [] } }}"; 
+	private static final String DEFAULT_APP_LIST = "{\"response\": {\"com.livio.sdl\" : { \"versionBlacklist\":[] }, \"com.lexus.tcapp\" : { \"versionBlacklist\":[] }, \"com.toyota.tcapp\" : { \"versionBlacklist\": [] } , \"com.sdl.router\":{\"versionBlacklist\": [] },\"com.ford.fordpass\" : { \"versionBlacklist\":[] } }}"; 
 	
 	
 	private static final String JSON_RESPONSE_OBJECT_TAG = "response";

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -87,15 +87,13 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 							@Override
 							public void onListObtained(boolean successful) {
 								//Log.v(TAG, "SDL enabled by router service from " + packageName + " compnent package " + componentName.getPackageName()  + " - " + componentName.getClassName());
+								//List obtained. Let's start our service
+								queuedService = componentName;
+								finalIntent.setAction("com.sdl.noaction"); //Replace what's there so we do go into some unintended loop
+								//Validate the router service so the service knows if this is a trusted router service
 								RouterServiceValidator vlad = new RouterServiceValidator(finalContext,componentName);
-								if(vlad.validate()){
-									//Log.d(TAG, "Router service trusted!");
-									queuedService = componentName;
-									finalIntent.setAction("com.sdl.noaction"); //Replace what's there so we do go into some unintended loop
-									onSdlEnabled(finalContext, finalIntent);
-								}else{
-									Log.w(TAG, "RouterService was not trusted. Ignoring intent from : "+ componentName.getClassName());
-								}
+								finalIntent.putExtra(TransportConstants.ROUTER_SERVICE_VALIDATED, vlad.validate());
+								onSdlEnabled(finalContext, finalIntent);
 							}
 							
 						});

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -22,6 +22,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 
 	private static final String BOOT_COMPLETE = "android.intent.action.BOOT_COMPLETED";
 	private static final String ACL_CONNECTED = "android.bluetooth.device.action.ACL_CONNECTED";
+	private static final String STATE_CHANGED = "android.bluetooth.adapter.action.STATE_CHANGED" ;
 	
 	protected static final String SDL_ROUTER_SERVICE_CLASS_NAME 			= "sdlrouterservice";
 	
@@ -57,6 +58,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 		
         if(!(action.equalsIgnoreCase(BOOT_COMPLETE)
         		|| action.equalsIgnoreCase(ACL_CONNECTED)
+        		|| action.equalsIgnoreCase(STATE_CHANGED)
         		|| action.equalsIgnoreCase(USBTransport.ACTION_USB_ACCESSORY_ATTACHED)
         		|| action.equalsIgnoreCase(TransportConstants.START_ROUTER_SERVICE_ACTION))){
         	//We don't want anything else here if the child class called super and has different intent filters

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -22,7 +22,6 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 
 	private static final String BOOT_COMPLETE = "android.intent.action.BOOT_COMPLETED";
 	private static final String ACL_CONNECTED = "android.bluetooth.device.action.ACL_CONNECTED";
-	private static final String STATE_CHANGED = "android.bluetooth.adapter.action.STATE_CHANGED" ;
 	
 	protected static final String SDL_ROUTER_SERVICE_CLASS_NAME 			= "sdlrouterservice";
 	
@@ -58,7 +57,6 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 		
         if(!(action.equalsIgnoreCase(BOOT_COMPLETE)
         		|| action.equalsIgnoreCase(ACL_CONNECTED)
-        		|| action.equalsIgnoreCase(STATE_CHANGED)
         		|| action.equalsIgnoreCase(USBTransport.ACTION_USB_ACCESSORY_ATTACHED)
         		|| action.equalsIgnoreCase(TransportConstants.START_ROUTER_SERVICE_ACTION))){
         	//We don't want anything else here if the child class called super and has different intent filters
@@ -120,20 +118,6 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 
 		}
 		
-	    if (intent.getAction().contains("android.bluetooth.adapter.action.STATE_CHANGED")){
-	    	int state = intent.getIntExtra("android.bluetooth.adapter.extra.STATE",-1);
-	    		if (state == BluetoothAdapter.STATE_OFF || 
-	    			state == BluetoothAdapter.STATE_TURNING_OFF ){
-	    			//onProtocolDisabled(context);
-	    			//Let's let the service that is running manage what to do for this
-	    			//If we were to do it here, for every instance of this BR it would send
-	    			//an intent to stop service, where it's only one that is needed.
-	    			return;
-	    		}else if(state == BluetoothAdapter.STATE_TURNING_ON){
-	    			//We started bluetooth, we should check for a new valid router list
-	    			RouterServiceValidator.createTrustedListRequest(context,true);
-	    		}
-	    }
 
 	    if(localRouterClass!=null){ //If there is a supplied router service lets run some logic regarding starting one
 	    	

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -118,7 +118,18 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 
 		}
 		
-
+	    if (intent.getAction().contains("android.bluetooth.adapter.action.STATE_CHANGED")){
+	    	int state = intent.getIntExtra("android.bluetooth.adapter.extra.STATE",-1);
+	    		if (state == BluetoothAdapter.STATE_OFF || 
+	    			state == BluetoothAdapter.STATE_TURNING_OFF){
+	    			//onProtocolDisabled(context);
+	    			//Let's let the service that is running manage what to do for this
+	    			//If we were to do it here, for every instance of this BR it would send
+	    			//an intent to stop service, where it's only one that is needed.
+	    			return;
+	    		}
+	    }
+	    
 	    if(localRouterClass!=null){ //If there is a supplied router service lets run some logic regarding starting one
 	    	
 	    	if(!didStart){

--- a/sdl_android_lib/src/com/smartdevicelink/transport/TransportConstants.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/TransportConstants.java
@@ -27,6 +27,8 @@ public class TransportConstants {
 	public static final String START_ROUTER_SERVICE_SDL_ENABLED_CMP_NAME    = "component_name";
 	public static final String START_ROUTER_SERVICE_SDL_ENABLED_PING		= "ping";
 	public static final String FORCE_TRANSPORT_CONNECTED					= "force_connect"; //This is legacy, do not refactor this. 
+	public static final String ROUTER_SERVICE_VALIDATED						= "router_service_validated"; 
+
 	
 	public static final String REPLY_TO_INTENT_EXTRA 						= "ReplyAddress";
 	public static final String CONNECT_AS_CLIENT_BOOLEAN_EXTRA				= "connectAsClient";

--- a/sdl_android_tests/AndroidManifest.xml
+++ b/sdl_android_tests/AndroidManifest.xml
@@ -15,7 +15,7 @@
     
     <instrumentation
         android:name="android.test.InstrumentationTestRunner"
-        android:targetPackage="com.smartdevicelink" />
+        android:targetPackage="com.smartdevicelink.test" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
  <application

--- a/sdl_android_tests/src/com/smartdevicelink/transport/RSVTestCase.java
+++ b/sdl_android_tests/src/com/smartdevicelink/transport/RSVTestCase.java
@@ -93,7 +93,7 @@ public class RSVTestCase extends AndroidTestCase {
 		assertFalse(RouterServiceValidator.setTrustedList(mContext,null));
 		assertFalse(RouterServiceValidator.setTrustedList(null,"test"));
 		assertTrue(RouterServiceValidator.setTrustedList(mContext,"test"));
-		String test= "{\"response\": {\"com.livio.sdl\" : { \"versionBlacklist\":[] }, \"com.lexus.tcapp\" : { \"versionBlacklist\":[] }, \"com.toyota.tcapp\" : { \"versionBlacklist\": [] } , \"com.sdl.router\":{\"versionBlacklist\": [] } }}"; 
+		String test = "{\"response\": {\"com.livio.sdl\" : { \"versionBlacklist\":[] }, \"com.lexus.tcapp\" : { \"versionBlacklist\":[] }, \"com.toyota.tcapp\" : { \"versionBlacklist\": [] } , \"com.sdl.router\":{\"versionBlacklist\": [] },\"com.ford.fordpass\" : { \"versionBlacklist\":[] } }}"; 
 		assertTrue(RouterServiceValidator.setTrustedList(mContext,test));
 		assertTrue(RouterServiceValidator.setTrustedList(mContext,test+test+test+test+test));
 		StringBuilder builder = new StringBuilder();
@@ -104,7 +104,7 @@ public class RSVTestCase extends AndroidTestCase {
 	}
 	
 	public void testTrustedListSetAndGet(){
-		String test= "{\"response\": {\"com.livio.sdl\" : { \"versionBlacklist\":[] }, \"com.lexus.tcapp\" : { \"versionBlacklist\":[] }, \"com.toyota.tcapp\" : { \"versionBlacklist\": [] } , \"com.sdl.router\":{\"versionBlacklist\": [] } }}"; 
+		String test = "{\"response\": {\"com.livio.sdl\" : { \"versionBlacklist\":[] }, \"com.lexus.tcapp\" : { \"versionBlacklist\":[] }, \"com.toyota.tcapp\" : { \"versionBlacklist\": [] } , \"com.sdl.router\":{\"versionBlacklist\": [] },\"com.ford.fordpass\" : { \"versionBlacklist\":[] } }}"; 
 		assertTrue(RouterServiceValidator.setTrustedList(mContext,test));
 		String retVal = RouterServiceValidator.getTrustedList(mContext);
 		assertNotNull(retVal);

--- a/sdl_android_tests/src/com/smartdevicelink/transport/RSVTestCase.java
+++ b/sdl_android_tests/src/com/smartdevicelink/transport/RSVTestCase.java
@@ -3,6 +3,8 @@ package com.smartdevicelink.transport;
 import java.util.List;
 
 import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -201,6 +203,42 @@ public class RSVTestCase extends AndroidTestCase {
 		}
 		
 		
+	}
+	
+	/**
+	 * Test to check that we can save our last request which actually houses all the previous known sdl enabled apps
+	 */
+	public void testRequestChange(){
+		assertNull(RouterServiceValidator.getLastRequest(mContext));
+		String test = "{\"response\": {\"com.livio.sdl\" : { \"versionBlacklist\":[] }, \"com.lexus.tcapp\" : { \"versionBlacklist\":[] }, \"com.toyota.tcapp\" : { \"versionBlacklist\": [] } , \"com.sdl.router\":{\"versionBlacklist\": [] },\"com.ford.fordpass\" : { \"versionBlacklist\":[] } }}"; 
+		JSONObject object = null;
+		try {
+			object = new JSONObject(test);
+		} catch (JSONException e) {
+			e.printStackTrace();
+		}
+		assertNotNull(object);
+		assertFalse(object.equals(RouterServiceValidator.getLastRequest(mContext)));
+		
+		assertTrue(RouterServiceValidator.setLastRequest(mContext, object.toString()));
+		
+		String oldRequest = RouterServiceValidator.getLastRequest(mContext);
+		assertNotNull(oldRequest);
+		assertTrue(object.toString().equals(oldRequest));
+		
+		//Now test a new list
+		test = "{\"response\": {\"com.livio.sdl\" : { \"versionBlacklist\":[] }, \"com.lexus.tcapp\" : { \"versionBlacklist\":[] }, \"com.test.test\" : { \"versionBlacklist\":[] },\"com.toyota.tcapp\" : { \"versionBlacklist\": [] } , \"com.sdl.router\":{\"versionBlacklist\": [] },\"com.ford.fordpass\" : { \"versionBlacklist\":[] } }}"; 
+		object = null;
+		try {
+			object = new JSONObject(test);
+		} catch (JSONException e) {
+			e.printStackTrace();
+		}
+		assertNotNull(object);
+		assertFalse(object.equals(RouterServiceValidator.getLastRequest(mContext)));
+		//Clear it for next test
+		RouterServiceValidator.setLastRequest(mContext, null);
+
 	}
 	
 	 


### PR DESCRIPTION
Addresses issue #371. 

Based on recent usage and issues, the RSVP system needs improvements. This PR will be merged as a hotfix to address the issues found by the following:

- [x] Remove call to RSVP server during bluetooth state change. Should reduce server pings.
- [x] Increase time cached list can be used from 24 hours to 7 days
- [x] Add additional OEM apps to hardcoded to list 
- [x] Remove code that ignores intents from untrusted router services. This prevents legacy mode to engage. Now includes a boolean extra in the sdl enabled intent.
- [x] Invalidate list when new apps are installed. ([Commit](https://github.com/smartdevicelink/sdl_android/pull/372/commits/b9b7e29a9de424af608719a5ea88f54fe2a651b1))
- [x] Fix issue of legacy connection be closed due to "force connect" flag
- [x] Revert removal of android.bluetooth.adapter.action.STATE_CHANGED. Need it to start router service.