### PR TITLE
bugfix / issue 641

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -6271,11 +6271,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					}
 				}
 			});
-
-			VideoStreamingCapability capability = (VideoStreamingCapability)_systemCapabilityManager.getCapability(SystemCapabilityType.VIDEO_STREAMING);
-			if(capability != null && capability.getIsHapticSpatialDataSupported()){
-				hapticManager = new HapticInterfaceManager(iSdl);
-			}
 		}
 
 		public void startVideoStreaming(Class<? extends SdlRemoteDisplay> remoteDisplayClass, VideoStreamingParameters parameters, boolean encrypted){
@@ -6283,6 +6278,10 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			if(streamListener == null){
 				Log.e(TAG, "Error starting video service");
 				return;
+			}
+			VideoStreamingCapability capability = (VideoStreamingCapability)_systemCapabilityManager.getCapability(SystemCapabilityType.VIDEO_STREAMING);
+			if(capability != null && capability.getIsHapticSpatialDataSupported()){
+				hapticManager = new HapticInterfaceManager(internalInterface);
 			}
 			this.remoteDisplayClass = remoteDisplayClass;
 			try {


### PR DESCRIPTION
Fixes #641 

Moves the system capabilities query for haptic manager into `StartVideoStreaming` so that it isn't null