### PR TITLE
Bugfix/issue 379

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlRouterService.java
@@ -762,9 +762,11 @@ public class SdlRouterService extends Service{
 	private boolean processCheck(){
 		int myPid = android.os.Process.myPid();
 		ActivityManager am = (ActivityManager)this.getSystemService(ACTIVITY_SERVICE);
+		if(am.getRunningAppProcesses() == null)
+			return false; // No RunningAppProcesses, let's close out
 		for (RunningAppProcessInfo processInfo : am.getRunningAppProcesses())
 		{
-			if (processInfo.pid == myPid)
+			if (processInfo != null && processInfo.pid == myPid)
 			{
 				return ROUTER_SERVICE_PROCESS.equals(processInfo.processName);
 			}

--- a/sdl_android_lib/src/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/SdlRouterService.java
@@ -762,7 +762,7 @@ public class SdlRouterService extends Service{
 	private boolean processCheck(){
 		int myPid = android.os.Process.myPid();
 		ActivityManager am = (ActivityManager)this.getSystemService(ACTIVITY_SERVICE);
-		if(am.getRunningAppProcesses() == null)
+		if(am == null || am.getRunningAppProcesses() == null)
 			return false; // No RunningAppProcesses, let's close out
 		for (RunningAppProcessInfo processInfo : am.getRunningAppProcesses())
 		{


### PR DESCRIPTION
Aimed at #379 
- checks that am or am.getRunningAppProcesses() is not null before for loop
- checks that processInfo object is not null inside for loop, if
statement will short if false
- tested with sample app on Gen 3 TDK