### PR TITLE
Bugfix / Issue 587

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -75,7 +75,9 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
         }
         
 	    boolean didStart = false;
-	    localRouterClass = defineLocalSdlRouterClass();
+		if (localRouterClass == null){
+			localRouterClass = defineLocalSdlRouterClass();
+		}
         
 		//This will only be true if we are being told to reopen our SDL service because SDL is enabled
 		if(action.equalsIgnoreCase(TransportConstants.START_ROUTER_SERVICE_ACTION)){ 

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -74,7 +74,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			return;
         }
         
-	    boolean didStart = false;
+		boolean didStart = false;
 		if (localRouterClass == null){
 			localRouterClass = defineLocalSdlRouterClass();
 		}


### PR DESCRIPTION
Fixes #587 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke testing of the broadcast receiver was performed

### Summary
Prevent the `defineLocalSdlRouterClass()` from being called if not needed 

### Changelog

- `SdlBroadcastReceiver.java`

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)