### PR TITLE
Bugfix/follow up video streaming codec specific data

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/encoder/SdlEncoder.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/encoder/SdlEncoder.java
@@ -176,25 +176,28 @@ public class SdlEncoder {
 						Log.i(TAG, "H264 codec specific data not retrieved yet.");
 					}
 				}
-				// append SPS and PPS in front of every IDR NAL unit
-				if ((mBufferInfo.flags & MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0
-						&& mBufferInfo.size != 0
-						&& mH264CodecSpecificData != null) {
-					try {
-						mOutputStream.write(mH264CodecSpecificData, 0,
-								mH264CodecSpecificData.length);
-					} catch (Exception e) {}
-				}
 
 				if (mBufferInfo.size != 0) {
 					ByteBuffer encoderOutputBuffer = encoderOutputBuffers[encoderStatus];
-					byte[] dataToWrite = new byte[mBufferInfo.size];
+					byte[] dataToWrite = null;
+					int dataOffset = 0;
+
+					// append SPS and PPS in front of every IDR NAL unit
+					if ((mBufferInfo.flags & MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0
+							&& mH264CodecSpecificData != null) {
+						dataToWrite = new byte[mH264CodecSpecificData.length + mBufferInfo.size];
+						System.arraycopy(mH264CodecSpecificData, 0,
+								dataToWrite, 0, mH264CodecSpecificData.length);
+						dataOffset = mH264CodecSpecificData.length;
+					} else {
+						dataToWrite = new byte[mBufferInfo.size];
+					}
 
 					try {
 						encoderOutputBuffer.position(mBufferInfo.offset);
 						encoderOutputBuffer.limit(mBufferInfo.offset + mBufferInfo.size);
 
-						encoderOutputBuffer.get(dataToWrite, 0, mBufferInfo.size);
+						encoderOutputBuffer.get(dataToWrite, dataOffset, mBufferInfo.size);
 
 						if (mOutputStream != null) {
 							mOutputStream.write(dataToWrite, 0, mBufferInfo.size);

--- a/sdl_android/src/main/java/com/smartdevicelink/encoder/SdlEncoder.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/encoder/SdlEncoder.java
@@ -187,11 +187,15 @@ public class SdlEncoder {
 				}
 
 				if (mBufferInfo.size != 0) {
+					ByteBuffer encoderOutputBuffer = encoderOutputBuffers[encoderStatus];
 					byte[] dataToWrite = new byte[mBufferInfo.size];
-					encoderOutputBuffers[encoderStatus].get(dataToWrite,
-							mBufferInfo.offset, mBufferInfo.size);
 
 					try {
+						encoderOutputBuffer.position(mBufferInfo.offset);
+						encoderOutputBuffer.limit(mBufferInfo.offset + mBufferInfo.size);
+
+						encoderOutputBuffer.get(dataToWrite, 0, mBufferInfo.size);
+
 						if (mOutputStream != null) {
 							mOutputStream.write(dataToWrite, 0, mBufferInfo.size);
 						} else if (mOutputListener != null) {


### PR DESCRIPTION
This is a follow-up of PR https://github.com/smartdevicelink/sdl_android/pull/590, which fixes issue https://github.com/smartdevicelink/sdl_android/issues/589.

- The main purpose of this PR is to support the new interface introduced by PR https://github.com/smartdevicelink/sdl_android/pull/623.
- Additionally, I found that BufferInfo.offset value wasn't properly handled. This is also fixed.

This change has been tested on Nexus 6 (Android 5.0.1) and Xepria Z3+ (Android 6.0) phones.