### PR TITLE
Proposal 1 to fix Issue_373

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -90,7 +90,7 @@ public class MultiplexBluetoothTransport {
     //private BluetoothServerSocket serverSocket= null;
 
 
-	static boolean listening = false, keepSocketAlive = true;
+	static boolean keepSocketAlive = true;
     
     
     /**
@@ -184,8 +184,7 @@ public class MultiplexBluetoothTransport {
        
 
         // Start the thread to listen on a BluetoothServerSocket
-        if (getBluetoothSerialServerInstance().getAcceptThread() == null 
-        		//&& !listening
+        if (getBluetoothSerialServerInstance().getAcceptThread() == null
         		&& serverInstance.mAdapter != null
         		&&  serverInstance.mAdapter.isEnabled()) {
         	//Log.d(TAG, "Secure thread was null, attempting to create new");
@@ -338,7 +337,6 @@ public class MultiplexBluetoothTransport {
      * Indicate that the connection was lost and notify the UI Activity.
      */
     private void connectionLost() {
-    	listening = false;
         // Send a failure message back to the Activity
         Message msg = mHandler.obtainMessage(SdlRouterService.MESSAGE_TOAST);
         Bundle bundle = new Bundle();
@@ -379,7 +377,6 @@ public class MultiplexBluetoothTransport {
         @SuppressLint("NewApi")
 		public AcceptThread(boolean secure) {
         	synchronized(threadLock){
-            	listening = false;
             	//Log.d(TAG, "Creating an Accept Thread");
             	BluetoothServerSocket tmp = null;
             	mSocketType = secure ? "Secure":"Insecure";
@@ -387,15 +384,12 @@ public class MultiplexBluetoothTransport {
             	try {
                 	if (secure) {
                 		tmp = getBluetoothSerialServerInstance().mAdapter.listenUsingRfcommWithServiceRecord(NAME_SECURE, SERVER_UUID);
-                		listening = true;
                 	}
             	} catch (IOException e) {
-            		listening = false;
                 	//Log.e(TAG, "Socket Type: " + mSocketType + "listen() failed", e);
                 	 //Let's try to shut down this thead
             	}catch(SecurityException e2){
             		//Log.e(TAG, "<LIVIO> Security Exception in Accept Thread - "+e2.toString());
-            		listening = false;
             		interrupt();
             	}
             	mmServerSocket = tmp;
@@ -438,7 +432,7 @@ public class MultiplexBluetoothTransport {
                 		return;
                 	}
                 } catch (IOException e) {
-                    Log.e(TAG, "Socket Type: " + mSocketType + "accept() failed", e);
+                    Log.e(TAG, "Socket Type: " + mSocketType + "accept() failed");
                     getBluetoothSerialServerInstance().stop(STATE_ERROR);
                     return;
                 }
@@ -474,7 +468,6 @@ public class MultiplexBluetoothTransport {
         }
 
         public synchronized void cancel() {
-        	listening = false;
         	Log.d(TAG, mState + " Socket Type " + mSocketType + " cancel ");
             try {
             	if(mmServerSocket != null){

--- a/sdl_android_lib/src/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -439,7 +439,7 @@ public class MultiplexBluetoothTransport {
                 	}
                 } catch (IOException e) {
                     Log.e(TAG, "Socket Type: " + mSocketType + "accept() failed", e);
-					getBluetoothSerialServerInstance().stop(STATE_ERROR);
+                    getBluetoothSerialServerInstance().stop(STATE_ERROR);
                     return;
                 }
 

--- a/sdl_android_lib/src/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -438,9 +438,8 @@ public class MultiplexBluetoothTransport {
                 		return;
                 	}
                 } catch (IOException e) {
-                	listening = false;
                     Log.e(TAG, "Socket Type: " + mSocketType + "accept() failed", e);
-					interrupt(); 
+					getBluetoothSerialServerInstance().stop(STATE_ERROR);
                     return;
                 }
 

--- a/sdl_android_tests/src/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
+++ b/sdl_android_tests/src/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
@@ -1,0 +1,72 @@
+package com.smartdevicelink.test.transport;
+
+import junit.framework.TestCase;
+import android.os.Handler;
+import android.os.Message;
+
+import com.smartdevicelink.transport.MultiplexBluetoothTransport;
+import com.smartdevicelink.transport.SdlRouterService;
+
+
+
+public class MultiplexBluetoothTransportTest extends TestCase {
+	
+	private static final Object REQUEST_LOCK = new Object();
+	
+	MultiplexBluetoothTransport bluetooth;
+	boolean didCorrectThing = false, isWaitingForResponse = false;
+	
+	//Example handler
+	Handler stateChangeHandler = new Handler(){
+		int stateDesired = MultiplexBluetoothTransport.STATE_LISTEN;
+		@Override
+		public void handleMessage(Message msg) {
+			if(!isWaitingForResponse){
+				return;
+			}
+			switch(msg.what){
+				case SdlRouterService.MESSAGE_STATE_CHANGE:
+					if(msg.arg1 == stateDesired){
+							didCorrectThing = true;
+							break;
+					}
+					default:
+						didCorrectThing = false;
+			}
+			REQUEST_LOCK.notify();
+		}
+		
+	};
+	
+	public void testStateTransitions() {
+		//TODO test for more than the two states
+		bluetooth = MultiplexBluetoothTransport.getBluetoothSerialServerInstance();
+		assertNull(bluetooth);
+
+		bluetooth = MultiplexBluetoothTransport.getBluetoothSerialServerInstance(stateChangeHandler);
+		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
+		
+		bluetooth.start();
+		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_LISTEN);
+		
+		bluetooth.stop();
+		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
+
+	}
+	
+	private void notifyResponseReceived(){
+		REQUEST_LOCK.notify();
+	}
+	
+	private void waitForResponse(){
+		synchronized(REQUEST_LOCK){
+			try {
+				REQUEST_LOCK.wait();
+				assertTrue(didCorrectThing);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Fixing https://github.com/smartdevicelink/sdl_android/issues/373
- Remove interrupt()
- listening variable is not needed
- put transport in STATE_ERROR

Bluetooth Transport Log before fix (toggling BT rapidly):
```
01-23 14:18:11.804 23088-23088/? D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:18:11.805 23088-23131/? E/Bluetooth Transport: Socket Type: Secureaccept() failed
                                                        java.io.IOException: read failed, socket might closed or timeout, read ret: -1
                                                            at android.bluetooth.BluetoothSocket.readAll(BluetoothSocket.java:741)
                                                            at android.bluetooth.BluetoothSocket.waitSocketSignal(BluetoothSocket.java:700)
                                                            at android.bluetooth.BluetoothSocket.accept(BluetoothSocket.java:460)
                                                            at android.bluetooth.BluetoothServerSocket.accept(BluetoothServerSocket.java:158)
                                                            at android.bluetooth.BluetoothServerSocket.accept(BluetoothServerSocket.java:144)
                                                            at com.smartdevicelink.transport.MultiplexBluetoothTransport$AcceptThread.run(MultiplexBluetoothTransport.java:432)
01-23 14:18:17.362 23277-23324/com.smartdevicelink.router D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:18:48.352 23277-23528/com.smartdevicelink.router D/Bluetooth Transport: 3 Socket Type Secure cancel 
01-23 14:18:53.213 24076-24130/? D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:18:53.923 24076-24076/com.smartdevicelink.router D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:19:03.273 24286-24447/com.smartdevicelink.router D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:19:04.122 24286-24286/? D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:19:12.510 24606-24768/com.smartdevicelink.router D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:19:13.114 24606-24606/? D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:19:20.602 24918-25086/com.smartdevicelink.router D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:19:21.416 24918-24918/? D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:19:29.805 25239-25405/com.smartdevicelink.router D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:19:30.762 25239-25239/com.smartdevicelink.router D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:19:43.473 25731-25899/com.smartdevicelink.router D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:19:47.957 25731-25731/com.smartdevicelink.router D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:19:55.096 26133-26204/com.smartdevicelink.router D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:19:56.687 26133-26133/? D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:19:56.692 26133-26204/? E/Bluetooth Transport: Socket Type: Secureaccept() failed
                                                        java.io.IOException: read failed, socket might closed or timeout, read ret: -1
                                                            at android.bluetooth.BluetoothSocket.readAll(BluetoothSocket.java:741)
                                                            at android.bluetooth.BluetoothSocket.waitSocketSignal(BluetoothSocket.java:700)
                                                            at android.bluetooth.BluetoothSocket.accept(BluetoothSocket.java:460)
                                                            at android.bluetooth.BluetoothServerSocket.accept(BluetoothServerSocket.java:158)
                                                            at android.bluetooth.BluetoothServerSocket.accept(BluetoothServerSocket.java:144)
                                                            at com.smartdevicelink.transport.MultiplexBluetoothTransport$AcceptThread.run(MultiplexBluetoothTransport.java:432)
01-23 14:20:01.850 26344-26405/com.smartdevicelink.router D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
```
- When toggling BT, it was harder to see the IOException for a closed socket being thrown. (After further tests, this was probably due to `interrupt()`) 

After editing the catch block in https://github.com/smartdevicelink/sdl_android/blob/bugfix/issue_371/sdl_android_lib/src/com/smartdevicelink/transport/MultiplexBluetoothTransport.java#L435-L445 (toggling BT rapidly):
```
01-23 14:21:21.354 27291-27469/com.smartdevicelink.router D/Bluetooth Transport: 3 Socket Type Secure cancel 
01-23 14:21:25.425 27727-27774/? D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:21:26.133 27727-27727/? D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:21:26.134 27727-27774/? E/Bluetooth Transport: Socket Type: Secureaccept() failed
                                                        java.io.IOException: read failed, socket might closed or timeout, read ret: -1
                                                            at android.bluetooth.BluetoothSocket.readAll(BluetoothSocket.java:741)
                                                            at android.bluetooth.BluetoothSocket.waitSocketSignal(BluetoothSocket.java:700)
                                                            at android.bluetooth.BluetoothSocket.accept(BluetoothSocket.java:460)
                                                            at android.bluetooth.BluetoothServerSocket.accept(BluetoothServerSocket.java:158)
                                                            at android.bluetooth.BluetoothServerSocket.accept(BluetoothServerSocket.java:144)
                                                            at com.smartdevicelink.transport.MultiplexBluetoothTransport$AcceptThread.run(MultiplexBluetoothTransport.java:432)
01-23 14:21:33.117 27931-27996/com.smartdevicelink.router D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:21:33.571 27931-27931/com.smartdevicelink.router D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:21:33.572 27931-27996/com.smartdevicelink.router E/Bluetooth Transport: Socket Type: Secureaccept() failed
                                                                                 java.io.IOException: read failed, socket might closed or timeout, read ret: -1
                                                                                     at android.bluetooth.BluetoothSocket.readAll(BluetoothSocket.java:741)
                                                                                     at android.bluetooth.BluetoothSocket.waitSocketSignal(BluetoothSocket.java:700)
                                                                                     at android.bluetooth.BluetoothSocket.accept(BluetoothSocket.java:460)
                                                                                     at android.bluetooth.BluetoothServerSocket.accept(BluetoothServerSocket.java:158)
                                                                                     at android.bluetooth.BluetoothServerSocket.accept(BluetoothServerSocket.java:144)
                                                                                     at com.smartdevicelink.transport.MultiplexBluetoothTransport$AcceptThread.run(MultiplexBluetoothTransport.java:432)
01-23 14:21:41.123 28155-28222/com.smartdevicelink.router D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:21:41.233 28155-28155/com.smartdevicelink.router D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:21:45.936 28405-28453/? D/Bluetooth Transport: Socket Type: Secure BEGIN mAcceptThreadThread[Thread-2,5,main]
01-23 14:21:46.602 28405-28405/? D/Bluetooth Transport: 1 Socket Type Secure cancel 
01-23 14:21:46.607 28405-28453/? E/Bluetooth Transport: Socket Type: Secureaccept() failed
                                                        java.io.IOException: read failed, socket might closed or timeout, read ret: -1
                                                            at android.bluetooth.BluetoothSocket.readAll(BluetoothSocket.java:741)
                                                            at android.bluetooth.BluetoothSocket.waitSocketSignal(BluetoothSocket.java:700)
                                                            at android.bluetooth.BluetoothSocket.accept(BluetoothSocket.java:460)
                                                            at android.bluetooth.BluetoothServerSocket.accept(BluetoothServerSocket.java:158)
                                                            at android.bluetooth.BluetoothServerSocket.accept(BluetoothServerSocket.java:144)
                                                            at com.smartdevicelink.transport.MultiplexBluetoothTransport$AcceptThread.run(MultiplexBluetoothTransport.java:432)
```

- I believe the previous `interrupt()` call was preventing the IOException being thrown regularly after a socket was closed and the transport was in the STATE_LISTEN state.
