### PR TITLE
hotfix/Remove android:debuggable=“true” from Manifest

### DIFF
--- a/sdl_android/src/main/AndroidManifest.xml
+++ b/sdl_android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
 <manifest package="com.smartdevicelink" xmlns:android="http://schemas.android.com/apk/res/android">
 	<uses-sdk android:minSdkVersion="8"/>
-    <application android:debuggable="true"/>
 </manifest>


### PR DESCRIPTION
This is causing build issues for developers so we have to issue a hotfix. See #540 and #546 