### PR TITLE
Fixing the failing unit tests in Emulator

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/SdlConnection/SdlConnectionTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/SdlConnection/SdlConnectionTest.java
@@ -3,6 +3,7 @@ package com.smartdevicelink.SdlConnection;
 import android.test.AndroidTestCase;
 
 import com.smartdevicelink.test.SdlUnitTestContants;
+import com.smartdevicelink.test.util.DeviceUtil;
 import com.smartdevicelink.transport.BTTransportConfig;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
@@ -46,9 +47,10 @@ public class SdlConnectionTest extends AndroidTestCase {
 
 		SdlConnectionTestClass.cachedMultiConfig.setSecurityLevel(MultiplexTransportConfig.FLAG_MULTI_SECURITY_OFF);
 		
-		assertNotNull(SdlConnectionTestClass.cachedMultiConfig.getService());
-
-		assertEquals(TransportType.MULTIPLEX, connection.getCurrentTransportType());
+		if(!DeviceUtil.isEmulator()) { // Cannot perform MBT operations in emulator
+			assertNotNull(SdlConnectionTestClass.cachedMultiConfig.getService());
+			assertEquals(TransportType.MULTIPLEX, connection.getCurrentTransportType());
+		}
 		
 		// Test for handling of null service
 		MultiplexTransportConfig null_service_config = new MultiplexTransportConfig(this.mContext,SdlUnitTestContants.TEST_APP_ID);
@@ -70,7 +72,11 @@ public class SdlConnectionTest extends AndroidTestCase {
 		rsvp.setFlags(RouterServiceValidator.FLAG_DEBUG_NONE);
 		MultiplexTransportConfig config = new MultiplexTransportConfig(this.mContext,SdlUnitTestContants.TEST_APP_ID);
 		SdlConnection connection = new SdlConnection(config,rsvp);
-		assertEquals(TransportType.MULTIPLEX, connection.getCurrentTransportType());
+		if(DeviceUtil.isEmulator()){ // Cannot perform MBT operations in emulator
+			assertEquals(TransportType.BLUETOOTH, connection.getCurrentTransportType());
+		}else{
+			assertEquals(TransportType.MULTIPLEX, connection.getCurrentTransportType());
+		}
 	}
 	
 	public void testMultiplexConstructorInsalledFrom(){

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/AbstractPacketizerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/AbstractPacketizerTests.java
@@ -46,7 +46,7 @@ public class AbstractPacketizerTests extends TestCase {
 		
 		try {
 			
-			URL url = new URL("ftp://mirror.csclub.uwaterloo.ca/index.html");
+			URL url = new URL("https://github.com/smartdevicelink/sdl_android");
 		    URLConnection urlConnection = url.openConnection();
 			testInputStream = new BufferedInputStream(urlConnection.getInputStream());
 			
@@ -90,6 +90,7 @@ public class AbstractPacketizerTests extends TestCase {
 			assertNull(Test.NULL, testPacketizer2.getSessionType());
 			
 		} catch (IOException e) {
+			e.printStackTrace();
 			fail("IOException was thrown.");
 		}
 	}

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/StreamPacketizerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/StreamPacketizerTests.java
@@ -40,7 +40,7 @@ public class StreamPacketizerTests extends TestCase {
 		SdlSession testSdlSession = SdlSession.createSession(testWiproVersion,_interfaceBroker, _transportConfig);
 		
 		try {			
-			URL url = new URL("ftp://mirror.csclub.uwaterloo.ca/index.html");
+			URL url = new URL("https://github.com/smartdevicelink/sdl_android");
 		    URLConnection urlConnection = url.openConnection();
 			testInputStream = new BufferedInputStream(urlConnection.getInputStream());
 			

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/StreamRPCPacketizerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/StreamRPCPacketizerTests.java
@@ -43,7 +43,7 @@ public class StreamRPCPacketizerTests extends TestCase {
 		SdlSession testSdlSession = SdlSession.createSession(testWiproVersion,_interfaceBroker, _transportConfig);
 
 		try {			
-			URL url = new URL("ftp://mirror.csclub.uwaterloo.ca/index.html");
+			URL url = new URL("https://github.com/smartdevicelink/sdl_android");
 		    URLConnection urlConnection = url.openConnection();
 			testInputStream = new BufferedInputStream(urlConnection.getInputStream());
 			

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
@@ -4,6 +4,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 
+import com.smartdevicelink.test.util.DeviceUtil;
 import com.smartdevicelink.transport.MultiplexBluetoothTransport;
 import com.smartdevicelink.transport.SdlRouterService;
 
@@ -54,7 +55,11 @@ public class MultiplexBluetoothTransportTest extends TestCase {
 		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
 
 		bluetooth.start();
-		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_LISTEN);
+		if(DeviceUtil.isEmulator()){
+			assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
+		}else{
+			assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_LISTEN);
+		}
 
 		bluetooth.stop();
 		assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/DeviceUtil.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/DeviceUtil.java
@@ -1,0 +1,14 @@
+package com.smartdevicelink.test.util;
+
+import android.os.Build;
+
+public class DeviceUtil {
+    public static boolean isEmulator() {
+        return Build.FINGERPRINT.startsWith("generic")
+                || Build.FINGERPRINT.startsWith("unknown")
+                || Build.MODEL.contains("google_sdk")
+                || Build.MODEL.contains("Emulator")
+                || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
+                || "google_sdk".equals(Build.PRODUCT);
+    }
+}

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/TransportBrokerTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/TransportBrokerTest.java
@@ -8,6 +8,7 @@ import android.os.Messenger;
 import android.test.AndroidTestCase;
 
 import com.smartdevicelink.test.SdlUnitTestContants;
+import com.smartdevicelink.test.util.DeviceUtil;
 
 public class TransportBrokerTest extends AndroidTestCase {
 	RouterServiceValidator rsvp;
@@ -32,7 +33,9 @@ public class TransportBrokerTest extends AndroidTestCase {
 			Looper.prepare();
 		}
 		TransportBroker broker = new TransportBroker(mContext, SdlUnitTestContants.TEST_APP_ID,rsvp.getService());
-		assertTrue(broker.start());
+		if(!DeviceUtil.isEmulator()){ // Cannot perform MBT operations in emulator
+			assertTrue(broker.start());
+		}
 		broker.stop();
 
 	}
@@ -44,17 +47,23 @@ public class TransportBrokerTest extends AndroidTestCase {
 
 		TransportBroker broker = new TransportBroker(mContext, SdlUnitTestContants.TEST_APP_ID,rsvp.getService());
 
-		assertTrue(broker.start());
+		if(!DeviceUtil.isEmulator()){ // Cannot perform MBT operations in emulator
+			assertTrue(broker.start());
+		}
 		BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
-		assertNotNull(adapter);
-		assertTrue(adapter.isEnabled());
+		if(!DeviceUtil.isEmulator()){ // Cannot perform BT adapter operations in emulator
+			assertNotNull(adapter);
+			assertTrue(adapter.isEnabled());
+		}
 		//Not ideal, but not implementing callbacks just for unit tests
 		int count = 0;
 		while(broker.routerServiceMessenger == null && count<10){
 			sleep();
 			count++;
 		}
-		assertNotNull(broker.routerServiceMessenger);
+		if(!DeviceUtil.isEmulator()){ // Cannot perform BT adapter operations in emulator
+			assertNotNull(broker.routerServiceMessenger);
+		}
 
 		//assertFalse(broker.sendPacketToRouterService(null, 0, 0));
 		//assertFalse(broker.sendPacketToRouterService(new byte[3], -1, 0));
@@ -70,7 +79,9 @@ public class TransportBrokerTest extends AndroidTestCase {
 			Looper.prepare();
 		}
 		TransportBroker broker = new TransportBroker(mContext, SdlUnitTestContants.TEST_APP_ID, rsvp.getService());
-		assertTrue(broker.start());
+		if(!DeviceUtil.isEmulator()){ // Cannot perform MBT operations in emulator
+			assertTrue(broker.start());
+		}
 
 	}
 	


### PR DESCRIPTION
Adds a DeviceUtil class with isEmulator() function to detect if running in emulator. Aspects like MultiplexBT and BT adapter checks will account for if an emulator is running the test. Changed FTP url in Packetizer tests that was failing in emulator.