### PR TITLE
Bugfix/issue_375

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
@@ -19,7 +19,7 @@ public class WiProProtocol extends AbstractProtocol {
 	byte _version = 1;
 	private final static String FailurePropagating_Msg = "Failure propagating ";
 
-	private static final int V1_V2_MTU_SIZE = 1500;
+	public static final int V1_V2_MTU_SIZE = 1500;
 	private static final int V3_V4_MTU_SIZE = 131072;
 	private static int HEADER_SIZE = 8;
 	private static int MAX_DATA_SIZE = V1_V2_MTU_SIZE  - HEADER_SIZE;

--- a/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
@@ -22,7 +22,7 @@ public class WiProProtocol extends AbstractProtocol {
 	public static final int V1_V2_MTU_SIZE = 1500;
 	public static final int V3_V4_MTU_SIZE = 131072;
 	public static final int V1_HEADER_SIZE = 8;
-	public static final int V2_V4_HEADER_SIZE =12;
+	public static final int V2_HEADER_SIZE = 12;
 	private static int HEADER_SIZE = 8;
 	private static int MAX_DATA_SIZE = V1_V2_MTU_SIZE  - HEADER_SIZE;
 

--- a/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
+++ b/sdl_android_lib/src/com/smartdevicelink/protocol/WiProProtocol.java
@@ -20,7 +20,9 @@ public class WiProProtocol extends AbstractProtocol {
 	private final static String FailurePropagating_Msg = "Failure propagating ";
 
 	public static final int V1_V2_MTU_SIZE = 1500;
-	private static final int V3_V4_MTU_SIZE = 131072;
+	public static final int V3_V4_MTU_SIZE = 131072;
+	public static final int V1_HEADER_SIZE = 8;
+	public static final int V2_V4_HEADER_SIZE =12;
 	private static int HEADER_SIZE = 8;
 	private static int MAX_DATA_SIZE = V1_V2_MTU_SIZE  - HEADER_SIZE;
 

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlPsm.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlPsm.java
@@ -25,6 +25,7 @@ public class SdlPsm{
 
 	
 	private static final byte FIRST_FRAME_DATA_SIZE 			= 0x08;
+	private static final int  V1_V2_MTU_SIZE 					= 1500;
 	
 	private static final int VERSION_MASK 						= 0xF0; //4 highest bits
 	private static final int COMPRESSION_MASK 					= 0x08; //4th lowest bit
@@ -153,9 +154,9 @@ public class SdlPsm{
 					if(dataLength==0){
 						return FINISHED_STATE; //We are done if we don't have any payload
 					}
-					try{
+					if(dataLength <= V1_V2_MTU_SIZE){ // size from protocol/WiProProtocol.java
 						payload = new byte[dataLength];
-					}catch(OutOfMemoryError oom){
+					}else{
 						return ERROR_STATE;
 					}
 					dumpSize = dataLength;
@@ -174,7 +175,11 @@ public class SdlPsm{
 				if(dataLength == 0){
 					return FINISHED_STATE; //We are done if we don't have any payload
 				}
-				payload = new byte[dataLength];
+				try {
+					payload = new byte[dataLength];
+				}catch(OutOfMemoryError e){
+					return ERROR_STATE;
+				}
 				dumpSize = dataLength;
 				return DATA_PUMP_STATE;
 			}else{

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlPsm.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlPsm.java
@@ -153,7 +153,11 @@ public class SdlPsm{
 					if(dataLength==0){
 						return FINISHED_STATE; //We are done if we don't have any payload
 					}
-					payload = new byte[dataLength];
+					try{
+						payload = new byte[dataLength];
+					}catch(OutOfMemoryError oom){
+						return ERROR_STATE;
+					}
 					dumpSize = dataLength;
 					return DATA_PUMP_STATE;
 				}

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlPsm.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlPsm.java
@@ -2,6 +2,7 @@ package com.smartdevicelink.transport;
 
 import com.smartdevicelink.protocol.SdlPacket;
 
+import static com.smartdevicelink.protocol.WiProProtocol.V1_HEADER_SIZE;
 import static com.smartdevicelink.protocol.WiProProtocol.V1_V2_MTU_SIZE;
 
 
@@ -155,7 +156,7 @@ public class SdlPsm{
 					if(dataLength==0){
 						return FINISHED_STATE; //We are done if we don't have any payload
 					}
-					if(dataLength <= V1_V2_MTU_SIZE){ // size from protocol/WiProProtocol.java
+					if(dataLength <= V1_V2_MTU_SIZE - V1_HEADER_SIZE){ // sizes from protocol/WiProProtocol.java
 						payload = new byte[dataLength];
 					}else{
 						return ERROR_STATE;

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlPsm.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlPsm.java
@@ -177,9 +177,9 @@ public class SdlPsm{
 				if(dataLength == 0){
 					return FINISHED_STATE; //We are done if we don't have any payload
 				}
-				try {
+				if(dataLength <= V1_V2_MTU_SIZE - V1_HEADER_SIZE){ // sizes from protocol/WiProProtocol.java
 					payload = new byte[dataLength];
-				}catch(OutOfMemoryError e){
+				}else{
 					return ERROR_STATE;
 				}
 				dumpSize = dataLength;

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlPsm.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlPsm.java
@@ -2,6 +2,8 @@ package com.smartdevicelink.transport;
 
 import com.smartdevicelink.protocol.SdlPacket;
 
+import static com.smartdevicelink.protocol.WiProProtocol.V1_V2_MTU_SIZE;
+
 
 public class SdlPsm{
 	//private static final String TAG = "Sdl PSM";
@@ -25,7 +27,6 @@ public class SdlPsm{
 
 	
 	private static final byte FIRST_FRAME_DATA_SIZE 			= 0x08;
-	private static final int  V1_V2_MTU_SIZE 					= 1500;
 	
 	private static final int VERSION_MASK 						= 0xF0; //4 highest bits
 	private static final int COMPRESSION_MASK 					= 0x08; //4th lowest bit

--- a/sdl_android_tests/src/com/smartdevicelink/test/transport/SdlPsmTests.java
+++ b/sdl_android_tests/src/com/smartdevicelink/test/transport/SdlPsmTests.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Method;
 import com.smartdevicelink.protocol.SdlPacket;
 import com.smartdevicelink.test.Test;
 import com.smartdevicelink.transport.SdlPsm;
+import com.smartdevicelink.protocol.WiProProtocol;
 
 import android.util.Log;
 import junit.framework.TestCase;
@@ -16,7 +17,7 @@ import junit.framework.TestCase;
  */
 public class SdlPsmTests extends TestCase {
 	private static final String TAG = "SdlPsmTests";
-	private static final int V1_V2_MTU_SIZE = 1500;
+	private static final int MAX_DATA_LENGTH = WiProProtocol.V1_V2_MTU_SIZE - WiProProtocol.V1_HEADER_SIZE;
 	SdlPsm sdlPsm;
 	Field frameType, dataLength, version, controlFrameInfo;
 	Method transitionOnInput;
@@ -50,7 +51,7 @@ public class SdlPsmTests extends TestCase {
 			controlFrameInfo.set(sdlPsm, SdlPacket.FRAME_INFO_START_SERVICE);
 			frameType.set(sdlPsm, SdlPacket.FRAME_TYPE_CONTROL);
 			
-			dataLength.set(sdlPsm, V1_V2_MTU_SIZE + 1);
+			dataLength.set(sdlPsm, MAX_DATA_LENGTH + 1);
 			int STATE = (Integer) transitionOnInput.invoke(sdlPsm, rawByte, SdlPsm.DATA_SIZE_4_STATE);
 			
 			assertEquals(Test.MATCH, SdlPsm.ERROR_STATE, STATE);
@@ -66,7 +67,7 @@ public class SdlPsmTests extends TestCase {
 			controlFrameInfo.set(sdlPsm, SdlPacket.FRAME_INFO_START_SERVICE);
 			frameType.set(sdlPsm, SdlPacket.FRAME_TYPE_CONTROL);
 			
-			dataLength.set(sdlPsm, V1_V2_MTU_SIZE);
+			dataLength.set(sdlPsm, MAX_DATA_LENGTH);
 			int STATE = (Integer) transitionOnInput.invoke(sdlPsm, rawByte, SdlPsm.DATA_SIZE_4_STATE);
 			
 			assertEquals(Test.MATCH, SdlPsm.DATA_PUMP_STATE, STATE);

--- a/sdl_android_tests/src/com/smartdevicelink/test/transport/SdlPsmTests.java
+++ b/sdl_android_tests/src/com/smartdevicelink/test/transport/SdlPsmTests.java
@@ -1,0 +1,79 @@
+package com.smartdevicelink.test.transport;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import com.smartdevicelink.protocol.SdlPacket;
+import com.smartdevicelink.protocol.WiProProtocol;
+import com.smartdevicelink.test.Test;
+import com.smartdevicelink.transport.SdlPsm;
+import com.smartdevicelink.transport.SdlRouterService;
+
+import android.util.Log;
+import junit.framework.TestCase;
+
+/**
+ * This is a unit test class for the SmartDeviceLink library project class : 
+ * {@link com.smartdevicelink.transport.SdlPsm}
+ */
+public class SdlPsmTests extends TestCase {
+	
+	/**
+	 * This is a unit test for the following methods : 
+	 * {@link com.smartdevicelink.transport.SdlPsm#transitionOnInput()}
+	 */
+	public void testConfigs () {
+		// Test Values
+		byte rawByte = (byte) 0x0;
+		int tooBigForControlFrame = 1501, tooBigToAllocate = 2147483647;
+		SdlPsm sdlPsm = new SdlPsm();
+		
+		int STATE_EXTENDED_MAX = 0, STATE_EXACT_MAX = 0, STATE_OOM_ERROR = 0;
+		
+		try{
+			Method method = SdlPsm.class.getDeclaredMethod("transitionOnInput", byte.class, int.class);
+			method.setAccessible(true);
+			
+			Field frameType = SdlPsm.class.getDeclaredField("frameType");
+			Field dataLength = SdlPsm.class.getDeclaredField("dataLength");
+			Field version = SdlPsm.class.getDeclaredField("version");
+			Field controlFrameInfo = SdlPsm.class.getDeclaredField("controlFrameInfo");
+			frameType.setAccessible(true);
+			dataLength.setAccessible(true);
+			version.setAccessible(true);
+			controlFrameInfo.setAccessible(true);
+			
+			version.set(sdlPsm, 1);
+			controlFrameInfo.set(sdlPsm, SdlPacket.FRAME_INFO_START_SERVICE);
+			
+			frameType.set(sdlPsm, SdlPacket.FRAME_TYPE_CONTROL);
+			
+			dataLength.set(sdlPsm, tooBigForControlFrame);
+			STATE_EXTENDED_MAX  = (Integer) method.invoke(sdlPsm, rawByte, SdlPsm.DATA_SIZE_4_STATE);
+			
+			dataLength.set(sdlPsm, tooBigForControlFrame - 1);
+			STATE_EXACT_MAX  = (Integer) method.invoke(sdlPsm, rawByte, SdlPsm.DATA_SIZE_4_STATE);
+			
+			frameType.set(sdlPsm, SdlPacket.FRAME_TYPE_SINGLE);
+			
+			dataLength.set(sdlPsm, tooBigToAllocate);
+			STATE_OOM_ERROR = (Integer) method.invoke(sdlPsm, rawByte, SdlPsm.DATA_SIZE_4_STATE);
+			
+		}catch(Exception e){
+			Log.e("Shouldn't reach this", e.toString());
+			assert(false);
+		}
+		
+		// Comparison Values
+		int EXPECTED_STATE_EXTENDED_MAX = SdlPsm.ERROR_STATE, EXPECTED_STATE_OOM_ERROR = SdlPsm.ERROR_STATE;
+		int EXPECTED_STATE_EXACT_MAX = SdlPsm.DATA_PUMP_STATE;
+		
+		// Valid Tests
+		assertEquals(Test.MATCH, EXPECTED_STATE_EXTENDED_MAX, STATE_EXTENDED_MAX);
+		assertEquals(Test.MATCH, EXPECTED_STATE_OOM_ERROR, STATE_OOM_ERROR);
+		assertEquals(Test.MATCH, EXPECTED_STATE_EXACT_MAX, STATE_EXACT_MAX);
+		
+		// Invalid/Null Tests
+		
+	}
+}


### PR DESCRIPTION
Resolving #375 

In first case, we don't need a try/catch because is the dataLength is over 1500, we know the data has been garbled.

In the second case we surround allocation of byte array with try/catch to catch the OOM case.
Not much else we can do about an erroneously large dataLength.

L178-182 is Mirroring https://github.com/smartdevicelink/sdl_android/blob/master/sdl_android_lib/src/com/smartdevicelink/transport/SdlPsm.java#L198-L202

-Tested with Gen 3 TDK