### PR TITLE
Catching NPE on mmOutStream

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -731,7 +731,7 @@ public class MultiplexBluetoothTransport {
             	//This would be a good spot to log out all bytes received
             	mmOutStream.write(buffer, offset, count);
             	//Log.w(TAG, "Wrote out to device: bytes = "+ count);
-            } catch (IOException e) {
+            } catch (IOException|NullPointerException e) { // STRICTLY to catch mmOutStream NPE
                 // Exception during write
             	//OMG! WE MUST NOT BE CONNECTED ANYMORE! LET THE USER KNOW
             	Log.e(TAG, "Error sending bytes to connected device!");


### PR DESCRIPTION
Bugfix #384 
-Comment specifies it is only to catch mmOutStream NPE (don’t be lazy)
-Tested connecting to Gen 3 TDK w/ sample app