### PR TITLE
bugfix/554 - Refactor of MultiplexBluetoothTransport to no longer be a singleton.

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
@@ -108,7 +108,7 @@ public class SdlRouterServiceTests extends AndroidTestCase {
 
             //Send a non-null bundle with a null bytes array
             //First, set mSerialService to the correct state so we get to test packet being null
-            MultiplexBluetoothTransport transport = MultiplexBluetoothTransport.getBluetoothSerialServerInstance(null);
+            MultiplexBluetoothTransport transport = new MultiplexBluetoothTransport(null);
             transport.setStateManually(MultiplexBluetoothTransport.STATE_CONNECTED);
             field = SdlRouterService.class.getDeclaredField("mSerialService");
             field.setAccessible(true);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -450,9 +450,7 @@ public class MultiplexBluetoothTransport {
                             // Either not ready or already connected. Terminate new socket.
                             try {
                             	Log.d(TAG, "Close unwanted socket");
-                                if(socket!=null){
-                                	socket.close();
-                                }
+                               	socket.close();
                             } catch (IOException e) {
                                 Log.e(TAG, "Could not close unwanted socket", e);
                             }

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -256,16 +256,15 @@ public class MultiplexBluetoothTransport {
         mConnectedWriteThread = new ConnectedWriteThread(socket);
         mConnectedWriteThread.start();
 
-        //Store a static name of the device that is connected. We can do this since the only time
-        //we will access it will be when we receive a CONNECT packet from a device
-        if(device!=null && device.getName()!=null && device.getName()!=""){
+        //Store a static name of the device that is connected.
+        if(device!=null){
         	currentlyConnectedDevice = device.getName();
         }
         
         // Send the name of the connected device back to the UI Activity
         Message msg = mHandler.obtainMessage(SdlRouterService.MESSAGE_DEVICE_NAME);
         Bundle bundle = new Bundle();
-        bundle.putString(DEVICE_NAME, device.getName());
+        bundle.putString(DEVICE_NAME, currentlyConnectedDevice);
         msg.setData(bundle);
         mHandler.sendMessage(msg);
         setState(STATE_CONNECTED);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -143,8 +143,6 @@ public class MultiplexBluetoothTransport {
     protected synchronized void setStateManually(int state){
         //Log.d(TAG, "Setting state from: " +mState + " to: " +state);
         mState = state;
-
-        clearInstanceOnError(state);
     }
     /**
      * Set the current state of the chat connection
@@ -158,14 +156,6 @@ public class MultiplexBluetoothTransport {
         // Give the new state to the Handler so the UI Activity can update
         //Also sending the previous state so we know if we lost a connection
         mHandler.obtainMessage(SdlRouterService.MESSAGE_STATE_CHANGE, state, previousState).sendToTarget();
-
-        clearInstanceOnError(state);
-    }
-
-    private void clearInstanceOnError(int state){
-        if(state == STATE_ERROR){
-           // serverInstance = null;
-        }
     }
 
     /**


### PR DESCRIPTION
Fixes #554 

Refactor of `MultiplexBluetoothTransport` to no longer be a singleton. It also cleans up a little of the code in the same class. Changes were also made to the `SdlRouterService` to no longer keep a static reference to the transport class. 