### PR TITLE
bugfix/utest_MultiplexBluetoothTransport

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
@@ -1,14 +1,13 @@
 package com.smartdevicelink.test.transport;
 
 import android.os.Handler;
+import android.os.Looper;
 import android.os.Message;
 
 import com.smartdevicelink.transport.MultiplexBluetoothTransport;
 import com.smartdevicelink.transport.SdlRouterService;
 
 import junit.framework.TestCase;
-
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 
 
 public class MultiplexBluetoothTransportTest extends TestCase {
@@ -22,46 +21,43 @@ public class MultiplexBluetoothTransportTest extends TestCase {
 	Handler stateChangeHandler;
 	
 	public void testStateTransitions() {
+		if(Looper.myLooper() == null){
+			Looper.prepare();
+		}
 
-		getInstrumentation().runOnMainSync(new Runnable() {
+		stateChangeHandler = new Handler(){
+			int stateDesired = MultiplexBluetoothTransport.STATE_LISTEN;
 			@Override
-			public void run() {
-
-				stateChangeHandler = new Handler(){
-					int stateDesired = MultiplexBluetoothTransport.STATE_LISTEN;
-					@Override
-					public void handleMessage(Message msg) {
-						if(!isWaitingForResponse){
-							return;
+			public void handleMessage(Message msg) {
+				if(!isWaitingForResponse){
+					return;
+				}
+				switch(msg.what){
+					case SdlRouterService.MESSAGE_STATE_CHANGE:
+						if(msg.arg1 == stateDesired){
+							didCorrectThing = true;
+							break;
 						}
-						switch(msg.what){
-							case SdlRouterService.MESSAGE_STATE_CHANGE:
-								if(msg.arg1 == stateDesired){
-									didCorrectThing = true;
-									break;
-								}
-							default:
-								didCorrectThing = false;
-						}
-						REQUEST_LOCK.notify();
-					}
-
-				};
-
-				//TODO test for more than the two states
-				bluetooth = MultiplexBluetoothTransport.getBluetoothSerialServerInstance();
-				assertNull(bluetooth);
-
-				bluetooth = MultiplexBluetoothTransport.getBluetoothSerialServerInstance(stateChangeHandler);
-				assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
-
-				//TODO test changing to a different state without having Bluetooth permissions
-
-				bluetooth.stop();
-				assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
-
+					default:
+						didCorrectThing = false;
+				}
+				REQUEST_LOCK.notify();
 			}
-		});
+
+		};
+
+		//TODO test for more than the two states
+		bluetooth = MultiplexBluetoothTransport.getBluetoothSerialServerInstance();
+		assertNull(bluetooth);
+
+		bluetooth = MultiplexBluetoothTransport.getBluetoothSerialServerInstance(stateChangeHandler);
+		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
+
+		bluetooth.start();
+		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_LISTEN);
+
+		bluetooth.stop();
+		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
 	}
 	
 	private void notifyResponseReceived(){

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
@@ -1,12 +1,14 @@
 package com.smartdevicelink.test.transport;
 
-import junit.framework.TestCase;
 import android.os.Handler;
 import android.os.Message;
 
 import com.smartdevicelink.transport.MultiplexBluetoothTransport;
 import com.smartdevicelink.transport.SdlRouterService;
 
+import junit.framework.TestCase;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
 
 
 public class MultiplexBluetoothTransportTest extends TestCase {
@@ -17,41 +19,49 @@ public class MultiplexBluetoothTransportTest extends TestCase {
 	boolean didCorrectThing = false, isWaitingForResponse = false;
 	
 	//Example handler
-	Handler stateChangeHandler = new Handler(){
-		int stateDesired = MultiplexBluetoothTransport.STATE_LISTEN;
-		@Override
-		public void handleMessage(Message msg) {
-			if(!isWaitingForResponse){
-				return;
-			}
-			switch(msg.what){
-				case SdlRouterService.MESSAGE_STATE_CHANGE:
-					if(msg.arg1 == stateDesired){
-							didCorrectThing = true;
-							break;
-					}
-					default:
-						didCorrectThing = false;
-			}
-			REQUEST_LOCK.notify();
-		}
-		
-	};
+	Handler stateChangeHandler;
 	
 	public void testStateTransitions() {
-		//TODO test for more than the two states
-		bluetooth = MultiplexBluetoothTransport.getBluetoothSerialServerInstance();
-		assertNull(bluetooth);
 
-		bluetooth = MultiplexBluetoothTransport.getBluetoothSerialServerInstance(stateChangeHandler);
-		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
-		
-		bluetooth.start();
-		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_LISTEN);
-		
-		bluetooth.stop();
-		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
+		getInstrumentation().runOnMainSync(new Runnable() {
+			@Override
+			public void run() {
 
+				stateChangeHandler = new Handler(){
+					int stateDesired = MultiplexBluetoothTransport.STATE_LISTEN;
+					@Override
+					public void handleMessage(Message msg) {
+						if(!isWaitingForResponse){
+							return;
+						}
+						switch(msg.what){
+							case SdlRouterService.MESSAGE_STATE_CHANGE:
+								if(msg.arg1 == stateDesired){
+									didCorrectThing = true;
+									break;
+								}
+							default:
+								didCorrectThing = false;
+						}
+						REQUEST_LOCK.notify();
+					}
+
+				};
+
+				//TODO test for more than the two states
+				bluetooth = MultiplexBluetoothTransport.getBluetoothSerialServerInstance();
+				assertNull(bluetooth);
+
+				bluetooth = MultiplexBluetoothTransport.getBluetoothSerialServerInstance(stateChangeHandler);
+				assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
+
+				//TODO test changing to a different state without having Bluetooth permissions
+
+				bluetooth.stop();
+				assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
+
+			}
+		});
 	}
 	
 	private void notifyResponseReceived(){


### PR DESCRIPTION
- Was previously failing due to need to call Looper.prepare()
- The start() call and subsequent check for changed state failed because the BT adapter is not enabled, there are no bluetooth permissions in this library (TODO: find a way to test around that)