### PR TITLE
bugfix/issue_666 prevent OnSystemCapabilityListener from being called twice

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -84,6 +84,7 @@ public class SystemCapabilityManager {
 		Object capability = cachedSystemCapabilities.get(systemCapabilityType);
 		if(capability != null){
 			scListener.onCapabilityRetrieved(capability);
+			return;
 		}else if(scListener == null){
 			return;
 		}


### PR DESCRIPTION
Fixes #666 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
No API's were changed. Ran unit tests.

### Summary
Prevent `OnSystemCapabilityListener` from being called twice as noted by @shiniwat 

### Changelog
##### Breaking Changes
* no breaking changes

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)