### PR TITLE
Check protocol version inside of createOpenGLInputSurface

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -4032,7 +4032,11 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
         if (acceptedParams != null) {
             return sdlSession.createOpenGLInputSurface(frameRate, iFrameInterval, width,
                     height, bitrate, SessionType.NAV, sdlSession.getSessionId());
-        } else {
+        } else if(getWiProVersion() < 5){
+			sdlSession.setAcceptedVideoParams(new VideoStreamingParameters());
+			return sdlSession.createOpenGLInputSurface(frameRate, iFrameInterval, width,
+					height, bitrate, SessionType.NAV, sdlSession.getSessionId());
+		} else {
             return null;
         }
     }


### PR DESCRIPTION
Fixes #638
Corrected the use case when createOpenGLInputSurface  is called with a protocol version lower than 5.
