### PR TITLE
Bugfix/issue 569

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RSVTestCase.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RSVTestCase.java
@@ -1,5 +1,8 @@
 package com.smartdevicelink.transport;
 
+import android.app.ActivityManager;
+import android.content.ComponentName;
+import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.test.AndroidTestCase;
@@ -392,6 +395,38 @@ public class RSVTestCase extends AndroidTestCase {
 
 		releaseTListLock();
 	}
-	
+
+	/**
+	 * Test app's router validation. Validation should fail when the given context and ComponentName object are from different packages and security setting is not OFF
+	 * and app is not on trusted list. Validation should pass when the given context and ComponentName object are from the same package.
+	 */
+	public void testAppSelfValidation() {
+
+		class RouterServiceValidatorTest extends RouterServiceValidator{
+			public RouterServiceValidatorTest(Context context){
+				super(context);
+			}
+
+			public RouterServiceValidatorTest(Context context, ComponentName service){
+				super(context, service);
+			}
+
+			// Override this method and simply returning true for the purpose of this test
+			protected boolean isServiceRunning(Context context, ComponentName service){
+				return true;
+			}
+		}
+
+		// Fail, different package name for context and service and app security setting is not OFF and app is not on trusted list
+		RouterServiceValidatorTest rsvpFail = new RouterServiceValidatorTest(this.mContext, new ComponentName("anything", mContext.getClass().getSimpleName()));
+		rsvpFail.setSecurityLevel(MultiplexTransportConfig.FLAG_MULTI_SECURITY_HIGH);
+		assertFalse(rsvpFail.validate());
+
+		// Success, same package name for context and service
+		RouterServiceValidatorTest rsvpPass = new RouterServiceValidatorTest(this.mContext, new ComponentName(mContext.getPackageName(), mContext.getClass().getSimpleName()));
+		rsvpPass.setSecurityLevel(MultiplexTransportConfig.FLAG_MULTI_SECURITY_HIGH);
+		assertTrue(rsvpPass.validate());
+	}
+
 	 
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -121,6 +121,11 @@ public class RouterServiceValidator {
 				//This means our service isn't actually running, so set to null. Hopefully we can find a real router service after this.
 				service = null;
 				Log.w(TAG, "Supplied service is not actually running.");
+			} else {
+				// If the running router service is created by this app, the validation is good by default
+				if (this.service.getPackageName().equals(context.getPackageName())) {
+					return true;
+				}
 			}
 		}
 		if(this.service == null){


### PR DESCRIPTION
Fixes # [569](https://github.com/smartdevicelink/sdl_android/issues/569)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test RouterServiceValidator.validate() using app context and running service router from different packages; also test using app context and running service router from the same package.

### Summary
During app's router service validation, if the running router service is created by the app, validation is good by default. This will let the app bind to the service it created regardless of its Multiplex security setting.