### PR TITLE
bugfix/utest_SdlDataTypeConverterTests

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/SdlDataTypeConverterTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/SdlDataTypeConverterTests.java
@@ -36,11 +36,11 @@ public class SdlDataTypeConverterTests extends TestCase {
 		// Valid Tests		
 		assertEquals(Test.MATCH, expectedValue, actualDoubleValue);
 		assertEquals(Test.MATCH, expectedValue, actualIntegerValue);
+		assertEquals(Test.MATCH, expectedValue, actualFloatValue);
 		
 		// Null Tests
 		assertNull(Test.NULL, actualNullValue);
 		assertNull(Test.NULL, actualLongValue);
 		assertNull(Test.NULL, actualShortValue);
-		assertNull(Test.NULL, actualFloatValue);
 	}
 }


### PR DESCRIPTION
- it was testing for a null float value even though the SdlDataTypeConverter has a float to double line in there.
- added in a valid test case