### PR TITLE
Bugfix/issue 464

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
@@ -1,0 +1,85 @@
+package com.smartdevicelink.transport;
+
+
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import android.test.AndroidTestCase;
+import android.util.Log;
+
+import com.smartdevicelink.protocol.SdlPacket;
+
+import junit.framework.Assert;
+
+import java.lang.ref.WeakReference;
+
+public class SdlRouterServiceTests extends AndroidTestCase {
+
+    public static final String TAG = "SdlRouterServiceTests";
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        //Nothing here for now
+    }
+
+    /**
+     * Test null bundle handling in AltTransportHandler when handling messages. Only test the case of
+     * msg.what == TransportConstants.ROUTER_RECEIVED_PACKET
+     */
+    public void testAlTransportHandlerHandleNullBundle() {
+        Looper.prepare();
+        class AltTransportHandler extends Handler {
+            ClassLoader loader;
+            final WeakReference<SdlRouterService> provider;
+
+            public AltTransportHandler(SdlRouterService provider) {
+                this.provider = new WeakReference<SdlRouterService>(provider);
+                loader = getClass().getClassLoader();
+            }
+
+            @Override
+            public void handleMessage(Message msg) {
+                SdlRouterService service = this.provider.get();
+                Bundle receivedBundle = msg.getData();
+                switch (msg.what) {
+                    case TransportConstants.ROUTER_RECEIVED_PACKET:
+                        if (receivedBundle != null) {
+                            receivedBundle.setClassLoader(loader);//We do this because loading a custom parceable object isn't possible without it
+                            if (receivedBundle.containsKey(TransportConstants.FORMED_PACKET_EXTRA_NAME)) {
+                                SdlPacket packet = receivedBundle.getParcelable(TransportConstants.FORMED_PACKET_EXTRA_NAME);
+                                if (packet != null && service != null) {
+                                    service.onPacketRead(packet);
+                                } else {
+                                    Log.w(TAG, "Received null packet from alt transport service");
+                                }
+                            } else {
+                                Log.w(TAG, "Flase positive packet reception");
+                            }
+                        } else {
+                            Log.e(TAG, "Bundle was null while sending packet to router service from alt transport");
+                        }
+                        break;
+                    default:
+                        super.handleMessage(msg);
+                }
+
+            }
+        }
+        AltTransportHandler testHandler = new AltTransportHandler(null);
+        Message msg = Message.obtain(null, TransportConstants.ROUTER_RECEIVED_PACKET);
+        //Send a null bundle
+        msg.setData(null);
+        try {
+            testHandler.handleMessage(msg);
+        } catch (Exception e) {
+            Assert.fail("Exception in testAlTransportHandlerHandleNullBundle, " + e);
+        }
+    }
+}

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
@@ -34,7 +34,9 @@ public class SdlRouterServiceTests extends AndroidTestCase {
      * msg.what == TransportConstants.ROUTER_RECEIVED_PACKET
      */
     public void testAlTransportHandlerHandleNullBundle() {
-        Looper.prepare();
+        if (Looper.myLooper() == null) {
+            Looper.prepare();
+        }
         class AltTransportHandler extends Handler {
             ClassLoader loader;
             final WeakReference<SdlRouterService> provider;

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -609,19 +609,19 @@ public class SdlRouterService extends Service{
 	        	case TransportConstants.ROUTER_RECEIVED_PACKET:
 	        		if(receivedBundle!=null){
 	        			receivedBundle.setClassLoader(loader);//We do this because loading a custom parceable object isn't possible without it
+						if(receivedBundle.containsKey(TransportConstants.FORMED_PACKET_EXTRA_NAME)){
+							SdlPacket packet = receivedBundle.getParcelable(TransportConstants.FORMED_PACKET_EXTRA_NAME);
+							if(packet!=null){
+								service.onPacketRead(packet);
+							}else{
+								Log.w(TAG, "Received null packet from alt transport service");
+							}
+						}else{
+							Log.w(TAG, "Flase positive packet reception");
+						}
 	            	}else{
 	            		Log.e(TAG, "Bundle was null while sending packet to router service from alt transport");
 	            	}
-            		if(receivedBundle.containsKey(TransportConstants.FORMED_PACKET_EXTRA_NAME)){
-            			SdlPacket packet = receivedBundle.getParcelable(TransportConstants.FORMED_PACKET_EXTRA_NAME);
-    					if(packet!=null){
-    						service.onPacketRead(packet);
-    					}else{
-    						Log.w(TAG, "Received null packet from alt transport service");
-    					}
-            		}else{
-            			Log.w(TAG, "Flase positive packet reception");
-            		}
             		break; 
 	        	default:
 	        		super.handleMessage(msg);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -609,20 +609,20 @@ public class SdlRouterService extends Service{
 	        	case TransportConstants.ROUTER_RECEIVED_PACKET:
 	        		if(receivedBundle!=null){
 	        			receivedBundle.setClassLoader(loader);//We do this because loading a custom parceable object isn't possible without it
-						if(receivedBundle.containsKey(TransportConstants.FORMED_PACKET_EXTRA_NAME)){
-							SdlPacket packet = receivedBundle.getParcelable(TransportConstants.FORMED_PACKET_EXTRA_NAME);
-							if(packet!=null){
-								service.onPacketRead(packet);
-							}else{
-								Log.w(TAG, "Received null packet from alt transport service");
-							}
+					if(receivedBundle.containsKey(TransportConstants.FORMED_PACKET_EXTRA_NAME)){
+						SdlPacket packet = receivedBundle.getParcelable(TransportConstants.FORMED_PACKET_EXTRA_NAME);
+						if(packet!=null){
+							service.onPacketRead(packet);
 						}else{
-							Log.w(TAG, "Flase positive packet reception");
+							Log.w(TAG, "Received null packet from alt transport service");
 						}
-	            	}else{
-	            		Log.e(TAG, "Bundle was null while sending packet to router service from alt transport");
-	            	}
-            		break; 
+					}else{
+						Log.w(TAG, "Flase positive packet reception");
+					}
+	            		}else{
+	            			Log.e(TAG, "Bundle was null while sending packet to router service from alt transport");
+	            		}
+            			break; 
 	        	default:
 	        		super.handleMessage(msg);
 	        	}


### PR DESCRIPTION
Fix issue [#464](https://github.com/smartdevicelink/sdl_android/issues/464)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Create a Message object with null data, feed the message into the handler and test if handleMessage method can handle null.
New unit test passed.

### Summary
We will attempt to handle message data being null and prevent a npe crash here.
