### PR TITLE
bugfix / issue 671 Attempt to resolve intent before starting router service

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -223,14 +223,13 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 								}
 							});
 							serviceIntent = new Intent();
-							String pkgName;
-							do {
-								pkgName = apps.remove(0).activityInfo.packageName;
+							for (ResolveInfo app : apps) {
+								String pkgName = app.activityInfo.packageName;
 								serviceIntent.setComponent(new ComponentName(pkgName, pkgName + ".SdlRouterService"));
 								if (packageManager.resolveService(serviceIntent, PackageManager.MATCH_DEFAULT_ONLY) != null) {
 									break;
 								}
-							} while (apps.size() > 1);
+							}
 						} else{
 							Log.d(TAG, "No router service running, starting ours");
 							//So let's start up our service since no copy is running

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -222,9 +222,10 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 									return 0;
 								}
 							});
+							serviceIntent = new Intent();
+							String pkgName;
 							do {
-								serviceIntent = new Intent();
-								String pkgName = apps.remove(0).activityInfo.packageName;
+								pkgName = apps.remove(0).activityInfo.packageName;
 								serviceIntent.setComponent(new ComponentName(pkgName, pkgName + ".SdlRouterService"));
 								if (packageManager.resolveService(serviceIntent, PackageManager.MATCH_DEFAULT_ONLY) != null) {
 									break;

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -222,11 +222,14 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 									return 0;
 								}
 							});
-							serviceIntent = buildStartServiceIntent(apps.remove(0));
-							while (!AndroidTools.isIntentAvailable(packageManager, serviceIntent)
-									&& apps.size() > 0) {
-								serviceIntent = buildStartServiceIntent(apps.remove(0));
-							}
+							do {
+								serviceIntent = new Intent();
+								String pkgName = apps.remove(0).activityInfo.packageName;
+								serviceIntent.setComponent(new ComponentName(pkgName, pkgName + ".SdlRouterService"));
+								if (packageManager.resolveService(serviceIntent, PackageManager.MATCH_DEFAULT_ONLY) != null) {
+									break;
+								}
+							} while (apps.size() > 1);
 						} else{
 							Log.d(TAG, "No router service running, starting ours");
 							//So let's start up our service since no copy is running
@@ -254,19 +257,6 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			});
 			return true;
 		}
-	}
-
-	/**
-	 * Given a ResolveInfo object, builds an intent to start the SdlRouterService service with info from the ResolveInfo object
-	 * @param info ResolveInfo object to use
-	 * @return intent to start an SdlRouterService service
-	 */
-	private Intent buildStartServiceIntent(ResolveInfo info) {
-		Intent i = new Intent();
-		String pkgName = info.activityInfo.packageName;
-		i.setComponent(new ComponentName(pkgName, pkgName + ".SdlRouterService"));
-
-		return i;
 	}
 
 	private void wakeRouterServiceAltTransport(Context context){

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -222,9 +222,11 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 									return 0;
 								}
 							});
-							String packageName = apps.get(0).activityInfo.packageName;
-							serviceIntent = new Intent();
-							serviceIntent.setComponent(new ComponentName(packageName, packageName +".SdlRouterService"));
+							serviceIntent = buildStartServiceIntent(apps.remove(0));
+							while (!AndroidTools.isIntentAvailable(packageManager, serviceIntent)
+									&& apps.size() > 0) {
+								serviceIntent = buildStartServiceIntent(apps.remove(0));
+							}
 						} else{
 							Log.d(TAG, "No router service running, starting ours");
 							//So let's start up our service since no copy is running
@@ -252,6 +254,19 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			});
 			return true;
 		}
+	}
+
+	/**
+	 * Given a ResolveInfo object, builds an intent to start the SdlRouterService service with info from the ResolveInfo object
+	 * @param info ResolveInfo object to use
+	 * @return intent to start an SdlRouterService service
+	 */
+	private Intent buildStartServiceIntent(ResolveInfo info) {
+		Intent i = new Intent();
+		String pkgName = info.activityInfo.packageName;
+		i.setComponent(new ComponentName(pkgName, pkgName + ".SdlRouterService"));
+
+		return i;
 	}
 
 	private void wakeRouterServiceAltTransport(Context context){

--- a/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -48,4 +48,5 @@ public class AndroidTools {
 		}
 		return sdlMultiList;
 	}
+
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -49,4 +49,16 @@ public class AndroidTools {
 		return sdlMultiList;
 	}
 
+	/**
+	 * Checks if the given Intent can be resolved.
+	 * @param pm the PackageManager to use
+	 * @param i the intent to be checked
+	 * @return true if the intent can be resolve; false otherwise
+	 */
+	public static boolean isIntentAvailable(PackageManager pm, Intent i) {
+		List<ResolveInfo> list = pm.queryIntentServices(i, PackageManager.MATCH_DEFAULT_ONLY);
+
+		return list.size() > 1;
+	}
+
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -48,17 +48,4 @@ public class AndroidTools {
 		}
 		return sdlMultiList;
 	}
-
-	/**
-	 * Checks if the given Intent can be resolved.
-	 * @param pm the PackageManager to use
-	 * @param i the intent to be checked
-	 * @return true if the intent can be resolve; false otherwise
-	 */
-	public static boolean isIntentAvailable(PackageManager pm, Intent i) {
-		List<ResolveInfo> list = pm.queryIntentServices(i, PackageManager.MATCH_DEFAULT_ONLY);
-
-		return list.size() > 1;
-	}
-
 }


### PR DESCRIPTION
Fixes [#671](https://github.com/smartdevicelink/sdl_android/issues/671)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
No API's were changed. Ran unit tests.

### Summary
If the intent to start the eligible router service does not resolve, attempt to start the next eligible router service.

### Changelog
##### Breaking Changes
* No breaking changes

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)