### PR TITLE
Add Turbo Boost pressure to vehicle data

### DIFF
--- a/sdl_android/src/androidTest/assets/json/GetVehicleData.json
+++ b/sdl_android/src/androidTest/assets/json/GetVehicleData.json
@@ -27,7 +27,8 @@
       "airbagStatus":true,
       "emergencyEvent":false,
       "clusterModeStatus":true,
-      "myKey":true
+      "myKey":true,
+      "turboBoost":true
     }
   },
   "response":{
@@ -151,7 +152,8 @@
       },
       "myKey":{
         "e911Override":"NO_DATA_EXISTS"
-      }
+      },
+      "turboBoost":10.10
     }
   }
 }

--- a/sdl_android/src/androidTest/assets/json/SubscribeVehicleData.json
+++ b/sdl_android/src/androidTest/assets/json/SubscribeVehicleData.json
@@ -26,7 +26,8 @@
       "airbagStatus":true,
       "emergencyEvent":false,
       "clusterModeStatus":true,
-      "myKey":true
+      "myKey":true,
+      "turboBoost":true
     }
   },
   "response":{
@@ -128,6 +129,10 @@
       "myKey":{
         "dataType":"VEHICLEDATA_MYKEY",
         "resultCode":"IGNORED"
+      },
+      "turboBoost":{
+        "dataType":"VEHICLEDATA_TURBOBOOST",
+        "resultCode":"SUCCESS"
       }
     }
   }

--- a/sdl_android/src/androidTest/assets/json/UnsubscribeVehicleData.json
+++ b/sdl_android/src/androidTest/assets/json/UnsubscribeVehicleData.json
@@ -26,7 +26,8 @@
       "airbagStatus":true,
       "emergencyEvent":false,
       "clusterModeStatus":true,
-      "myKey":true
+      "myKey":true,
+      "turboBoost":true
     }
   },
   "response":{
@@ -128,6 +129,10 @@
       "myKey":{
         "dataType":"VEHICLEDATA_MYKEY",
         "resultCode":"IGNORED"
+      },
+      "turboBoost":{
+        "dataType":"VEHICLEDATA_TURBOBOOST",
+        "resultCode":"SUCCESS"
       }
     }
   }

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/VehicleDataHelper.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/VehicleDataHelper.java
@@ -62,7 +62,8 @@ public class VehicleDataHelper{
 	public static final EmergencyEvent EMERGENCY_EVENT = new EmergencyEvent();
 	public static final ClusterModeStatus CLUSTER_MODE_STATUS = new ClusterModeStatus();
 	public static final MyKey MY_KEY = new MyKey();
-	
+	public static final double TURBO_BOOST = 10.10;
+
 	//other variables inside some of the above objects
     // tire status
 	public static final WarningLightStatus 	  TIRE_PRESSURE_TELL_TALE = WarningLightStatus.ON;
@@ -318,7 +319,8 @@ public class VehicleDataHelper{
 		VEHICLE_DATA.setEmergencyEvent(EMERGENCY_EVENT);
 		VEHICLE_DATA.setClusterModeStatus(CLUSTER_MODE_STATUS);
 		VEHICLE_DATA.setMyKey(MY_KEY);
-		
+		VEHICLE_DATA.setTurboBoost(TURBO_BOOST);
+
 		//set up the GetVehicleDataResponse object
 		VEHICLE_DATA_RESPONSE.setSpeed(SPEED);
 		VEHICLE_DATA_RESPONSE.setRpm(RPM);
@@ -345,6 +347,7 @@ public class VehicleDataHelper{
 		VEHICLE_DATA_RESPONSE.setEmergencyEvent(EMERGENCY_EVENT);
 		VEHICLE_DATA_RESPONSE.setClusterModeStatus(CLUSTER_MODE_STATUS);
 		VEHICLE_DATA_RESPONSE.setMyKey(MY_KEY);
+		VEHICLE_DATA_RESPONSE.setTurboBoost(TURBO_BOOST);
 	}
 	
     private VehicleDataHelper(){}	

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCRequestFactoryTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/RPCRequestFactoryTests.java
@@ -886,12 +886,12 @@ public class RPCRequestFactoryTests extends TestCase {
 	
 	public void testBuildSubscribeVehicleData () {
 		
-		boolean testGPS = true, testSpeed = true, testRPM = true, testFuelLevel = true, testFuelLevelState = true, testInstantFuelConsumption = true, testExternalTemperature = true, testPRNDL = true, testTirePressure = true, testOdometer = true, testBeltStatus = true, testBodyInformation = true, testDeviceStatus = true, testDriverBraking = true;
+		boolean testGPS = true, testSpeed = true, testRPM = true, testFuelLevel = true, testFuelLevelState = true, testInstantFuelConsumption = true, testExternalTemperature = true, testPRNDL = true, testTirePressure = true, testOdometer = true, testBeltStatus = true, testBodyInformation = true, testDeviceStatus = true, testDriverBraking = true, testTurboBoost = true;
 		Integer testCorrelationID = 0;
 		SubscribeVehicleData testSVD;
 		
-		// Test -- BuildSubscribeVehicleData(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State, boolean instantFuelConsumption, boolean externalTemperature, boolean prndl, boolean tirePressure, boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus, boolean driverBraking, Integer correlationID) 
-		testSVD = RPCRequestFactory.BuildSubscribeVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, testCorrelationID);	
+		// Test -- BuildSubscribeVehicleData(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State, boolean instantFuelConsumption, boolean externalTemperature, boolean prndl, boolean tirePressure, boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus, boolean driverBraking, boolean turboBoost, Integer correlationID)
+		testSVD = RPCRequestFactory.BuildSubscribeVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, testTurboBoost, testCorrelationID);
 		assertTrue(Test.TRUE, testSVD.getGps());
 		assertTrue(Test.TRUE, testSVD.getSpeed());
 		assertTrue(Test.TRUE, testSVD.getRpm());
@@ -906,20 +906,21 @@ public class RPCRequestFactoryTests extends TestCase {
 		assertTrue(Test.TRUE, testSVD.getBodyInformation());
 		assertTrue(Test.TRUE, testSVD.getDeviceStatus());
 		assertTrue(Test.TRUE, testSVD.getDriverBraking());
+		assertTrue(Test.TRUE, testSVD.getTurboBoost());
 		assertEquals(Test.MATCH, testCorrelationID, testSVD.getCorrelationID());
 		
-		testSVD = RPCRequestFactory.BuildSubscribeVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, null);
+		testSVD = RPCRequestFactory.BuildSubscribeVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, testTurboBoost, null);
 		assertNull(Test.NULL, testSVD.getCorrelationID());
 	}
 	
 	public void testBuildUnsubscribeVehicleData () {
 		
-		boolean testGPS = true, testSpeed = true, testRPM = true, testFuelLevel = true, testFuelLevelState = true, testInstantFuelConsumption = true, testExternalTemperature = true, testPRNDL = true, testTirePressure = true, testOdometer = true, testBeltStatus = true, testBodyInformation = true, testDeviceStatus = true, testDriverBraking = true;
+		boolean testGPS = true, testSpeed = true, testRPM = true, testFuelLevel = true, testFuelLevelState = true, testInstantFuelConsumption = true, testExternalTemperature = true, testPRNDL = true, testTirePressure = true, testOdometer = true, testBeltStatus = true, testBodyInformation = true, testDeviceStatus = true, testDriverBraking = true, testTurboBoost = true;
 		Integer testCorrelationID = 0;
 		UnsubscribeVehicleData testUVD;
 		
-		// Test -- BuildUnsubscribeVehicleData(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State, boolean instantFuelConsumption, boolean externalTemperature, boolean prndl, boolean tirePressure, boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus, boolean driverBraking, Integer correlationID) 
-		testUVD = RPCRequestFactory.BuildUnsubscribeVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, testCorrelationID);	
+		// Test -- BuildUnsubscribeVehicleData(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State, boolean instantFuelConsumption, boolean externalTemperature, boolean prndl, boolean tirePressure, boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus, boolean driverBraking, boolean turboBoost, Integer correlationID)
+		testUVD = RPCRequestFactory.BuildUnsubscribeVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, testTurboBoost, testCorrelationID);
 		assertTrue(Test.TRUE, testUVD.getGps());
 		assertTrue(Test.TRUE, testUVD.getSpeed());
 		assertTrue(Test.TRUE, testUVD.getRpm());
@@ -934,20 +935,21 @@ public class RPCRequestFactoryTests extends TestCase {
 		assertTrue(Test.TRUE, testUVD.getBodyInformation());
 		assertTrue(Test.TRUE, testUVD.getDeviceStatus());
 		assertTrue(Test.TRUE, testUVD.getDriverBraking());
+		assertTrue(Test.TRUE, testUVD.getTurboBoost());
 		assertEquals(Test.MATCH, testCorrelationID, testUVD.getCorrelationID());
 		
-		testUVD = RPCRequestFactory.BuildUnsubscribeVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, null);
+		testUVD = RPCRequestFactory.BuildUnsubscribeVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, testTurboBoost, null);
 		assertNull(Test.NULL, testUVD.getCorrelationID());
 	}
 	
 	public void testBuildGetVehicleData () {
 		
-		boolean testGPS = true, testSpeed = true, testRPM = true, testFuelLevel = true, testFuelLevelState = true, testInstantFuelConsumption = true, testExternalTemperature = true, testVIN = true, testPRNDL = true, testTirePressure = true, testOdometer = true, testBeltStatus = true, testBodyInformation = true, testDeviceStatus = true, testDriverBraking = true;
+		boolean testGPS = true, testSpeed = true, testRPM = true, testFuelLevel = true, testFuelLevelState = true, testInstantFuelConsumption = true, testExternalTemperature = true, testVIN = true, testPRNDL = true, testTirePressure = true, testOdometer = true, testBeltStatus = true, testBodyInformation = true, testDeviceStatus = true, testDriverBraking = true, testTurboBoost = true;
 		Integer testCorrelationID = 0;
 		GetVehicleData testGVD;
 		
-		// Test -- BuildGetVehicleData(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State, boolean instantFuelConsumption, boolean externalTemperature, boolean vin, boolean prndl, boolean tirePressure, boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus, boolean driverBraking, Integer correlationID)
-		testGVD = RPCRequestFactory.BuildGetVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testVIN, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, testCorrelationID);	
+		// Test -- BuildGetVehicleData(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State, boolean instantFuelConsumption, boolean externalTemperature, boolean vin, boolean prndl, boolean tirePressure, boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus, boolean driverBraking, boolean turboBoost, Integer correlationID)
+		testGVD = RPCRequestFactory.BuildGetVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testVIN, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, testTurboBoost, testCorrelationID);
 		assertTrue(Test.TRUE, testGVD.getGps());
 		assertTrue(Test.TRUE, testGVD.getSpeed());
 		assertTrue(Test.TRUE, testGVD.getRpm());
@@ -962,10 +964,11 @@ public class RPCRequestFactoryTests extends TestCase {
 		assertTrue(Test.TRUE, testGVD.getBodyInformation());
 		assertTrue(Test.TRUE, testGVD.getDeviceStatus());
 		assertTrue(Test.TRUE, testGVD.getDriverBraking());
+		assertTrue(Test.TRUE, testGVD.getTurboBoost());
 		assertTrue(Test.TRUE, testGVD.getVin());
 		assertEquals(Test.MATCH, testCorrelationID, testGVD.getCorrelationID());
 		
-		testGVD = RPCRequestFactory.BuildGetVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testVIN, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, null);
+		testGVD = RPCRequestFactory.BuildGetVehicleData(testGPS, testSpeed, testRPM, testFuelLevel, testFuelLevelState, testInstantFuelConsumption, testExternalTemperature, testVIN, testPRNDL, testTirePressure, testOdometer, testBeltStatus, testBodyInformation, testDeviceStatus, testDriverBraking, testTurboBoost, null);
 		assertNull(Test.NULL, testGVD.getCorrelationID());	
 	}
 	

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/VehicleDataTypeTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/VehicleDataTypeTests.java
@@ -70,6 +70,8 @@ public class VehicleDataTypeTests extends TestCase {
 		VehicleDataType enumVehicleDataClusterModeStatus = VehicleDataType.valueForString(example);
 		example = "VEHICLEDATA_MYKEY";
 		VehicleDataType enumVehicleDataMyKey = VehicleDataType.valueForString(example);
+		example = "VEHICLEDATA_TURBOBOOST";
+		VehicleDataType enumVehicleDataTurboBoost = VehicleDataType.valueForString(example);
 		
 		assertNotNull("VEHICLEDATA_GPS returned null", enumVehicleDataGps);
 		assertNotNull("VEHICLEDATA_SPEED returned null", enumVehicleDataSpeed);
@@ -97,6 +99,8 @@ public class VehicleDataTypeTests extends TestCase {
 		assertNotNull("VEHICLEDATA_EMERGENCYEVENT returned null", enumVehicleDataEmergencyEvent);
 		assertNotNull("VEHICLEDATA_CLUSTERMODESTATUS returned null", enumVehicleDataClusterModeStatus);
 		assertNotNull("VEHICLEDATA_MYKEY returned null", enumVehicleDataMyKey);
+		assertNotNull("VEHICLEDATA_TURBOBOOST returned null", enumVehicleDataTurboBoost);
+
 	}
 	
 	/**
@@ -159,7 +163,9 @@ public class VehicleDataTypeTests extends TestCase {
 		enumTestList.add(VehicleDataType.VEHICLEDATA_AIRBAGSTATUS);
 		enumTestList.add(VehicleDataType.VEHICLEDATA_EMERGENCYEVENT);	
 		enumTestList.add(VehicleDataType.VEHICLEDATA_CLUSTERMODESTATUS);
-		enumTestList.add(VehicleDataType.VEHICLEDATA_MYKEY);	
+		enumTestList.add(VehicleDataType.VEHICLEDATA_MYKEY);
+		enumTestList.add(VehicleDataType.VEHICLEDATA_TURBOBOOST);
+
 
 		assertTrue("Enum value list does not match enum class list", 
 				enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/notifications/OnVehicleDataTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/notifications/OnVehicleDataTests.java
@@ -82,7 +82,8 @@ public class OnVehicleDataTests extends BaseRpcTests{
             result.put(OnVehicleData.KEY_EMERGENCY_EVENT, VehicleDataHelper.EMERGENCY_EVENT.serializeJSON());
             result.put(OnVehicleData.KEY_CLUSTER_MODE_STATUS, VehicleDataHelper.CLUSTER_MODE_STATUS.serializeJSON());
             result.put(OnVehicleData.KEY_MY_KEY, VehicleDataHelper.MY_KEY.serializeJSON());
-        } catch(JSONException e) {
+			result.put(OnVehicleData.KEY_TURBO_BOOST, VehicleDataHelper.TURBO_BOOST);
+		} catch(JSONException e) {
         	fail(Test.JSON_FAIL);
         }
 
@@ -119,8 +120,9 @@ public class OnVehicleDataTests extends BaseRpcTests{
     	EmergencyEvent event = ( (OnVehicleData) msg).getEmergencyEvent();
     	ClusterModeStatus cluster = ( (OnVehicleData) msg).getClusterModeStatus();
     	MyKey key = ( (OnVehicleData) msg).getMyKey();
-    	
-    	// Valid Tests
+		Double turboBoost = ( (OnVehicleData) msg).getTurboBoost();
+
+		// Valid Tests
     	assertEquals(Test.MATCH, VehicleDataHelper.SPEED, speed);
     	assertEquals(Test.MATCH, VehicleDataHelper.RPM, rpm);
     	assertEquals(Test.MATCH, VehicleDataHelper.EXTERNAL_TEMPERATURE, external);
@@ -146,8 +148,9 @@ public class OnVehicleDataTests extends BaseRpcTests{
 	    assertTrue(Test.TRUE, Validator.validateEmergencyEvent(VehicleDataHelper.EMERGENCY_EVENT, event));
 	    assertTrue(Test.TRUE, Validator.validateClusterModeStatus(VehicleDataHelper.CLUSTER_MODE_STATUS, cluster));
 	    assertTrue(Test.TRUE, Validator.validateMyKey(VehicleDataHelper.MY_KEY, key));
-    
-	    // Invalid/Null Tests
+		assertEquals(Test.MATCH, VehicleDataHelper.TURBO_BOOST, turboBoost);
+
+		// Invalid/Null Tests
         OnVehicleData msg = new OnVehicleData();
         assertNotNull(Test.NOT_NULL, msg);
         testNullBase(msg);
@@ -176,8 +179,9 @@ public class OnVehicleDataTests extends BaseRpcTests{
         assertNull(Test.NULL, msg.getAirbagStatus());
         assertNull(Test.NULL, msg.getEmergencyEvent());
         assertNull(Test.NULL, msg.getClusterModeStatus());
-        assertNull(Test.NULL, msg.getMyKey());    	
-    }  
+        assertNull(Test.NULL, msg.getMyKey());
+		assertNull(Test.NULL, msg.getTurboBoost());
+	}
     
     public void testJson() {
 		JSONObject reference = new JSONObject();
@@ -339,7 +343,8 @@ public class OnVehicleDataTests extends BaseRpcTests{
 			reference.put(OnVehicleData.KEY_EMERGENCY_EVENT, emergencyEventObj);
 			reference.put(OnVehicleData.KEY_CLUSTER_MODE_STATUS, clusterModeStatusObj);
 			reference.put(OnVehicleData.KEY_MY_KEY, myKeyObj);
-			
+			reference.put(OnVehicleData.KEY_TURBO_BOOST, VehicleDataHelper.TURBO_BOOST);
+
 			JSONObject underTest = msg.serializeJSON();
 			//go inside underTest and only return the JSONObject inside the parameters key inside the notification key
 			underTest = underTest.getJSONObject("notification").getJSONObject("parameters");

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/GetVehicleDataTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/GetVehicleDataTests.java
@@ -49,6 +49,7 @@ public class GetVehicleDataTests extends BaseRpcTests {
 		msg.setEmergencyEvent(Test.GENERAL_BOOLEAN);
 		msg.setClusterModeStatus(Test.GENERAL_BOOLEAN);
 		msg.setMyKey(Test.GENERAL_BOOLEAN);
+		msg.setTurboBoost(Test.GENERAL_BOOLEAN);
 
         return msg;
     }
@@ -93,7 +94,8 @@ public class GetVehicleDataTests extends BaseRpcTests {
             result.put(GetVehicleData.KEY_EMERGENCY_EVENT, Test.GENERAL_BOOLEAN);
             result.put(GetVehicleData.KEY_CLUSTER_MODE_STATUS, Test.GENERAL_BOOLEAN);
             result.put(GetVehicleData.KEY_MY_KEY, Test.GENERAL_BOOLEAN);
-        }catch(JSONException e){
+			result.put(GetVehicleData.KEY_TURBO_BOOST, Test.GENERAL_BOOLEAN);
+		}catch(JSONException e){
         	fail(Test.JSON_FAIL);
         }
 
@@ -131,7 +133,8 @@ public class GetVehicleDataTests extends BaseRpcTests {
 		assertTrue(Test.TRUE, ( (GetVehicleData) msg ).getEmergencyEvent());
 		assertTrue(Test.TRUE, ( (GetVehicleData) msg ).getClusterModeStatus());
 		assertTrue(Test.TRUE, ( (GetVehicleData) msg ).getMyKey());
-    
+		assertTrue(Test.TRUE, ( (GetVehicleData) msg ).getTurboBoost());
+
 		// Invalid/Null Tests
         GetVehicleData msg = new GetVehicleData();
         assertNotNull(Test.NOT_NULL, msg);
@@ -162,7 +165,8 @@ public class GetVehicleDataTests extends BaseRpcTests {
         assertNull(Test.NULL, msg.getEmergencyEvent());
         assertNull(Test.NULL, msg.getClusterModeStatus());
         assertNull(Test.NULL, msg.getMyKey());
-    }
+		assertNull(Test.NULL, msg.getTurboBoost());
+	}
     
     /**
      * Tests a valid JSON construction of this RPC message.
@@ -208,6 +212,7 @@ public class GetVehicleDataTests extends BaseRpcTests {
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, GetVehicleData.KEY_EMERGENCY_EVENT), cmd.getEmergencyEvent());
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, GetVehicleData.KEY_CLUSTER_MODE_STATUS), cmd.getClusterModeStatus());
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, GetVehicleData.KEY_MY_KEY), cmd.getMyKey());
+			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, GetVehicleData.KEY_TURBO_BOOST), cmd.getTurboBoost());
 		} catch (JSONException e) {
 			fail(Test.JSON_FAIL);
 		}    	

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/SubscribeVehicleDataTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/SubscribeVehicleDataTests.java
@@ -48,7 +48,8 @@ public class SubscribeVehicleDataTests extends BaseRpcTests {
 		msg.setEmergencyEvent(Test.GENERAL_BOOLEAN);
 		msg.setClusterModeStatus(Test.GENERAL_BOOLEAN);
 		msg.setMyKey(Test.GENERAL_BOOLEAN);
-		
+		msg.setTurboBoost(Test.GENERAL_BOOLEAN);
+
 		return msg;
 	}
 
@@ -91,6 +92,7 @@ public class SubscribeVehicleDataTests extends BaseRpcTests {
             result.put(SubscribeVehicleData.KEY_EMERGENCY_EVENT, Test.GENERAL_BOOLEAN);
             result.put(SubscribeVehicleData.KEY_CLUSTER_MODE_STATUS, Test.GENERAL_BOOLEAN);
             result.put(SubscribeVehicleData.KEY_MY_KEY, Test.GENERAL_BOOLEAN);
+			result.put(SubscribeVehicleData.KEY_TURBO_BOOST, Test.GENERAL_BOOLEAN);
 		} catch (JSONException e) {
 			fail(Test.JSON_FAIL);
 		}
@@ -128,7 +130,8 @@ public class SubscribeVehicleDataTests extends BaseRpcTests {
 		assertTrue(Test.MATCH,( (SubscribeVehicleData) msg ).getEmergencyEvent());
 		assertTrue(Test.MATCH,( (SubscribeVehicleData) msg ).getClusterModeStatus());
 		assertTrue(Test.MATCH,( (SubscribeVehicleData) msg ).getMyKey());
-    
+		assertTrue(Test.MATCH,( (SubscribeVehicleData) msg ).getTurboBoost());
+
 		// Invalid/Null Tests
 		SubscribeVehicleData msg = new SubscribeVehicleData();
 		assertNotNull(Test.NOT_NULL, msg);
@@ -158,6 +161,7 @@ public class SubscribeVehicleDataTests extends BaseRpcTests {
         assertNull(Test.NULL, msg.getEmergencyEvent());
         assertNull(Test.NULL, msg.getClusterModeStatus());
         assertNull(Test.NULL, msg.getMyKey());
+		assertNull(Test.NULL, msg.getTurboBoost());
 	}
 	
     /**
@@ -202,7 +206,8 @@ public class SubscribeVehicleDataTests extends BaseRpcTests {
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, SubscribeVehicleData.KEY_AIRBAG_STATUS), cmd.getAirbagStatus());
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, SubscribeVehicleData.KEY_EMERGENCY_EVENT), cmd.getEmergencyEvent());
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, SubscribeVehicleData.KEY_CLUSTER_MODE_STATUS), cmd.getClusterModeStatus());
-			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, SubscribeVehicleData.KEY_MY_KEY), cmd.getMyKey());	
+			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, SubscribeVehicleData.KEY_MY_KEY), cmd.getMyKey());
+			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, SubscribeVehicleData.KEY_TURBO_BOOST), cmd.getTurboBoost());
 		} catch (JSONException e) {
 			fail(Test.JSON_FAIL);
 		}    	

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/UnsubscribeVehicleDataTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/UnsubscribeVehicleDataTests.java
@@ -49,6 +49,7 @@ public class UnsubscribeVehicleDataTests extends BaseRpcTests {
 		msg.setEmergencyEvent(Test.GENERAL_BOOLEAN);
 		msg.setClusterModeStatus(Test.GENERAL_BOOLEAN);
 		msg.setMyKey(Test.GENERAL_BOOLEAN);
+		msg.setTurboBoost(Test.GENERAL_BOOLEAN);
 
 		return msg;
 	}
@@ -91,7 +92,8 @@ public class UnsubscribeVehicleDataTests extends BaseRpcTests {
             result.put(UnsubscribeVehicleData.KEY_AIRBAG_STATUS, Test.GENERAL_BOOLEAN);
             result.put(UnsubscribeVehicleData.KEY_EMERGENCY_EVENT, Test.GENERAL_BOOLEAN);
             result.put(UnsubscribeVehicleData.KEY_CLUSTER_MODE_STATUS, Test.GENERAL_BOOLEAN);
-            result.put(UnsubscribeVehicleData.KEY_MY_KEY, Test.GENERAL_BOOLEAN);            
+            result.put(UnsubscribeVehicleData.KEY_MY_KEY, Test.GENERAL_BOOLEAN);
+			result.put(UnsubscribeVehicleData.KEY_TURBO_BOOST, Test.GENERAL_BOOLEAN);
 		} catch (JSONException e) {
 			fail(Test.JSON_FAIL);
 		}
@@ -128,7 +130,8 @@ public class UnsubscribeVehicleDataTests extends BaseRpcTests {
 		assertTrue(Test.TRUE,( (UnsubscribeVehicleData) msg ).getEmergencyEvent());
 		assertTrue(Test.TRUE,( (UnsubscribeVehicleData) msg ).getClusterModeStatus());
 		assertTrue(Test.TRUE,( (UnsubscribeVehicleData) msg ).getMyKey());
-		
+		assertTrue(Test.TRUE,( (UnsubscribeVehicleData) msg ).getTurboBoost());
+
 		// Invalid/Null Tests
 		UnsubscribeVehicleData msg = new UnsubscribeVehicleData();
 		assertNotNull(Test.NOT_NULL, msg);
@@ -157,8 +160,9 @@ public class UnsubscribeVehicleDataTests extends BaseRpcTests {
         assertNull(Test.NULL, msg.getECallInfo());
         assertNull(Test.NULL, msg.getEmergencyEvent());
         assertNull(Test.NULL, msg.getClusterModeStatus());
-        assertNull(Test.NULL, msg.getMyKey());		
-    }
+        assertNull(Test.NULL, msg.getMyKey());
+		assertNull(Test.NULL, msg.getTurboBoost());
+	}
 
 	/**
      * Tests a valid JSON construction of this RPC message.
@@ -202,7 +206,8 @@ public class UnsubscribeVehicleDataTests extends BaseRpcTests {
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, UnsubscribeVehicleData.KEY_AIRBAG_STATUS), cmd.getAirbagStatus());
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, UnsubscribeVehicleData.KEY_EMERGENCY_EVENT), cmd.getEmergencyEvent());
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, UnsubscribeVehicleData.KEY_CLUSTER_MODE_STATUS), cmd.getClusterModeStatus());
-			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, UnsubscribeVehicleData.KEY_MY_KEY), cmd.getMyKey());			
+			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, UnsubscribeVehicleData.KEY_MY_KEY), cmd.getMyKey());
+			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, UnsubscribeVehicleData.KEY_TURBO_BOOST), cmd.getTurboBoost());
 		} 
 		catch (JSONException e) {
 			fail(Test.JSON_FAIL);

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/responses/GetVehicleDataResponseTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/responses/GetVehicleDataResponseTests.java
@@ -81,7 +81,8 @@ public class GetVehicleDataResponseTests extends BaseRpcTests{
             result.put(GetVehicleDataResponse.KEY_EMERGENCY_EVENT, VehicleDataHelper.EMERGENCY_EVENT.serializeJSON());
             result.put(GetVehicleDataResponse.KEY_CLUSTER_MODE_STATUS, VehicleDataHelper.CLUSTER_MODE_STATUS.serializeJSON());
             result.put(GetVehicleDataResponse.KEY_MY_KEY, VehicleDataHelper.MY_KEY.serializeJSON());
-        } catch(JSONException e){
+			result.put(GetVehicleDataResponse.KEY_TURBO_BOOST, VehicleDataHelper.TURBO_BOOST);
+		} catch(JSONException e){
         	fail(Test.JSON_FAIL);
         }
 
@@ -247,7 +248,8 @@ public class GetVehicleDataResponseTests extends BaseRpcTests{
 			reference.put(GetVehicleDataResponse.KEY_EMERGENCY_EVENT, emergencyEventObj);
 			reference.put(GetVehicleDataResponse.KEY_CLUSTER_MODE_STATUS, clusterModeStatusObj);
 			reference.put(GetVehicleDataResponse.KEY_MY_KEY, myKeyObj);
-			
+			reference.put(GetVehicleDataResponse.KEY_TURBO_BOOST, VehicleDataHelper.TURBO_BOOST);
+
 			JSONObject underTest = msg.serializeJSON();
 			
 			//go inside underTest and only return the JSONObject inside the parameters key inside the response key
@@ -402,7 +404,8 @@ public class GetVehicleDataResponseTests extends BaseRpcTests{
 		assertEquals(Test.MATCH, VehicleDataHelper.EMERGENCY_EVENT, ( (GetVehicleDataResponse) msg ).getEmergencyEvent());
 		assertEquals(Test.MATCH, VehicleDataHelper.CLUSTER_MODE_STATUS, ( (GetVehicleDataResponse) msg ).getClusterModeStatus());
 		assertEquals(Test.MATCH, VehicleDataHelper.MY_KEY, ( (GetVehicleDataResponse) msg ).getMyKey());
-		
+		assertEquals(Test.MATCH, VehicleDataHelper.TURBO_BOOST, ( (GetVehicleDataResponse) msg ).getTurboBoost());
+
 		// Invalid/Null Tests
 		GetVehicleDataResponse msg = new GetVehicleDataResponse();
 		assertNotNull(Test.NOT_NULL, msg);
@@ -431,8 +434,9 @@ public class GetVehicleDataResponseTests extends BaseRpcTests{
         assertNull(Test.NULL, msg.getECallInfo());
         assertNull(Test.NULL, msg.getEmergencyEvent());
         assertNull(Test.NULL, msg.getClusterModeStatus());
-        assertNull(Test.NULL, msg.getMyKey());		
-    }
+        assertNull(Test.NULL, msg.getMyKey());
+		assertNull(Test.NULL, msg.getTurboBoost());
+	}
     
 
 	/**
@@ -516,6 +520,8 @@ public class GetVehicleDataResponseTests extends BaseRpcTests{
 			JSONObject myKeyObj = JsonUtils.readJsonObjectFromJsonObject(parameters, GetVehicleDataResponse.KEY_MY_KEY);
 			MyKey myKey = new MyKey(JsonRPCMarshaller.deserializeJSONObject(myKeyObj));
 			assertTrue(Test.TRUE, Validator.validateMyKey(myKey, cmd.getMyKey()) );
+
+			assertEquals(Test.MATCH, JsonUtils.readDoubleFromJsonObject(parameters, GetVehicleDataResponse.KEY_TURBO_BOOST), cmd.getTurboBoost());
 		} catch (JSONException e) {
 			e.printStackTrace();
 		}    	

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/responses/SubscribeVehicleDataResponseTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/responses/SubscribeVehicleDataResponseTest.java
@@ -53,6 +53,8 @@ public class SubscribeVehicleDataResponseTest extends BaseRpcTests {
 		msg.setEmergencyEvent(Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_EMERGENCYEVENT.ordinal()));
 		msg.setClusterModeStatus(Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_CLUSTERMODESTATUS.ordinal()));
 		msg.setMyKey(Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_MYKEY.ordinal()));
+		msg.setTurboBoost(Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_TURBOBOOST.ordinal()));
+
 
 		return msg;
 	}
@@ -101,6 +103,7 @@ public class SubscribeVehicleDataResponseTest extends BaseRpcTests {
 	        result.put(SubscribeVehicleDataResponse.KEY_EMERGENCY_EVENT, Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_EMERGENCYEVENT.ordinal()).serializeJSON());
 	        result.put(SubscribeVehicleDataResponse.KEY_CLUSTER_MODE_STATUS, Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_CLUSTERMODESTATUS.ordinal()).serializeJSON());
 	        result.put(SubscribeVehicleDataResponse.KEY_MY_KEY, Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_MYKEY.ordinal()).serializeJSON());
+			result.put(SubscribeVehicleDataResponse.KEY_TURBO_BOOST, Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_TURBOBOOST.ordinal()).serializeJSON());
 		} catch (JSONException e) {
 			fail(Test.JSON_FAIL);
 		}
@@ -137,7 +140,9 @@ public class SubscribeVehicleDataResponseTest extends BaseRpcTests {
 		VehicleDataResult testPrndl          = ( (SubscribeVehicleDataResponse) msg ).getPrndl();
 		VehicleDataResult testBraking        = ( (SubscribeVehicleDataResponse) msg ).getDriverBraking();
 		VehicleDataResult testWiperStatus    = ( (SubscribeVehicleDataResponse) msg ).getWiperStatus();
-		
+		VehicleDataResult testTurboBoost     = ( (SubscribeVehicleDataResponse) msg ).getTurboBoost();
+
+
 		// Valid Tests
 		assertTrue(Test.TRUE, testGps.getDataType().equals(VehicleDataType.VEHICLEDATA_GPS));
 		assertTrue(Test.TRUE, testOdometer.getDataType().equals(VehicleDataType.VEHICLEDATA_ODOMETER));
@@ -163,8 +168,10 @@ public class SubscribeVehicleDataResponseTest extends BaseRpcTests {
 	    assertTrue(Test.TRUE, testPrndl.getDataType().equals(VehicleDataType.VEHICLEDATA_PRNDL));
 	    assertTrue(Test.TRUE, testBraking.getDataType().equals(VehicleDataType.VEHICLEDATA_BRAKING));
 	    assertTrue(Test.TRUE, testWiperStatus.getDataType().equals(VehicleDataType.VEHICLEDATA_WIPERSTATUS));
-   
-        // Invalid/Null Tests
+		assertTrue(Test.TRUE, testTurboBoost.getDataType().equals(VehicleDataType.VEHICLEDATA_TURBOBOOST));
+
+
+		// Invalid/Null Tests
 		SubscribeVehicleDataResponse msg = new SubscribeVehicleDataResponse();
         assertNotNull("Null object creation failed.", msg);        
         testNullBase(msg);
@@ -193,7 +200,8 @@ public class SubscribeVehicleDataResponseTest extends BaseRpcTests {
         assertNull(Test.NULL, msg.getEmergencyEvent());
         assertNull(Test.NULL, msg.getClusterModeStatus());
         assertNull(Test.NULL, msg.getMyKey());
-    }
+		assertNull(Test.NULL, msg.getTurboBoost());
+	}
 	
     /**
      * Tests a valid JSON construction of this RPC message.
@@ -310,6 +318,10 @@ public class SubscribeVehicleDataResponseTest extends BaseRpcTests {
 			JSONObject myKey = JsonUtils.readJsonObjectFromJsonObject(parameters, SubscribeVehicleDataResponse.KEY_MY_KEY);
 			VehicleDataResult referenceMyKey = new VehicleDataResult(JsonRPCMarshaller.deserializeJSONObject(myKey));
 			assertTrue(Test.TRUE, Validator.validateVehicleDataResult(referenceMyKey, cmd.getMyKey()));
+
+			JSONObject turboBoost = JsonUtils.readJsonObjectFromJsonObject(parameters, SubscribeVehicleDataResponse.KEY_TURBO_BOOST);
+			VehicleDataResult referenceTurboBoost = new VehicleDataResult(JsonRPCMarshaller.deserializeJSONObject(turboBoost));
+			assertTrue(Test.TRUE, Validator.validateVehicleDataResult(referenceTurboBoost, cmd.getTurboBoost()));
 		} catch (JSONException e) {
 			e.printStackTrace();
 		}    	

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/responses/UnsubscribeVehicleDataResponseTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/responses/UnsubscribeVehicleDataResponseTest.java
@@ -55,6 +55,7 @@ public class UnsubscribeVehicleDataResponseTest extends BaseRpcTests {
 		msg.setEmergencyEvent(Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_EMERGENCYEVENT.ordinal()));
 		msg.setClusterModeStatus(Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_CLUSTERMODESTATUS.ordinal()));
 		msg.setMyKey(Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_MYKEY.ordinal()));
+		msg.setTurboBoost(Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_TURBOBOOST.ordinal()));
 
 		return msg;
 	}
@@ -103,6 +104,7 @@ public class UnsubscribeVehicleDataResponseTest extends BaseRpcTests {
 	        result.put(SubscribeVehicleDataResponse.KEY_EMERGENCY_EVENT, Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_EMERGENCYEVENT.ordinal()).serializeJSON());
 	        result.put(SubscribeVehicleDataResponse.KEY_CLUSTER_MODE_STATUS, Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_CLUSTERMODESTATUS.ordinal()).serializeJSON());
 	        result.put(SubscribeVehicleDataResponse.KEY_MY_KEY, Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_MYKEY.ordinal()).serializeJSON());
+			result.put(SubscribeVehicleDataResponse.KEY_TURBO_BOOST, Test.GENERAL_VEHICLEDATARESULT_LIST.get(VehicleDataType.VEHICLEDATA_TURBOBOOST.ordinal()).serializeJSON());
 		} catch (JSONException e) {
 			fail(Test.JSON_FAIL);
 		}
@@ -139,7 +141,9 @@ public class UnsubscribeVehicleDataResponseTest extends BaseRpcTests {
 		VehicleDataResult testPrndl          = ( (UnsubscribeVehicleDataResponse) msg ).getPrndl();
 		VehicleDataResult testBraking        = ( (UnsubscribeVehicleDataResponse) msg ).getDriverBraking();
 		VehicleDataResult testWiperStatus    = ( (UnsubscribeVehicleDataResponse) msg ).getWiperStatus();
-		
+		VehicleDataResult testTurboBoost     = ( (UnsubscribeVehicleDataResponse) msg ).getTurboBoost();
+
+
 		// Valid Tests
 		assertTrue(Test.TRUE, testGps.getDataType().equals(VehicleDataType.VEHICLEDATA_GPS));
 		assertTrue(Test.TRUE, testOdometer.getDataType().equals(VehicleDataType.VEHICLEDATA_ODOMETER));
@@ -165,8 +169,9 @@ public class UnsubscribeVehicleDataResponseTest extends BaseRpcTests {
 	    assertTrue(Test.TRUE, testPrndl.getDataType().equals(VehicleDataType.VEHICLEDATA_PRNDL));
 	    assertTrue(Test.TRUE, testBraking.getDataType().equals(VehicleDataType.VEHICLEDATA_BRAKING));
 	    assertTrue(Test.TRUE, testWiperStatus.getDataType().equals(VehicleDataType.VEHICLEDATA_WIPERSTATUS));
-   
-        // Invalid/Null Tests
+		assertTrue(Test.TRUE, testTurboBoost.getDataType().equals(VehicleDataType.VEHICLEDATA_TURBOBOOST));
+
+		// Invalid/Null Tests
 		UnsubscribeVehicleDataResponse msg = new UnsubscribeVehicleDataResponse();
         assertNotNull("Null object creation failed.", msg);        
         testNullBase(msg);
@@ -195,7 +200,8 @@ public class UnsubscribeVehicleDataResponseTest extends BaseRpcTests {
         assertNull(Test.NULL, msg.getEmergencyEvent());
         assertNull(Test.NULL, msg.getClusterModeStatus());
         assertNull(Test.NULL, msg.getMyKey());
-    }
+		assertNull(Test.NULL, msg.getTurboBoost());
+	}
 
     /**
      * Tests a valid JSON construction of this RPC message.
@@ -312,6 +318,10 @@ public class UnsubscribeVehicleDataResponseTest extends BaseRpcTests {
 			JSONObject myKey = JsonUtils.readJsonObjectFromJsonObject(parameters, UnsubscribeVehicleDataResponse.KEY_MY_KEY);
 			VehicleDataResult referenceMyKey = new VehicleDataResult(JsonRPCMarshaller.deserializeJSONObject(myKey));
 			assertTrue(Test.TRUE, Validator.validateVehicleDataResult(referenceMyKey, cmd.getMyKey()));
+
+			JSONObject turboBoost = JsonUtils.readJsonObjectFromJsonObject(parameters, UnsubscribeVehicleDataResponse.KEY_TURBO_BOOST);
+			VehicleDataResult referenceTurboBoost = new VehicleDataResult(JsonRPCMarshaller.deserializeJSONObject(turboBoost));
+			assertTrue(Test.TRUE, Validator.validateVehicleDataResult(referenceTurboBoost, cmd.getTurboBoost()));
 		} catch (JSONException e) {
 			e.printStackTrace();
 		}    	

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCRequestFactory.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCRequestFactory.java
@@ -825,7 +825,7 @@ public class RPCRequestFactory {
     public static SubscribeVehicleData BuildSubscribeVehicleData(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State,
 																 boolean instantFuelConsumption, boolean externalTemperature, boolean prndl, boolean tirePressure,
 																 boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus,
-																 boolean driverBraking, Integer correlationID) 
+																 boolean driverBraking, boolean turboBoost, Integer correlationID)
 	{
 		SubscribeVehicleData msg = new SubscribeVehicleData();
 		msg.setGps(gps);
@@ -842,6 +842,7 @@ public class RPCRequestFactory {
 		msg.setBodyInformation(bodyInformation);
 		msg.setDeviceStatus(deviceStatus);
 		msg.setDriverBraking(driverBraking);
+		msg.setTurboBoost(turboBoost);
 		msg.setCorrelationID(correlationID);
 		
 		return msg;
@@ -851,7 +852,7 @@ public class RPCRequestFactory {
     public static UnsubscribeVehicleData BuildUnsubscribeVehicleData(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State,
 																	 boolean instantFuelConsumption, boolean externalTemperature, boolean prndl, boolean tirePressure,
 																	 boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus,
-																	 boolean driverBraking, Integer correlationID) 
+																	 boolean driverBraking, boolean turboBoost, Integer correlationID)
 	{
 		UnsubscribeVehicleData msg = new UnsubscribeVehicleData();
 		msg.setGps(gps);
@@ -868,6 +869,7 @@ public class RPCRequestFactory {
 		msg.setBodyInformation(bodyInformation);
 		msg.setDeviceStatus(deviceStatus);
 		msg.setDriverBraking(driverBraking);
+		msg.setTurboBoost(turboBoost);
 		msg.setCorrelationID(correlationID);
 		
 		return msg;		
@@ -877,7 +879,7 @@ public class RPCRequestFactory {
     public static GetVehicleData BuildGetVehicleData(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State,
 			 boolean instantFuelConsumption, boolean externalTemperature, boolean vin, boolean prndl, boolean tirePressure,
 			 boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus,
-			 boolean driverBraking, Integer correlationID)
+			 boolean driverBraking, boolean turboBoost, Integer correlationID)
 	{
 		GetVehicleData msg = new GetVehicleData();
 		msg.setGps(gps);
@@ -895,6 +897,7 @@ public class RPCRequestFactory {
 		msg.setBodyInformation(bodyInformation);
 		msg.setDeviceStatus(deviceStatus);
 		msg.setDriverBraking(driverBraking);
+		msg.setTurboBoost(turboBoost);
 		msg.setCorrelationID(correlationID);
 				
 		return msg;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -5039,16 +5039,17 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @param bodyInformation -Subscribes to body information including power modes.
 	 * @param deviceStatus -Subscribes to device status including signal and battery strength.
 	 * @param driverBraking -Subscribes to the status of the brake pedal.
+	 * @param turboBoost -Subscribes to vehicle turbo boost pressure data in PSI.
 	 * @param correlationID -A unique ID that correlates each RPCRequest and RPCResponse.
 	 * @throws SdlException
 	*/
 	public void subscribevehicledata(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State,
 									 boolean instantFuelConsumption, boolean externalTemperature, boolean prndl, boolean tirePressure,						
 									 boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus,
-									 boolean driverBraking, Integer correlationID) throws SdlException
+									 boolean driverBraking, boolean turboBoost, Integer correlationID) throws SdlException
 	{
 		SubscribeVehicleData msg = RPCRequestFactory.BuildSubscribeVehicleData(gps, speed, rpm, fuelLevel, fuelLevel_State, instantFuelConsumption, externalTemperature, prndl, tirePressure, 
-																				odometer, beltStatus, bodyInformation, deviceStatus, driverBraking, correlationID);
+																				odometer, beltStatus, bodyInformation, deviceStatus, driverBraking, turboBoost, correlationID);
 		
 		sendRPCRequest(msg);
 	}
@@ -5071,6 +5072,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @param bodyInformation -Unsubscribes to body information including power modes.
 	 * @param deviceStatus -Unsubscribes to device status including signal and battery strength.
 	 * @param driverBraking -Unsubscribes to the status of the brake pedal.
+	 * @param turboBoost -Unsubscribes to vehicle turbo boost pressure data in PSI.
 	 * @param correlationID -A unique ID that correlates each RPCRequest and RPCResponse.
 	 * @throws SdlException
 	*/
@@ -5078,10 +5080,10 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	public void unsubscribevehicledata(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State,
 			 						   boolean instantFuelConsumption, boolean externalTemperature, boolean prndl, boolean tirePressure,
 			 						   boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus,
-			 						   boolean driverBraking, Integer correlationID) throws SdlException
+			 						   boolean driverBraking, boolean turboBoost, Integer correlationID) throws SdlException
 	{
 		UnsubscribeVehicleData msg = RPCRequestFactory.BuildUnsubscribeVehicleData(gps, speed, rpm, fuelLevel, fuelLevel_State, instantFuelConsumption, externalTemperature, prndl, tirePressure,
-																					odometer, beltStatus, bodyInformation, deviceStatus, driverBraking, correlationID);
+																					odometer, beltStatus, bodyInformation, deviceStatus, driverBraking, turboBoost, correlationID);
 		sendRPCRequest(msg);
 	}
 
@@ -5105,17 +5107,18 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @param bodyInformation -Performs an ad-hoc request for  body information including power modes.
 	 * @param deviceStatus -Performs an ad-hoc request for device status including signal and battery strength.
 	 * @param driverBraking -Performs an ad-hoc request for the status of the brake pedal.
+	 * @param turboBoost -Performs an ad-hoc request for vehicle turbo boost pressure data in PSI.
 	 * @param correlationID -A unique ID that correlates each RPCRequest and RPCResponse.
 	 * @throws SdlException
 	*/
 	public void getvehicledata(boolean gps, boolean speed, boolean rpm, boolean fuelLevel, boolean fuelLevel_State,
 			 				   boolean instantFuelConsumption, boolean externalTemperature, boolean vin, boolean prndl, boolean tirePressure,
 			 				   boolean odometer, boolean beltStatus, boolean bodyInformation, boolean deviceStatus,
-			 				   boolean driverBraking, Integer correlationID) throws SdlException
+			 				   boolean driverBraking, boolean turboBoost, Integer correlationID) throws SdlException
 	{
 	
 		GetVehicleData msg = RPCRequestFactory.BuildGetVehicleData(gps, speed, rpm, fuelLevel, fuelLevel_State, instantFuelConsumption, externalTemperature, vin, prndl, tirePressure, odometer,
-																   beltStatus, bodyInformation, deviceStatus, driverBraking, correlationID);
+																   beltStatus, bodyInformation, deviceStatus, driverBraking, turboBoost, correlationID);
 		sendRPCRequest(msg);
 	}
 

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/GetVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/GetVehicleData.java
@@ -177,6 +177,14 @@ import com.smartdevicelink.proxy.RPCRequest;
  *                 <td>Subscribable</td>
  * 			<td>SmartDeviceLink 2.0</td>
  * 		</tr>
+ * 	    <tr>
+ * 			<td>turboBoost</td>
+ * 			<td>Boolean</td>
+ * 			<td>Boost Pressure at the manifold</td>
+ *                 <td>N</td>
+ *                 <td>Subscribable</td>
+ * 			<td>SmartDeviceLink 2.0</td>
+ * 		</tr>
  *  </table>
  *  
  *  
@@ -226,7 +234,9 @@ public class GetVehicleData extends RPCRequest {
 	public static final String KEY_EMERGENCY_EVENT = "emergencyEvent";
 	public static final String KEY_CLUSTER_MODE_STATUS = "clusterModeStatus";
 	public static final String KEY_MY_KEY = "myKey";
-	/**
+    public static final String KEY_TURBO_BOOST = "turboBoost";
+
+    /**
 	 * Constructs a new GetVehicleData object
 	 */
 
@@ -508,5 +518,16 @@ public class GetVehicleData extends RPCRequest {
     }
     public Boolean getMyKey() {
         return (Boolean) parameters.get(KEY_MY_KEY);
-    }        
+    }
+    public void setTurboBoost(Boolean turboBoost) {
+        if (turboBoost != null) {
+            parameters.put(KEY_TURBO_BOOST, turboBoost);
+        } else {
+            parameters.remove(KEY_TURBO_BOOST);
+        }
+    }
+    public Boolean getTurboBoost() {
+        return (Boolean) parameters.get(KEY_TURBO_BOOST);
+    }
+
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/GetVehicleDataResponse.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/GetVehicleDataResponse.java
@@ -43,8 +43,10 @@ public class GetVehicleDataResponse extends RPCResponse {
 	public static final String KEY_EMERGENCY_EVENT = "emergencyEvent";
 	public static final String KEY_CLUSTER_MODE_STATUS = "clusterModeStatus";
 	public static final String KEY_MY_KEY = "myKey";
+    public static final String KEY_TURBO_BOOST = "turboBoost";
 
-	/** 
+
+    /**
 	 * Constructs a new GetVehicleDataResponse object
 	 */
 
@@ -477,5 +479,17 @@ public class GetVehicleDataResponse extends RPCResponse {
             }
         }
         return null;
-    }        
+    }
+
+    public void setTurboBoost(Double turboBoost) {
+        if (turboBoost != null) {
+            parameters.put(KEY_TURBO_BOOST, turboBoost);
+        } else {
+            parameters.remove(KEY_TURBO_BOOST);
+        }
+    }
+    public Double getTurboBoost() {
+        Object object = parameters.get(KEY_TURBO_BOOST);
+        return SdlDataTypeConverter.objectToDouble(object);
+    }
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnVehicleData.java
@@ -234,6 +234,14 @@ import com.smartdevicelink.util.SdlDataTypeConverter;
  * 			<td> minvalue: -2000; maxvalue:2000</td>
  * 			<td>SmartDeviceLink 2.0</td>
  * 		</tr>
+ * 		<tr>
+ * 			<td>turboBoost</td>
+ * 			<td>Float</td>
+ * 			<td>Boost Pressure at the manifold</td>
+ *                 <td>N</td>
+ * 			<td>Subscribable</td>
+ * 			<td>SmartDeviceLink 2.0</td>
+ * 		</tr>
  *  </table>
  *
  * @since SmartDeviceLink 1.0
@@ -269,6 +277,7 @@ public class OnVehicleData extends RPCNotification {
 	public static final String KEY_EMERGENCY_EVENT = "emergencyEvent";
 	public static final String KEY_CLUSTER_MODE_STATUS = "clusterModeStatus";
 	public static final String KEY_MY_KEY = "myKey";
+    public static final String KEY_TURBO_BOOST = "turboBoost";
 
     public OnVehicleData() {
         super(FunctionID.ON_VEHICLE_DATA.toString());
@@ -693,5 +702,15 @@ public class OnVehicleData extends RPCNotification {
             }
         }
         return null;
-    }    
+    }
+    public void setTurboBoost(Double turboBoost) {
+        if (turboBoost != null) {
+            parameters.put(KEY_TURBO_BOOST, turboBoost);
+        } else {
+            parameters.remove(KEY_TURBO_BOOST);
+        }
+    }
+    public Double getTurboBoost() {
+        return (Double) parameters.get(KEY_TURBO_BOOST);
+    }
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SubscribeVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SubscribeVehicleData.java
@@ -218,6 +218,14 @@ import com.smartdevicelink.proxy.RPCRequest;
  *                 <td>Subscribable</td>
  * 			<td>SmartDeviceLink 2.0 </td>
  * 		</tr>
+ * 	 * 		<tr>
+ * 			<td>turboBoost</td>
+ * 			<td>Boolean</td>
+ * 			<td>Boost Pressure at the manifold</td>
+ *                 <td>N</td>
+ *                 <td>Subscribable</td>
+ * 			<td>SmartDeviceLink 2.0 </td>
+ * 		</tr>
  *  </table>
  *  
  * <p> <b>Response</b></p>
@@ -262,6 +270,8 @@ public class SubscribeVehicleData extends RPCRequest {
 	public static final String KEY_CLUSTER_MODE_STATUS = "clusterModeStatus";
 	public static final String KEY_MY_KEY = "myKey";
 	public static final String KEY_SPEED = "speed";
+	public static final String KEY_TURBO_BOOST = "turboBoost";
+
 
 	/**
 	 * Constructs a new SubscribeVehicleData object
@@ -812,6 +822,30 @@ public class SubscribeVehicleData extends RPCRequest {
     }
     public Boolean getMyKey() {
         return (Boolean) parameters.get(KEY_MY_KEY);
-    }      
+    }
+
+	/**
+	 * Sets a boolean value. If true, subscribes turboBoost data
+	 *
+	 * @param turboBoost
+	 *            a boolean value
+	 */
+	public void setTurboBoost(Boolean turboBoost) {
+		if (turboBoost != null) {
+			parameters.put(KEY_TURBO_BOOST, turboBoost);
+		} else {
+			parameters.remove(KEY_TURBO_BOOST);
+		}
+	}
+
+	/**
+	 * Gets a boolean value. If true, means the turboBoost data has been subscribed.
+	 *
+	 * @return Boolean -a Boolean value. If true, means the turboBoost data has been
+	 *         subscribed.
+	 */
+	public Boolean getTurboBoost() {
+		return (Boolean) parameters.get(KEY_TURBO_BOOST);
+	}
     
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SubscribeVehicleDataResponse.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SubscribeVehicleDataResponse.java
@@ -36,8 +36,9 @@ public class SubscribeVehicleDataResponse extends RPCResponse {
 	public static final String KEY_EMERGENCY_EVENT = "emergencyEvent";
 	public static final String KEY_CLUSTER_MODE_STATUS = "clusterModeStatus";
 	public static final String KEY_MY_KEY = "myKey";
+    public static final String KEY_TURBO_BOOST = "turboBoost";
 
-	/**
+    /**
 	 * Constructs a new SubscribeVehicleDataResponse object
 	 */
     public SubscribeVehicleDataResponse() {
@@ -717,5 +718,34 @@ public class SubscribeVehicleDataResponse extends RPCResponse {
             }
         }
         return null;
-    }       
+    }
+    /**
+     * Sets turboBoost
+     * @param turboBoost
+     */
+    public void setTurboBoost(VehicleDataResult turboBoost) {
+        if (turboBoost != null) {
+            parameters.put(KEY_TURBO_BOOST, turboBoost);
+        } else {
+            parameters.remove(KEY_TURBO_BOOST);
+        }
+    }
+    /**
+     * Gets turboBoost
+     * @return VehicleDataResult
+     */
+    @SuppressWarnings("unchecked")
+    public VehicleDataResult getTurboBoost() {
+        Object obj = parameters.get(KEY_TURBO_BOOST);
+        if (obj instanceof VehicleDataResult) {
+            return (VehicleDataResult) obj;
+        } else if (obj instanceof Hashtable) {
+            try {
+                return new VehicleDataResult((Hashtable<String, Object>) obj);
+            } catch (Exception e) {
+                DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_TURBO_BOOST, e);
+            }
+        }
+        return null;
+    }
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/UnregisterAppInterface.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/UnregisterAppInterface.java
@@ -219,6 +219,14 @@ import com.smartdevicelink.proxy.RPCRequest;
  *                 <td>Subscribable</td>
  * 			<td>SmartDeviceLink 2.0 </td>
  * 		</tr>
+ * 	 	<tr>
+ * 			<td>turboBoost</td>
+ * 			<td>Boolean</td>
+ * 			<td>Boost Pressure at the manifold</td>
+ *                 <td>N</td>
+ *                 <td>Subscribable</td>
+ * 			<td>SmartDeviceLink 2.0 </td>
+ * 		</tr>
  *  </table>
  * @see RegisterAppInterface
  * @see OnAppInterfaceUnregistered

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
@@ -213,6 +213,14 @@ import com.smartdevicelink.proxy.RPCRequest;
  *                 <td>Subscribable</td>
  * 			<td>SmartDeviceLink 2.0 </td>
  * 		</tr>
+ * 		<tr>
+ * 			<td>turboBoost</td>
+ * 			<td>Boolean</td>
+ * 			<td>Boost Pressure at the manifold</td>
+ *                 <td>N</td>
+ *                 <td>Subscribable</td>
+ * 			<td>SmartDeviceLink 2.0 </td>
+ * 		</tr>
  *  </table>
  * <p><b> Response</b></p>
  * <p><b>Non-default Result Codes:</b></p>
@@ -255,7 +263,8 @@ public class UnsubscribeVehicleData extends RPCRequest {
 	public static final String KEY_EMERGENCY_EVENT = "emergencyEvent";
 	public static final String KEY_CLUSTER_MODE_STATUS = "clusterModeStatus";
 	public static final String KEY_MY_KEY = "myKey";
-	
+	public static final String KEY_TURBO_BOOST = "turboBoost";
+
 
 	/**
 	 * Constructs a new UnsubscribeVehicleData object
@@ -807,5 +816,28 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
     public Boolean getMyKey() {
         return (Boolean) parameters.get(KEY_MY_KEY);
-    }    
+    }
+	/**
+	 * Sets a boolean value. If true, unsubscribe data
+	 *
+	 * @param turboBoost
+	 *            a boolean value
+	 */
+	public void setTurboBoost(Boolean turboBoost) {
+		if (turboBoost != null) {
+			parameters.put(KEY_TURBO_BOOST, turboBoost);
+		} else {
+			parameters.remove(KEY_TURBO_BOOST);
+		}
+	}
+
+	/**
+	 * Gets a boolean value. If true, means the turboBoost data has been unsubscribed.
+	 *
+	 * @return Boolean -a Boolean value. If true, means the turboBoost data has been
+	 *         unsubscribed.
+	 */
+	public Boolean getTurboBoost() {
+		return (Boolean) parameters.get(KEY_TURBO_BOOST);
+	}
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleDataResponse.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleDataResponse.java
@@ -36,8 +36,9 @@ public class UnsubscribeVehicleDataResponse extends RPCResponse {
 	public static final String KEY_EMERGENCY_EVENT = "emergencyEvent";
 	public static final String KEY_CLUSTER_MODE_STATUS = "clusterModeStatus";
 	public static final String KEY_MY_KEY = "myKey";
+    public static final String KEY_TURBO_BOOST = "turboBoost";
 
-	/**
+    /**
 	 * Constructs a new UnsubscribeVehicleDataResponse object
 	 */
     public UnsubscribeVehicleDataResponse() {
@@ -717,5 +718,34 @@ public class UnsubscribeVehicleDataResponse extends RPCResponse {
             }
         }
         return null;
-    }     
+    }
+    /**
+     * Sets turboBoost
+     * @param turboBoost
+     */
+    public void setTurboBoost(VehicleDataResult turboBoost) {
+        if (turboBoost != null) {
+            parameters.put(KEY_TURBO_BOOST, turboBoost);
+        } else {
+            parameters.remove(KEY_TURBO_BOOST);
+        }
+    }
+    /**
+     * Gets turboBoost
+     * @return VehicleDataResult
+     */
+    @SuppressWarnings("unchecked")
+    public VehicleDataResult getTurboBoost() {
+        Object obj = parameters.get(KEY_TURBO_BOOST);
+        if (obj instanceof VehicleDataResult) {
+            return (VehicleDataResult) obj;
+        } else if (obj instanceof Hashtable) {
+            try {
+                return new VehicleDataResult((Hashtable<String, Object>) obj);
+            } catch (Exception e) {
+                DebugTool.logError("Failed to parse " + getClass().getSimpleName() + "." + KEY_TURBO_BOOST, e);
+            }
+        }
+        return null;
+    }
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/VehicleDataType.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/VehicleDataType.java
@@ -108,7 +108,11 @@ public enum VehicleDataType {
     /**
      * Notifies MYKEYData may be subscribed
      */
-    VEHICLEDATA_MYKEY;
+    VEHICLEDATA_MYKEY,
+    /**
+     * Notifies TURBOBOOSTData may be subscribed
+     */
+    VEHICLEDATA_TURBOBOOST;
 	/**
      * Convert String to VehicleDataType
      * @param value String


### PR DESCRIPTION
This adds the capability for Turbo Boost pressure to be accessed on Android. This has yet to be be implemented in the core SDL library (to my knowledge).