### PR TITLE
bugfix/issue 616 fix NPE in proxy base 

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -1537,7 +1537,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 						if (message.getJsonSize() > 0) {
 							final Hashtable<String, Object> mhash = JsonRPCMarshaller.unmarshall(message.getData());
 							//hashTemp.put(Names.parameters, mhash.get(Names.parameters));
-							hashTemp.put(RPCMessage.KEY_PARAMETERS, mhash);
+							if (mhash != null) {
+								hashTemp.put(RPCMessage.KEY_PARAMETERS, mhash);
+							}
 						}
 
 						String functionName = FunctionID.getFunctionName(message.getFunctionID());


### PR DESCRIPTION
Fixes #616 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This does not change behavior, simply prevents possible NPE 

### Summary
Fix potential NPE in SDLProxyBase. Hashtables cannot take nulls like hash maps can. 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)