### PR TITLE
Bugfix/issue 443

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
@@ -1,0 +1,38 @@
+package com.smartdevicelink.transport;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Messenger;
+import android.test.AndroidTestCase;
+
+
+/**
+ * Created by brett on 4/4/17.
+ */
+
+public class RegisteredAppTests extends AndroidTestCase {
+
+    private static final String APP_ID = "123451123";
+
+
+    public void testHandleMessage() {
+
+
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+
+                SdlRouterService router = new SdlRouterService();
+
+                Messenger messenger = null;
+
+                SdlRouterService.RegisteredApp app = router.new RegisteredApp(APP_ID, messenger);
+
+                byte[] bytes = new byte[1];
+                app.handleMessage(TransportConstants.BYTES_TO_SEND_FLAG_LARGE_PACKET_START,bytes);
+                assertNotNull(app.buffer);
+            }
+        });
+    }
+}
+

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
@@ -7,30 +7,32 @@ import android.test.AndroidTestCase;
 
 
 /**
- * Created by brett on 4/4/17.
+ * Created by brettywhite on 4/4/17.
  */
 
 public class RegisteredAppTests extends AndroidTestCase {
 
     private static final String APP_ID = "123451123";
-
+    private static final Messenger messenger = null;
+    private static byte[] bytes = new byte[1];
 
     public void testHandleMessage() {
 
-
+        // Run Test in Main Thread
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
 
+                // Instantiate SdlRouterService and Registered App class
                 SdlRouterService router = new SdlRouterService();
-
-                Messenger messenger = null;
-
                 SdlRouterService.RegisteredApp app = router.new RegisteredApp(APP_ID, messenger);
 
-                byte[] bytes = new byte[1];
+                // Call Handle Message
                 app.handleMessage(TransportConstants.BYTES_TO_SEND_FLAG_LARGE_PACKET_START,bytes);
+
+                // Insure that the buffer is not null, if it is the test will fail
                 assertNotNull(app.buffer);
+
             }
         });
     }

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
@@ -54,7 +54,7 @@ public class RegisteredAppTests extends AndroidTestCase {
                 // Call Handle Message - Making sure it doesn't init buffer
                 app.handleMessage(TransportConstants.BYTES_TO_SEND_FLAG_NONE,bytes);
 
-                // Insure that the buffer is not null, if it is the test will fail
+                // Insure that the buffer is null. and no NPE
                 assertNull(app.buffer);
 
             }

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
@@ -36,5 +36,29 @@ public class RegisteredAppTests extends AndroidTestCase {
             }
         });
     }
+
+    public void testNullBuffer() {
+
+        // Run Test in Main Thread
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+
+                // Instantiate SdlRouterService and Registered App class
+                SdlRouterService router = new SdlRouterService();
+                SdlRouterService.RegisteredApp app = router.new RegisteredApp(APP_ID, messenger);
+
+                // Force Null Buffer
+                app.buffer = null;
+
+                // Call Handle Message - Making sure it doesn't init buffer
+                app.handleMessage(TransportConstants.BYTES_TO_SEND_FLAG_NONE,bytes);
+
+                // Insure that the buffer is not null, if it is the test will fail
+                assertNull(app.buffer);
+
+            }
+        });
+    }
 }
 

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -2265,19 +2265,20 @@ public class SdlRouterService extends Service{
 			}
 			if(buffer == null){
 				Log.e(TAG, "Unable to assemble message as buffer was null/not started");
-			}
-			if(!buffer.handleMessage(flags, packet)){ //If this returns false
-				Log.e(TAG, "Error handling bytes");
-			}
-			if(buffer.isFinished()){ //We are finished building the buffer so we should write the bytes out
-				byte[] bytes = buffer.getBytes();
-				if(queue!=null){
-					queue.add(new PacketWriteTask(bytes, 0, bytes.length,this.prioirtyForBuffingMessage));
-					if(packetWriteTaskMaster!=null){
-						packetWriteTaskMaster.alert();
-					}
+			}else {
+				if (!buffer.handleMessage(flags, packet)) { //If this returns false
+					Log.e(TAG, "Error handling bytes");
 				}
-				buffer.close();
+				if (buffer.isFinished()) { //We are finished building the buffer so we should write the bytes out
+					byte[] bytes = buffer.getBytes();
+					if (queue != null) {
+						queue.add(new PacketWriteTask(bytes, 0, bytes.length, this.prioirtyForBuffingMessage));
+						if (packetWriteTaskMaster != null) {
+							packetWriteTaskMaster.alert();
+						}
+					}
+					buffer.close();
+				}
 			}
 		}
 		

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -2263,9 +2263,7 @@ public class SdlRouterService extends Service{
 				buffer = new ByteAraryMessageAssembler();
 				buffer.init();
 			}
-			if(buffer == null){
-				Log.e(TAG, "Unable to assemble message as buffer was null/not started");
-			}else {
+			if(buffer != null){
 				if (!buffer.handleMessage(flags, packet)) { //If this returns false
 					Log.e(TAG, "Error handling bytes");
 				}


### PR DESCRIPTION
## Issue:

Buffer methods called even if buffer was null.

## Fix:

Don't invoke buffer methods if null by surrounding calls in an else statement insuring the buffer is indeed not null

Also added the unit test file RegisteredAppTests that tests is the buffer is null or not. Before, the app would crash with a NPE and now it will not. 