### PR TITLE
Added 'synchronized' keyword to lock threadLooper object

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/transport/MultiplexTransport.java
+++ b/sdl_android_lib/src/com/smartdevicelink/transport/MultiplexTransport.java
@@ -169,7 +169,7 @@ public class MultiplexTransport extends SdlTransport{
 		}
 
 		@SuppressLint("NewApi")
-		public void cancel(){
+		public synchronized void cancel(){
 				if(broker!=null){
 					broker.stop();
 					broker = null;


### PR DESCRIPTION
-Bugfix for #385 
-Tested connecting/disconnecting via BT to Gen 3 TDK with sample app 