### PR TITLE
bugfix/issue 662 HMI status not updating

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3025,19 +3025,18 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				
 				msg.setFirstRun(firstTimeFull);
 				if (msg.getHmiLevel() == HMILevel.HMI_FULL) firstTimeFull = false;
-				
-				if (msg.getHmiLevel() != _hmiLevel || msg.getAudioStreamingState() != _audioStreamingState) {
-					_hmiLevel = msg.getHmiLevel();
-					_audioStreamingState = msg.getAudioStreamingState();
 
-					if (_callbackToUIThread) {
-						// Run in UI thread
-						_mainUIHandler.post(new Runnable() {
-							@Override
-							public void run() {
-								_proxyListener.onOnHMIStatus(msg);
-								_proxyListener.onOnLockScreenNotification(sdlSession.getLockScreenMan().getLockObj());
-								onRPCNotificationReceived(msg);
+				_hmiLevel = msg.getHmiLevel();
+				_audioStreamingState = msg.getAudioStreamingState();
+
+				if (_callbackToUIThread) {
+					// Run in UI thread
+					_mainUIHandler.post(new Runnable() {
+						@Override
+						public void run() {
+							_proxyListener.onOnHMIStatus(msg);
+							_proxyListener.onOnLockScreenNotification(sdlSession.getLockScreenMan().getLockObj());
+							onRPCNotificationReceived(msg);
 							}
 						});
 					} else {
@@ -3045,7 +3044,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 						_proxyListener.onOnLockScreenNotification(sdlSession.getLockScreenMan().getLockObj());
 						onRPCNotificationReceived(msg);
 					}
-				}				
 			} else if (functionName.equals(FunctionID.ON_COMMAND.toString())) {
 				// OnCommand
 				


### PR DESCRIPTION
Fixes #662 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This was tested on a FORD TDK and test app. 

### Summary
There was logic to prevent HMI notifications when an HMI level or Audio Streaming State did not change. However, there is additional information in those notifications that the developer might want. That comparison logic was simply removed. 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)