### PR TITLE
Resend PR about enhance video streaming performance

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlSession.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlSession.java
@@ -1,14 +1,5 @@
 package com.smartdevicelink.SdlConnection;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import android.annotation.SuppressLint;
 import android.os.Build;
 import android.util.Log;
@@ -25,11 +16,20 @@ import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.security.ISecurityInitializedListener;
 import com.smartdevicelink.security.SdlSecurityBase;
 import com.smartdevicelink.streaming.IStreamListener;
+import com.smartdevicelink.streaming.SdlPipedInputStream;
+import com.smartdevicelink.streaming.SdlPipedOutputStream;
 import com.smartdevicelink.streaming.StreamPacketizer;
 import com.smartdevicelink.streaming.StreamRPCPacketizer;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.MultiplexTransport;
 import com.smartdevicelink.transport.enums.TransportType;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class SdlSession implements ISdlConnectionListener, IHeartbeatMonitorListener, IStreamListener, ISecurityInitializedListener {
 	private static CopyOnWriteArrayList<SdlConnection> shareConnections = new CopyOnWriteArrayList<SdlConnection>();
@@ -148,12 +148,12 @@ public class SdlSession implements ISdlConnectionListener, IHeartbeatMonitorList
 
 	@SuppressLint("NewApi")
 	public OutputStream startStream(SessionType sType, byte rpcSessionID) throws IOException {
-		OutputStream os = new PipedOutputStream();
+		OutputStream os = new SdlPipedOutputStream();
 		InputStream is = null;
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
-			is = new PipedInputStream((PipedOutputStream) os, BUFF_READ_SIZE);
+			is = new SdlPipedInputStream((SdlPipedOutputStream) os, BUFF_READ_SIZE);
 		} else {
-			is = new PipedInputStream((PipedOutputStream) os);
+			is = new SdlPipedInputStream((SdlPipedOutputStream) os);
 		}
         if (sType.equals(SessionType.NAV))
         {
@@ -187,8 +187,8 @@ public class SdlSession implements ISdlConnectionListener, IHeartbeatMonitorList
 
 	public OutputStream startRPCStream(RPCRequest request, SessionType sType, byte rpcSessionID, byte wiproVersion) {
 		try {
-			OutputStream os = new PipedOutputStream();
-	        InputStream is = new PipedInputStream((PipedOutputStream) os);
+			OutputStream os = new SdlPipedOutputStream();
+	        InputStream is = new SdlPipedInputStream((SdlPipedOutputStream) os);
 			mRPCPacketizer = new StreamRPCPacketizer(null, this, is, request, sType, rpcSessionID, wiproVersion, 0, this);
 			mRPCPacketizer.start();
 			return os;
@@ -285,7 +285,7 @@ public class SdlSession implements ISdlConnectionListener, IHeartbeatMonitorList
 	public Surface createOpenGLInputSurface(int frameRate, int iFrameInterval, int width,
 			int height, int bitrate, SessionType sType, byte rpcSessionID) {
 		try {
-			PipedOutputStream stream = (PipedOutputStream) startStream(sType, rpcSessionID);
+			SdlPipedOutputStream stream = (SdlPipedOutputStream) startStream(sType, rpcSessionID);
 			if (stream == null) return null;
 			mSdlEncoder = new SdlEncoder();
 			mSdlEncoder.setFrameRate(frameRate);

--- a/sdl_android/src/main/java/com/smartdevicelink/encoder/SdlEncoder.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/encoder/SdlEncoder.java
@@ -1,15 +1,16 @@
 package com.smartdevicelink.encoder;
 
-import java.io.IOException;
-import java.io.PipedOutputStream;
-import java.nio.ByteBuffer;
-
 import android.annotation.TargetApi;
 import android.media.MediaCodec;
 import android.media.MediaCodecInfo;
 import android.media.MediaFormat;
 import android.os.Build;
 import android.view.Surface;
+
+import com.smartdevicelink.streaming.SdlPipedOutputStream;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
 
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
 public class SdlEncoder {
@@ -25,7 +26,7 @@ public class SdlEncoder {
 
 	// encoder state
 	private MediaCodec mEncoder;
-	private PipedOutputStream mOutputStream;
+	private SdlPipedOutputStream mOutputStream;
 	
 	// allocate one of these up front so we don't need to do it every time
 	private MediaCodec.BufferInfo mBufferInfo;
@@ -48,7 +49,7 @@ public class SdlEncoder {
 	public void setBitrate(int iVal){
 		bitrate = iVal;	
 	}
-	public void setOutputStream(PipedOutputStream mStream){
+	public void setOutputStream(SdlPipedOutputStream mStream){
 		mOutputStream = mStream;
 	}
 	public Surface prepareEncoder () {

--- a/sdl_android/src/main/java/com/smartdevicelink/streaming/SdlPipedInputStream.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/streaming/SdlPipedInputStream.java
@@ -1,0 +1,480 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.smartdevicelink.streaming;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+
+/**
+ * Receives information from a communications pipe. When two threads want to
+ * pass data back and forth, one creates a piped output stream and the other one
+ * creates a piped input stream.
+ *
+ * @see java.io.PipedOutputStream
+ */
+public class SdlPipedInputStream extends InputStream {
+
+    private Thread lastReader;
+
+    private Thread lastWriter;
+
+    private boolean isClosed;
+
+    /**
+     * The circular buffer through which data is passed. Data is read from the
+     * range {@code [out, in)} and written to the range {@code [in, out)}.
+     * Data in the buffer is either sequential: <pre>
+     *     { - - - X X X X X X X - - - - - }
+     *             ^             ^
+     *             |             |
+     *            out           in</pre>
+     * ...or wrapped around the buffer's end: <pre>
+     *     { X X X X - - - - - - - - X X X }
+     *               ^               ^
+     *               |               |
+     *              in              out</pre>
+     * When the buffer is empty, {@code in == -1}. Reading when the buffer is
+     * empty will block until data is available. When the buffer is full,
+     * {@code in == out}. Writing when the buffer is full will block until free
+     * space is available.
+     */
+    protected byte[] buffer;
+
+    /**
+     * The index in {@code buffer} where the next byte will be written.
+     */
+    protected int in = -1;
+
+    /**
+     * The index in {@code buffer} where the next byte will be read.
+     */
+    protected int out;
+
+    /**
+     * The size of the default pipe in bytes.
+     */
+    protected static final int PIPE_SIZE = 1024;
+
+    /**
+     * Indicates if this pipe is connected.
+     */
+    boolean isConnected;
+
+    /**
+     * Constructs a new unconnected {@code SdlPipedInputStream}. The resulting
+     * stream must be connected to a {@link java.io.PipedOutputStream} before data may
+     * be read from it.
+     */
+    public SdlPipedInputStream() {}
+
+    /**
+     * Constructs a new {@code SdlPipedInputStream} connected to the
+     * {@link java.io.PipedOutputStream} {@code out}. Any data written to the output
+     * stream can be read from the this input stream.
+     *
+     * @param out
+     *            the piped output stream to connect to.
+     * @throws IOException
+     *             if this stream or {@code out} are already connected.
+     */
+    public SdlPipedInputStream(SdlPipedOutputStream out) throws IOException {
+        connect(out);
+    }
+
+    /**
+     * Constructs a new unconnected {@code SdlPipedInputStream} with the given
+     * buffer size. The resulting stream must be connected to a
+     * {@code SdlPipedOutputStream} before data may be read from it.
+     *
+     * @param pipeSize the size of the buffer in bytes.
+     * @throws IllegalArgumentException if pipeSize is less than or equal to zero.
+     * @since 1.6
+     */
+    public SdlPipedInputStream(int pipeSize) {
+        if (pipeSize <= 0) {
+            throw new IllegalArgumentException("pipe size " + pipeSize + " too small");
+        }
+        buffer = new byte[pipeSize];
+    }
+
+    /**
+     * Constructs a new {@code SdlPipedInputStream} connected to the given {@code SdlPipedOutputStream},
+     * with the given buffer size. Any data written to the output stream can be read from this
+     * input stream.
+     *
+     * @param out the {@code SdlPipedOutputStream} to connect to.
+     * @param pipeSize the size of the buffer in bytes.
+     * @throws IOException if an I/O error occurs.
+     * @throws IllegalArgumentException if pipeSize is less than or equal to zero.
+     * @since 1.6
+     */
+    public SdlPipedInputStream(SdlPipedOutputStream out, int pipeSize) throws IOException {
+        this(pipeSize);
+        connect(out);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Unlike most streams, {@code SdlPipedInputStream} returns 0 rather than throwing
+     * {@code IOException} if the stream has been closed. Unconnected and broken pipes also
+     * return 0.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public synchronized int available() throws IOException {
+        if (buffer == null || in == -1) {
+            return 0;
+        }
+        return in <= out ? buffer.length - out + in : in - out;
+    }
+
+    /**
+     * Closes this stream. This implementation releases the buffer used for the
+     * pipe and notifies all threads waiting to read or write.
+     *
+     * @throws IOException
+     *             if an error occurs while closing this stream.
+     */
+    @Override
+    public synchronized void close() throws IOException {
+        buffer = null;
+        notifyAll();
+    }
+
+    /**
+     * Connects this {@code SdlPipedInputStream} to a {@link java.io.PipedOutputStream}.
+     * Any data written to the output stream becomes readable in this input
+     * stream.
+     *
+     * @param src
+     *            the source output stream.
+     * @throws IOException
+     *             if either stream is already connected.
+     */
+    public void connect(SdlPipedOutputStream src) throws IOException {
+        src.connect(this);
+    }
+
+    /**
+     * Establishes the connection to the SdlPipedOutputStream.
+     *
+     * @throws IOException
+     *             If this Reader is already connected.
+     */
+    synchronized void establishConnection() throws IOException {
+        if (isConnected) {
+            throw new IOException("Pipe already connected");
+        }
+        if (buffer == null) { // We may already have allocated the buffer.
+            buffer = new byte[SdlPipedInputStream.PIPE_SIZE];
+        }
+        isConnected = true;
+    }
+
+    /**
+     * Reads a single byte from this stream and returns it as an integer in the
+     * range from 0 to 255. Returns -1 if the end of this stream has been
+     * reached. If there is no data in the pipe, this method blocks until data
+     * is available, the end of the stream is detected or an exception is
+     * thrown.
+     * <p>
+     * Separate threads should be used to read from a {@code SdlPipedInputStream}
+     * and to write to the connected {@link java.io.PipedOutputStream}. If the same
+     * thread is used, a deadlock may occur.
+     *
+     * @return the byte read or -1 if the end of the source stream has been
+     *         reached.
+     * @throws IOException
+     *             if this stream is closed or not connected to an output
+     *             stream, or if the thread writing to the connected output
+     *             stream is no longer alive.
+     */
+    @Override
+    public synchronized int read() throws IOException {
+        if (!isConnected) {
+            throw new IOException("Not connected");
+        }
+        if (buffer == null) {
+            throw new IOException("InputStream is closed");
+        }
+
+        /**
+         * Set the last thread to be reading on this SdlPipedInputStream. If
+         * lastReader dies while someone is waiting to write an IOException of
+         * "Pipe broken" will be thrown in receive()
+         */
+        lastReader = Thread.currentThread();
+        try {
+            int attempts = 3;
+            while (in == -1) {
+                // Are we at end of stream?
+                if (isClosed) {
+                    return -1;
+                }
+                if ((attempts-- <= 0) && lastWriter != null && !lastWriter.isAlive()) {
+                    throw new IOException("Pipe broken");
+                }
+                // Notify callers of receive()
+                notifyAll();
+                wait(1000);
+            }
+        } catch (InterruptedException e) {
+            throw new InterruptedIOException();
+        }
+
+        int result = buffer[out++] & 0xff;
+        if (out == buffer.length) {
+            out = 0;
+        }
+        if (out == in) {
+            // empty buffer
+            in = -1;
+            out = 0;
+        }
+
+        // let blocked writers write to the newly available buffer space
+        notifyAll();
+
+        return result;
+    }
+
+    /**
+     * Reads at most {@code byteCount} bytes from this stream and stores them in the
+     * byte array {@code bytes} starting at {@code offset}. Blocks until at
+     * least one byte has been read, the end of the stream is detected or an
+     * exception is thrown.
+     * <p>
+     * Separate threads should be used to read from a {@code SdlPipedInputStream}
+     * and to write to the connected {@link java.io.PipedOutputStream}. If the same
+     * thread is used, a deadlock may occur.
+     *
+     * @return the number of bytes actually read or -1 if the end of the stream
+     *         has been reached.
+     * @throws IndexOutOfBoundsException
+     *             if {@code offset < 0} or {@code byteCount < 0}, or if {@code
+     *             offset + byteCount} is greater than the size of {@code bytes}.
+     * @throws InterruptedIOException
+     *             if the thread reading from this stream is interrupted.
+     * @throws IOException
+     *             if this stream is closed or not connected to an output
+     *             stream, or if the thread writing to the connected output
+     *             stream is no longer alive.
+     * @throws NullPointerException
+     *             if {@code bytes} is {@code null}.
+     */
+    @Override
+    public synchronized int read(byte[] bytes, int offset, int byteCount) throws IOException {
+        if (bytes == null) {
+            throw new NullPointerException();
+        }else if ((offset < 0) || (byteCount < 0) || (byteCount > bytes.length - offset)) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        if (byteCount == 0) {
+            return 0;
+        }
+
+        if (!isConnected) {
+            throw new IOException("Not connected");
+        }
+
+        if (buffer == null) {
+            throw new IOException("InputStream is closed");
+        }
+
+        /*
+         * Set the last thread to be reading on this SdlPipedInputStream. If
+         * lastReader dies while someone is waiting to write an IOException of
+         * "Pipe broken" will be thrown in receive()
+         */
+        lastReader = Thread.currentThread();
+        try {
+            int attempts = 3;
+            while (in == -1) {
+                // Are we at end of stream?
+                if (isClosed) {
+                    return -1;
+                }
+                if ((attempts-- <= 0) && lastWriter != null && !lastWriter.isAlive()) {
+                    throw new IOException("Pipe broken");
+                }
+                // Notify callers of receive()
+                notifyAll();
+                wait(1000);
+            }
+        } catch (InterruptedException e) {
+            throw new InterruptedIOException();
+        }
+
+        int totalCopied = 0;
+
+        // copy bytes from out thru the end of buffer
+        if (out >= in) {
+            int leftInBuffer = buffer.length - out;
+            int length = leftInBuffer < byteCount ? leftInBuffer : byteCount;
+            System.arraycopy(buffer, out, bytes, offset, length);
+            out += length;
+            if (out == buffer.length) {
+                out = 0;
+            }
+            if (out == in) {
+                // empty buffer
+                in = -1;
+                out = 0;
+            }
+            totalCopied += length;
+        }
+
+        // copy bytes from out thru in
+        if (totalCopied < byteCount && in != -1) {
+            int leftInBuffer = in - out;
+            int leftToCopy = byteCount - totalCopied;
+            int length = leftToCopy < leftInBuffer ? leftToCopy : leftInBuffer;
+            System.arraycopy(buffer, out, bytes, offset + totalCopied, length);
+            out += length;
+            if (out == in) {
+                // empty buffer
+                in = -1;
+                out = 0;
+            }
+            totalCopied += length;
+        }
+
+        // let blocked writers write to the newly available buffer space
+        notifyAll();
+
+        return totalCopied;
+    }
+
+    /**
+     * Receives a byte and stores it in this stream's {@code buffer}. This
+     * method is called by {@link java.io.PipedOutputStream#write(int)}. The least
+     * significant byte of the integer {@code oneByte} is stored at index
+     * {@code in} in the {@code buffer}.
+     * <p>
+     * This method blocks as long as {@code buffer} is full.
+     *
+     * @param oneByte
+     *            the byte to store in this pipe.
+     * @throws InterruptedIOException
+     *             if the {@code buffer} is full and the thread that has called
+     *             this method is interrupted.
+     * @throws IOException
+     *             if this stream is closed or the thread that has last read
+     *             from this stream is no longer alive.
+     */
+    protected synchronized void receive(int oneByte) throws IOException {
+        if (buffer == null || isClosed) {
+            throw new IOException("Pipe is closed");
+        }
+
+        /*
+         * Set the last thread to be writing on this SdlPipedInputStream. If
+         * lastWriter dies while someone is waiting to read an IOException of
+         * "Pipe broken" will be thrown in read()
+         */
+        lastWriter = Thread.currentThread();
+        try {
+            while (buffer != null && out == in) {
+                if (lastReader != null && !lastReader.isAlive()) {
+                    throw new IOException("Pipe broken");
+                }
+                notifyAll();
+                wait(1000);
+            }
+        } catch (InterruptedException e) {
+            throw new InterruptedIOException();
+        }
+        if (buffer == null) {
+            throw new IOException("Pipe is closed");
+        }
+        if (in == -1) {
+            in = 0;
+        }
+        buffer[in++] = (byte) oneByte;
+        if (in == buffer.length) {
+            in = 0;
+        }
+
+        // let blocked readers read the newly available data
+        notifyAll();
+    }
+
+    synchronized void done() {
+        isClosed = true;
+        notifyAll();
+    }
+
+    /**
+     * Receives an array of bytes
+     * @param bytes data
+     * @param byteOffset offset of the data
+     * @param byteCount count of data
+     * @throws IOException
+     */
+    synchronized void receive(byte[] bytes, int byteOffset, int byteCount) throws IOException {
+        if (buffer == null || isClosed) {
+            throw new IOException("Pipe is closed");
+        }
+
+        lastWriter = Thread.currentThread();
+        int bytesToTransfer = byteCount;
+        while (bytesToTransfer > 0) {
+
+            while (in == out) {
+                if (buffer == null || isClosed) {
+                    throw new IOException("Pipe is closed");
+                }
+
+                notifyAll();
+                try {
+                    wait(1000);
+                } catch (InterruptedException localInterruptedException) {
+                    throw new InterruptedIOException();
+                }
+            }
+
+            int nextTransferBytes = 0;
+            if (out < in) {
+                nextTransferBytes = buffer.length - in;
+            } else if (in < out) {
+                if (in == -1) {
+                    in = out = 0;
+                    nextTransferBytes = buffer.length - in;
+                } else {
+                    nextTransferBytes = out - in;
+                }
+            }
+            if (nextTransferBytes > bytesToTransfer) {
+                nextTransferBytes = bytesToTransfer;
+            }
+            System.arraycopy(bytes, byteOffset, buffer, in, nextTransferBytes);
+            bytesToTransfer -= nextTransferBytes;
+            byteOffset += nextTransferBytes;
+            in += nextTransferBytes;
+            if (in >= buffer.length) {
+                in = 0;
+            }
+        }
+        notifyAll();
+    }
+
+}

--- a/sdl_android/src/main/java/com/smartdevicelink/streaming/SdlPipedOutputStream.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/streaming/SdlPipedOutputStream.java
@@ -1,0 +1,184 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.smartdevicelink.streaming;
+
+import java.io.*;
+
+/**
+ * Places information on a communications pipe. When two threads want to pass
+ * data back and forth, one creates a piped output stream and the other one
+ * creates a piped input stream.
+ *
+ * @see java.io.PipedInputStream
+ */
+public class SdlPipedOutputStream extends OutputStream {
+
+    /**
+     * The destination SdlPipedInputStream
+     */
+    private SdlPipedInputStream target;
+
+    /**
+     * Constructs a new unconnected {@code SdlPipedOutputStream}. The resulting
+     * stream must be connected to a {@link java.io.PipedInputStream} before data can be
+     * written to it.
+     */
+    public SdlPipedOutputStream() {
+    }
+
+    /**
+     * Constructs a new {@code SdlPipedOutputStream} connected to the
+     * {@link java.io.PipedInputStream} {@code target}. Any data written to this stream
+     * can be read from the target stream.
+     *
+     * @param target
+     *            the piped input stream to connect to.
+     * @throws IOException
+     *             if this stream or {@code target} are already connected.
+     */
+    public SdlPipedOutputStream(SdlPipedInputStream target) throws IOException {
+        connect(target);
+    }
+
+    /**
+     * Closes this stream. If this stream is connected to an input stream, the
+     * input stream is closed and the pipe is disconnected.
+     *
+     * @throws IOException
+     *             if an error occurs while closing this stream.
+     */
+    @Override
+    public void close() throws IOException {
+        // Is the pipe connected?
+        SdlPipedInputStream stream = target;
+        if (stream != null) {
+            stream.done();
+            target = null;
+        }
+    }
+
+    /**
+     * Connects this stream to a {@link java.io.PipedInputStream}. Any data written to
+     * this output stream becomes readable in the input stream.
+     *
+     * @param stream
+     *            the piped input stream to connect to.
+     * @throws IOException
+     *             if either stream is already connected.
+     */
+    public void connect(SdlPipedInputStream stream) throws IOException {
+        if (stream == null) {
+            throw new NullPointerException("stream == null");
+        }
+        synchronized (stream) {
+            if (this.target != null) {
+                throw new IOException("Already connected");
+            }
+            if (stream.isConnected) {
+                throw new IOException("Pipe already connected");
+            }
+            stream.establishConnection();
+            this.target = stream;
+        }
+    }
+
+    /**
+     * Notifies the readers of this {@link java.io.PipedInputStream} that bytes can be
+     * read. This method does nothing if this stream is not connected.
+     *
+     * @throws IOException
+     *             if an I/O error occurs while flushing this stream.
+     */
+    @Override
+    public void flush() throws IOException {
+        SdlPipedInputStream stream = target;
+        if (stream == null) {
+            return;
+        }
+
+        synchronized (stream) {
+            stream.notifyAll();
+        }
+    }
+
+    /**
+     * Writes {@code count} bytes from the byte array {@code buffer} starting at
+     * {@code offset} to this stream. The written data can then be read from the
+     * connected input stream.
+     * <p>
+     * Separate threads should be used to write to a {@code SdlPipedOutputStream}
+     * and to read from the connected {@link java.io.PipedInputStream}. If the same
+     * thread is used, a deadlock may occur.
+     *
+     * @param buffer
+     *            the buffer to write.
+     * @param offset
+     *            the index of the first byte in {@code buffer} to write.
+     * @param count
+     *            the number of bytes from {@code buffer} to write to this
+     *            stream.
+     * @throws IndexOutOfBoundsException
+     *             if {@code offset < 0} or {@code count < 0}, or if {@code
+     *             offset + count} is bigger than the length of {@code buffer}.
+     * @throws InterruptedIOException
+     *             if the pipe is full and the current thread is interrupted
+     *             waiting for space to write data. This case is not currently
+     *             handled correctly.
+     * @throws IOException
+     *             if this stream is not connected, if the target stream is
+     *             closed or if the thread reading from the target stream is no
+     *             longer alive. This case is currently not handled correctly.
+     */
+    @Override
+    public void write(byte[] buffer, int offset, int count) throws IOException {
+        SdlPipedInputStream stream = target;
+        if (stream == null) {
+            throw new IOException("Pipe not connected");
+        }
+        stream.receive(buffer, offset, count);
+    }
+
+    /**
+     * Writes a single byte to this stream. Only the least significant byte of
+     * the integer {@code oneByte} is written. The written byte can then be read
+     * from the connected input stream.
+     * <p>
+     * Separate threads should be used to write to a {@code SdlPipedOutputStream}
+     * and to read from the connected {@link java.io.PipedInputStream}. If the same
+     * thread is used, a deadlock may occur.
+     *
+     * @param oneByte
+     *            the byte to write.
+     * @throws InterruptedIOException
+     *             if the pipe is full and the current thread is interrupted
+     *             waiting for space to write data. This case is not currently
+     *             handled correctly.
+     * @throws IOException
+     *             if this stream is not connected, if the target stream is
+     *             closed or if the thread reading from the target stream is no
+     *             longer alive. This case is currently not handled correctly.
+     */
+    @Override
+    public void write(int oneByte) throws IOException {
+        SdlPipedInputStream stream = target;
+        if (stream == null) {
+            throw new IOException("Pipe not connected");
+        }
+        stream.receive(oneByte);
+    }
+}


### PR DESCRIPTION
Hi @joeygrover 
Sorry resend this PR again, since we have done something and we'd like you to review again:
- Have reset the commits in #446 
- Rewrite the code in custom class `SdlPipedInputStream` and `SdlPipedOutStream` based on default sdk
- I think it's now under **Apache 2.0 license.**

**Test**:
PC: Debian 32-bit, Windows 32-bit
Phone: Android4.4(API_LEVEL 19)
Connection: USB_AOA
**Result:**
The data in test are false video stream data, aims to get the max value in transmission.

|             | Core(Windows)|
|:---------|:------:|
|Proxy (**NOT** include this PR) | 1.54MB/s  |
|Proxy (**include** this PR)         | 9.11MB/s  |

Could you please review again and give your feedback?
