### PR TITLE
Bugfix/issue 465

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/MultiplexTransportTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/MultiplexTransportTest.java
@@ -6,6 +6,8 @@ import com.smartdevicelink.transport.enums.TransportType;
 
 import android.test.AndroidTestCase;
 
+import junit.framework.Assert;
+
 public class MultiplexTransportTest extends AndroidTestCase {
 
 	private static final int TIMEOUT = 2000;
@@ -69,8 +71,14 @@ public class MultiplexTransportTest extends AndroidTestCase {
 		
 		trans = new MultiplexTransport(config,transportListener);
 		assertTrue(trans.brokerThread.isAlive());
-		
-		
-		
+
+		// Send a null config object in the constructor and expect an IllegalArgumentException
+		try {
+			trans = new MultiplexTransport(null, transportListener);
+		} catch (IllegalArgumentException e) {
+			assertEquals("Null transportConfig in MultiplexTransport constructor", e.getMessage());
+		} catch (NullPointerException e) {
+			Assert.fail("NPE in MultiplexTransport constructor");
+		}
 	}
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTransport.java
@@ -24,6 +24,7 @@ public class MultiplexTransport extends SdlTransport{
 		super(transportListener);
 		if(transportConfig == null){
 			this.handleTransportError("Transport config was null", null);
+			throw new IllegalArgumentException("Null transportConfig in MultiplexTransport constructor");
 		}
 		this.transportConfig = transportConfig;
 		brokerThread = new TransportBrokerThread(transportConfig.context, transportConfig.appId, transportConfig.service);


### PR DESCRIPTION
Fix issue [#465](https://github.com/smartdevicelink/sdl_android/issues/465)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Construct a MultiplexTransport object with a null MultiplexTransportConfig and test if the null value is handled properly. 
New unit test passed.

### Summary
Catch and handle a potential null MultiplexTransportConfig object when constructing a MultiplexTransport.