### PR TITLE
Bugfix/issue 431

### DIFF
--- a/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android_lib/src/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -1401,7 +1401,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				_cycling = true;
 				cleanProxy(disconnectedReason);
 				initializeProxy();
-				if(!SdlDisconnectedReason.LEGACY_BLUETOOTH_MODE_ENABLED.equals(disconnectedReason)){//We don't want to alert higher if we are just cycling for legacy bluetooth
+				if(!SdlDisconnectedReason.LEGACY_BLUETOOTH_MODE_ENABLED.equals(disconnectedReason) && !_transportConfig.getTransportType().equals(TransportType.MULTIPLEX)){
 					notifyProxyClosed("Sdl Proxy Cycled", new SdlException("Sdl Proxy Cycled", SdlExceptionCause.SDL_PROXY_CYCLED), disconnectedReason);							
 				}
 			}


### PR DESCRIPTION
This change will prevent notifying an app's SdlService that its proxy has been closed when it is cycled. It will only affect proxies using the Multiplex transport. This will allow current app developers to still use the common snippet
```
public void onProxyClosed(String info, Exception e, SdlDisconnectedReason reason) {
		stopSelf();
}
```
without having to worry about their service stopping on a Language change or another reason that prompts the cycling of a proxy.

(for issue #431)

Before this change, if you changed the lanuage on core, the SdlProxy object is discarded and the SdlService is stopped without any recourse. With this change, a new SdlProxy is registered with core without closing down the SdlService (but it is registered with the previous languageDesired). 