### PR TITLE
Bugfix/issue 660 UAI Race condition logic

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
@@ -29,8 +29,7 @@ import java.util.HashMap;
 
 public class SdlRouterServiceTests extends AndroidTestCase {
 
-	public static final String TAG = "SdlRouterServiceTests";
-
+    public static final String TAG = "SdlRouterServiceTests";
 	private final int SAMPLE_RPC_CORRELATION_ID = 630;
 
 	int version = 1;
@@ -38,115 +37,115 @@ public class SdlRouterServiceTests extends AndroidTestCase {
 	ProtocolMessage pm = null;
 	BinaryFrameHeader binFrameHeader = null;
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-	}
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		//Nothing here for now
-	}
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        //Nothing here for now
+    }
 
-	/**
-	 * Test null bundle handling in AltTransportHandler when handling messages. Only test the case of
-	 * msg.what == TransportConstants.ROUTER_RECEIVED_PACKET
-	 */
-	public void testAlTransportHandlerHandleNullBundle() {
-		if (Looper.myLooper() == null) {
-			Looper.prepare();
-		}
-		class AltTransportHandler extends Handler {
-			ClassLoader loader;
-			final WeakReference<SdlRouterService> provider;
+    /**
+     * Test null bundle handling in AltTransportHandler when handling messages. Only test the case of
+     * msg.what == TransportConstants.ROUTER_RECEIVED_PACKET
+     */
+    public void testAlTransportHandlerHandleNullBundle() {
+        if (Looper.myLooper() == null) {
+            Looper.prepare();
+        }
+        class AltTransportHandler extends Handler {
+            ClassLoader loader;
+            final WeakReference<SdlRouterService> provider;
 
-			public AltTransportHandler(SdlRouterService provider) {
-				this.provider = new WeakReference<SdlRouterService>(provider);
-				loader = getClass().getClassLoader();
-			}
+            public AltTransportHandler(SdlRouterService provider) {
+                this.provider = new WeakReference<SdlRouterService>(provider);
+                loader = getClass().getClassLoader();
+            }
 
-			@Override
-			public void handleMessage(Message msg) {
-				SdlRouterService service = this.provider.get();
-				Bundle receivedBundle = msg.getData();
-				switch (msg.what) {
-					case TransportConstants.ROUTER_RECEIVED_PACKET:
-						if (receivedBundle != null) {
-							receivedBundle.setClassLoader(loader);//We do this because loading a custom parceable object isn't possible without it
-							if (receivedBundle.containsKey(TransportConstants.FORMED_PACKET_EXTRA_NAME)) {
-								SdlPacket packet = receivedBundle.getParcelable(TransportConstants.FORMED_PACKET_EXTRA_NAME);
-								if (packet != null && service != null) {
-									service.onPacketRead(packet);
-								} else {
-									Log.w(TAG, "Received null packet from alt transport service");
-								}
-							} else {
-								Log.w(TAG, "Flase positive packet reception");
-							}
-						} else {
-							Log.e(TAG, "Bundle was null while sending packet to router service from alt transport");
-						}
-						break;
-					default:
-						super.handleMessage(msg);
-				}
+            @Override
+            public void handleMessage(Message msg) {
+                SdlRouterService service = this.provider.get();
+                Bundle receivedBundle = msg.getData();
+                switch (msg.what) {
+                    case TransportConstants.ROUTER_RECEIVED_PACKET:
+                        if (receivedBundle != null) {
+                            receivedBundle.setClassLoader(loader);//We do this because loading a custom parceable object isn't possible without it
+                            if (receivedBundle.containsKey(TransportConstants.FORMED_PACKET_EXTRA_NAME)) {
+                                SdlPacket packet = receivedBundle.getParcelable(TransportConstants.FORMED_PACKET_EXTRA_NAME);
+                                if (packet != null && service != null) {
+                                    service.onPacketRead(packet);
+                                } else {
+                                    Log.w(TAG, "Received null packet from alt transport service");
+                                }
+                            } else {
+                                Log.w(TAG, "Flase positive packet reception");
+                            }
+                        } else {
+                            Log.e(TAG, "Bundle was null while sending packet to router service from alt transport");
+                        }
+                        break;
+                    default:
+                        super.handleMessage(msg);
+                }
 
-			}
-		}
-		AltTransportHandler testHandler = new AltTransportHandler(null);
-		Message msg = Message.obtain(null, TransportConstants.ROUTER_RECEIVED_PACKET);
-		//Send a null bundle
-		msg.setData(null);
-		try {
-			testHandler.handleMessage(msg);
-		} catch (Exception e) {
-			Assert.fail("Exception in testAlTransportHandlerHandleNullBundle, " + e);
-		}
-	}
+            }
+        }
+        AltTransportHandler testHandler = new AltTransportHandler(null);
+        Message msg = Message.obtain(null, TransportConstants.ROUTER_RECEIVED_PACKET);
+        //Send a null bundle
+        msg.setData(null);
+        try {
+            testHandler.handleMessage(msg);
+        } catch (Exception e) {
+            Assert.fail("Exception in testAlTransportHandlerHandleNullBundle, " + e);
+        }
+    }
 
-	/**
-	 * Test writeBytesToTransport method for handling null byte array in bundle
-	 *
-	 * @see SdlRouterService#writeBytesToTransport(Bundle)
-	 */
-	public void testWriteBytesToTransport() {
-		if (Looper.myLooper() == null) {
-			Looper.prepare();
-		}
-		Method method;
-		Field field = null;
-		Object sdlRouterService = null;
-		try {
-			sdlRouterService = Class.forName("com.smartdevicelink.transport.SdlRouterService").newInstance();
-			//Send a null bundle
-			method = SdlRouterService.class.getDeclaredMethod("writeBytesToTransport", Bundle.class);
-			Bundle bundle = null;
-			method.invoke(sdlRouterService, bundle);
+    /**
+     * Test writeBytesToTransport method for handling null byte array in bundle
+     *
+     * @see SdlRouterService#writeBytesToTransport(Bundle)
+     */
+    public void testWriteBytesToTransport() {
+        if (Looper.myLooper() == null) {
+            Looper.prepare();
+        }
+        Method method;
+        Field field = null;
+        Object sdlRouterService = null;
+        try {
+            sdlRouterService = Class.forName("com.smartdevicelink.transport.SdlRouterService").newInstance();
+            //Send a null bundle
+            method = SdlRouterService.class.getDeclaredMethod("writeBytesToTransport", Bundle.class);
+            Bundle bundle = null;
+            method.invoke(sdlRouterService, bundle);
 
-			//Send a non-null bundle with a null bytes array
-			//First, set mSerialService to the correct state so we get to test packet being null
-			MultiplexBluetoothTransport transport = new MultiplexBluetoothTransport(null);
-			transport.setStateManually(MultiplexBluetoothTransport.STATE_CONNECTED);
-			field = SdlRouterService.class.getDeclaredField("mSerialService");
-			field.setAccessible(true);
-			field.set(sdlRouterService, transport);
-			bundle = new Bundle();
-			bundle.putByteArray(TransportConstants.BYTES_TO_SEND_EXTRA_NAME, null);
-			method.invoke(sdlRouterService, bundle);
-		} catch (Exception e) {
-			Assert.fail("Exception in testWriteBytesToTransport, " + e);
-		}
+            //Send a non-null bundle with a null bytes array
+            //First, set mSerialService to the correct state so we get to test packet being null
+            MultiplexBluetoothTransport transport = new MultiplexBluetoothTransport(null);
+            transport.setStateManually(MultiplexBluetoothTransport.STATE_CONNECTED);
+            field = SdlRouterService.class.getDeclaredField("mSerialService");
+            field.setAccessible(true);
+            field.set(sdlRouterService, transport);
+            bundle = new Bundle();
+            bundle.putByteArray(TransportConstants.BYTES_TO_SEND_EXTRA_NAME, null);
+            method.invoke(sdlRouterService, bundle);
+        } catch (Exception e) {
+            Assert.fail("Exception in testWriteBytesToTransport, " + e);
+        }
 
-		//Return mSerialService to previous state
-		if (field != null && sdlRouterService != null) {
-			try {
-				field.set(sdlRouterService, null);
-			} catch (IllegalAccessException e) {
-				e.printStackTrace();
-			}
-		}
-	}
+        //Return mSerialService to previous state
+        if (field != null && sdlRouterService != null) {
+            try {
+                field.set(sdlRouterService, null);
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+    }
 
 	/**
 	 * Test sending UAI to an app whose session id is the same as a removed app

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
@@ -30,12 +30,11 @@ import java.util.HashMap;
 public class SdlRouterServiceTests extends AndroidTestCase {
 
     public static final String TAG = "SdlRouterServiceTests";
-	private final int SAMPLE_RPC_CORRELATION_ID = 630;
-
-	int version = 1;
-	int sessionId = 1;
-	ProtocolMessage pm = null;
-	BinaryFrameHeader binFrameHeader = null;
+    private final int SAMPLE_RPC_CORRELATION_ID = 630;
+    int version = 1;
+    int sessionId = 1;
+    ProtocolMessage pm = null;
+    BinaryFrameHeader binFrameHeader = null;
 
     @Override
     protected void setUp() throws Exception {

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
@@ -325,7 +325,7 @@ public class SdlRouterServiceTests extends AndroidTestCase {
 			method = sdlRouterService.getClass().getDeclaredMethod("sendPacketToRegisteredApp", SdlPacket.class);
 			Boolean success = (Boolean) method.invoke(sdlRouterService, packet);
 
-			// we do not want the UAI packet to be sent. make sure it is dropped
+			// Since it is the same app, allow the packet to be sent
 			Assert.assertTrue(success);
 
 		} catch (Exception e) {

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
@@ -7,11 +7,14 @@ import android.os.Looper;
 import android.os.Message;
 import android.test.AndroidTestCase;
 import android.util.Log;
+import android.util.SparseArray;
 import android.util.SparseIntArray;
 
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
+import com.smartdevicelink.protocol.BinaryFrameHeader;
 import com.smartdevicelink.protocol.ProtocolMessage;
 import com.smartdevicelink.protocol.SdlPacket;
+import com.smartdevicelink.protocol.SdlPacketFactory;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.protocol.enums.MessageType;
 import com.smartdevicelink.protocol.enums.SessionType;
@@ -22,126 +25,128 @@ import junit.framework.Assert;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.HashMap;
 
 public class SdlRouterServiceTests extends AndroidTestCase {
 
-    public static final String TAG = "SdlRouterServiceTests";
+	public static final String TAG = "SdlRouterServiceTests";
 
 	private final int SAMPLE_RPC_CORRELATION_ID = 630;
 
 	int version = 1;
-	int sessionId =1;
+	int sessionId = 1;
 	ProtocolMessage pm = null;
+	BinaryFrameHeader binFrameHeader = null;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+	}
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-        //Nothing here for now
-    }
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		//Nothing here for now
+	}
 
-    /**
-     * Test null bundle handling in AltTransportHandler when handling messages. Only test the case of
-     * msg.what == TransportConstants.ROUTER_RECEIVED_PACKET
-     */
-    public void testAlTransportHandlerHandleNullBundle() {
-        if (Looper.myLooper() == null) {
-            Looper.prepare();
-        }
-        class AltTransportHandler extends Handler {
-            ClassLoader loader;
-            final WeakReference<SdlRouterService> provider;
+	/**
+	 * Test null bundle handling in AltTransportHandler when handling messages. Only test the case of
+	 * msg.what == TransportConstants.ROUTER_RECEIVED_PACKET
+	 */
+	public void testAlTransportHandlerHandleNullBundle() {
+		if (Looper.myLooper() == null) {
+			Looper.prepare();
+		}
+		class AltTransportHandler extends Handler {
+			ClassLoader loader;
+			final WeakReference<SdlRouterService> provider;
 
-            public AltTransportHandler(SdlRouterService provider) {
-                this.provider = new WeakReference<SdlRouterService>(provider);
-                loader = getClass().getClassLoader();
-            }
+			public AltTransportHandler(SdlRouterService provider) {
+				this.provider = new WeakReference<SdlRouterService>(provider);
+				loader = getClass().getClassLoader();
+			}
 
-            @Override
-            public void handleMessage(Message msg) {
-                SdlRouterService service = this.provider.get();
-                Bundle receivedBundle = msg.getData();
-                switch (msg.what) {
-                    case TransportConstants.ROUTER_RECEIVED_PACKET:
-                        if (receivedBundle != null) {
-                            receivedBundle.setClassLoader(loader);//We do this because loading a custom parceable object isn't possible without it
-                            if (receivedBundle.containsKey(TransportConstants.FORMED_PACKET_EXTRA_NAME)) {
-                                SdlPacket packet = receivedBundle.getParcelable(TransportConstants.FORMED_PACKET_EXTRA_NAME);
-                                if (packet != null && service != null) {
-                                    service.onPacketRead(packet);
-                                } else {
-                                    Log.w(TAG, "Received null packet from alt transport service");
-                                }
-                            } else {
-                                Log.w(TAG, "Flase positive packet reception");
-                            }
-                        } else {
-                            Log.e(TAG, "Bundle was null while sending packet to router service from alt transport");
-                        }
-                        break;
-                    default:
-                        super.handleMessage(msg);
-                }
+			@Override
+			public void handleMessage(Message msg) {
+				SdlRouterService service = this.provider.get();
+				Bundle receivedBundle = msg.getData();
+				switch (msg.what) {
+					case TransportConstants.ROUTER_RECEIVED_PACKET:
+						if (receivedBundle != null) {
+							receivedBundle.setClassLoader(loader);//We do this because loading a custom parceable object isn't possible without it
+							if (receivedBundle.containsKey(TransportConstants.FORMED_PACKET_EXTRA_NAME)) {
+								SdlPacket packet = receivedBundle.getParcelable(TransportConstants.FORMED_PACKET_EXTRA_NAME);
+								if (packet != null && service != null) {
+									service.onPacketRead(packet);
+								} else {
+									Log.w(TAG, "Received null packet from alt transport service");
+								}
+							} else {
+								Log.w(TAG, "Flase positive packet reception");
+							}
+						} else {
+							Log.e(TAG, "Bundle was null while sending packet to router service from alt transport");
+						}
+						break;
+					default:
+						super.handleMessage(msg);
+				}
 
-            }
-        }
-        AltTransportHandler testHandler = new AltTransportHandler(null);
-        Message msg = Message.obtain(null, TransportConstants.ROUTER_RECEIVED_PACKET);
-        //Send a null bundle
-        msg.setData(null);
-        try {
-            testHandler.handleMessage(msg);
-        } catch (Exception e) {
-            Assert.fail("Exception in testAlTransportHandlerHandleNullBundle, " + e);
-        }
-    }
+			}
+		}
+		AltTransportHandler testHandler = new AltTransportHandler(null);
+		Message msg = Message.obtain(null, TransportConstants.ROUTER_RECEIVED_PACKET);
+		//Send a null bundle
+		msg.setData(null);
+		try {
+			testHandler.handleMessage(msg);
+		} catch (Exception e) {
+			Assert.fail("Exception in testAlTransportHandlerHandleNullBundle, " + e);
+		}
+	}
 
-    /**
-     * Test writeBytesToTransport method for handling null byte array in bundle
-     *
-     * @see SdlRouterService#writeBytesToTransport(Bundle)
-     */
-    public void testWriteBytesToTransport() {
-        if (Looper.myLooper() == null) {
-            Looper.prepare();
-        }
-        Method method;
-        Field field = null;
-        Object sdlRouterService = null;
-        try {
-            sdlRouterService = Class.forName("com.smartdevicelink.transport.SdlRouterService").newInstance();
-            //Send a null bundle
-            method = SdlRouterService.class.getDeclaredMethod("writeBytesToTransport", Bundle.class);
-            Bundle bundle = null;
-            method.invoke(sdlRouterService, bundle);
+	/**
+	 * Test writeBytesToTransport method for handling null byte array in bundle
+	 *
+	 * @see SdlRouterService#writeBytesToTransport(Bundle)
+	 */
+	public void testWriteBytesToTransport() {
+		if (Looper.myLooper() == null) {
+			Looper.prepare();
+		}
+		Method method;
+		Field field = null;
+		Object sdlRouterService = null;
+		try {
+			sdlRouterService = Class.forName("com.smartdevicelink.transport.SdlRouterService").newInstance();
+			//Send a null bundle
+			method = SdlRouterService.class.getDeclaredMethod("writeBytesToTransport", Bundle.class);
+			Bundle bundle = null;
+			method.invoke(sdlRouterService, bundle);
 
-            //Send a non-null bundle with a null bytes array
-            //First, set mSerialService to the correct state so we get to test packet being null
-            MultiplexBluetoothTransport transport = new MultiplexBluetoothTransport(null);
-            transport.setStateManually(MultiplexBluetoothTransport.STATE_CONNECTED);
-            field = SdlRouterService.class.getDeclaredField("mSerialService");
-            field.setAccessible(true);
-            field.set(sdlRouterService, transport);
-            bundle = new Bundle();
-            bundle.putByteArray(TransportConstants.BYTES_TO_SEND_EXTRA_NAME, null);
-            method.invoke(sdlRouterService, bundle);
-        } catch (Exception e) {
-            Assert.fail("Exception in testWriteBytesToTransport, " + e);
-        }
+			//Send a non-null bundle with a null bytes array
+			//First, set mSerialService to the correct state so we get to test packet being null
+			MultiplexBluetoothTransport transport = new MultiplexBluetoothTransport(null);
+			transport.setStateManually(MultiplexBluetoothTransport.STATE_CONNECTED);
+			field = SdlRouterService.class.getDeclaredField("mSerialService");
+			field.setAccessible(true);
+			field.set(sdlRouterService, transport);
+			bundle = new Bundle();
+			bundle.putByteArray(TransportConstants.BYTES_TO_SEND_EXTRA_NAME, null);
+			method.invoke(sdlRouterService, bundle);
+		} catch (Exception e) {
+			Assert.fail("Exception in testWriteBytesToTransport, " + e);
+		}
 
-        //Return mSerialService to previous state
-        if (field != null && sdlRouterService != null) {
-            try {
-                field.set(sdlRouterService, null);
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
-            }
-        }
-    }
+		//Return mSerialService to previous state
+		if (field != null && sdlRouterService != null) {
+			try {
+				field.set(sdlRouterService, null);
+			} catch (IllegalAccessException e) {
+				e.printStackTrace();
+			}
+		}
+	}
 
 	/**
 	 * Test sending UAI to an app whose session id is the same as a removed app
@@ -149,7 +154,7 @@ public class SdlRouterServiceTests extends AndroidTestCase {
 	 *
 	 * @see SdlRouterService#sendPacketToRegisteredApp(SdlPacket)
 	 */
-    public void testRegisterAppExistingSessionID() {
+	public void testRegisterAppExistingSessionID() {
 		if (Looper.myLooper() == null) {
 			Looper.prepare();
 		}
@@ -159,35 +164,60 @@ public class SdlRouterServiceTests extends AndroidTestCase {
 		try {
 
 			// create instance of router service
-			Class<?> routerService = SdlRouterService.class;
-			Object sdlRouterService = routerService.newInstance();
+			SdlRouterService sdlRouterService = new SdlRouterService();
+
+			// We need a registered app for this to work
+			Message message = Message.obtain();
+			SdlRouterService.RegisteredApp app1 = sdlRouterService.new RegisteredApp("12345",message.replyTo);
+			SdlRouterService.RegisteredApp app2 = sdlRouterService.new RegisteredApp("12344",message.replyTo);
+			HashMap<String,SdlRouterService.RegisteredApp> registeredApps = new HashMap<>();
+			registeredApps.put(app1.getAppId(),app1);
+			registeredApps.put(app2.getAppId(),app2);
+
+			// set registered apps array
+			Field raf = sdlRouterService.getClass().getDeclaredField("registeredApps");
+			raf.setAccessible(true);
+			raf.set(sdlRouterService, registeredApps);
+			System.out.println(raf.get(sdlRouterService).toString());
+
+			// need a session map too
+			SparseArray<String> sessionMap = new SparseArray<String>();
+			sessionMap.put(1, "12345");
+			Field sessionMapField = sdlRouterService.getClass().getDeclaredField("sessionMap");
+			sessionMapField.setAccessible(true);
+			sessionMapField.set(sdlRouterService, sessionMap);
+			System.out.println(sessionMapField.get(sdlRouterService).toString());
 
 			// set cleaned session map
 			SparseIntArray testCleanedMap = new SparseIntArray();
-			testCleanedMap.put(1,12345);
-			Field f = SdlRouterService.class.getDeclaredField("cleanedSessionMap");
-			f.setAccessible(true);//Very important, this allows the setting to work.
+			testCleanedMap.put(1, 12345);
+			Field f = sdlRouterService.getClass().getDeclaredField("cleanedSessionMap");
+			f.setAccessible(true);
 			f.set(sdlRouterService, testCleanedMap);
 
 			// set session hash id map
 			SparseIntArray testHashIdMap = new SparseIntArray();
-			testCleanedMap.put(1,12344);
-			Field f2 = SdlRouterService.class.getDeclaredField("sessionHashIdMap");
-			f2.setAccessible(true);//Very important, this allows the setting to work.
+			testHashIdMap.put(1, 12345);
+			Field f2 = sdlRouterService.getClass().getDeclaredField("sessionHashIdMap");
+			f2.setAccessible(true);
 			f2.set(sdlRouterService, testHashIdMap);
 
 			// make sure maps are set and NOT the same
-			Assert.assertNotSame(f.get(sdlRouterService),f2.get(sdlRouterService));
+			Assert.assertNotNull(f.get(sdlRouterService));
+			Assert.assertNotNull(f2.get(sdlRouterService));
+			Assert.assertNotSame(f.get(sdlRouterService), f2.get(sdlRouterService));
+			System.out.println(f.get(sdlRouterService).toString());
+			System.out.println(f2.get(sdlRouterService).toString());
 
 			// make da RPC
 			UnregisterAppInterface request = new UnregisterAppInterface();
 			request.setCorrelationID(SAMPLE_RPC_CORRELATION_ID);
 
 			// build protocol message
-			byte[] msgBytes = JsonRPCMarshaller.marshall(request, (byte)version);
+			byte[] msgBytes = JsonRPCMarshaller.marshall(request, (byte) version);
 			pm = new ProtocolMessage();
 			pm.setData(msgBytes);
-			pm.setSessionID((byte)sessionId);
+			pm.setSessionID((byte) sessionId);
 			pm.setMessageType(MessageType.RPC);
 			pm.setSessionType(SessionType.RPC);
 			pm.setFunctionID(FunctionID.getFunctionId(request.getFunctionName()));
@@ -197,12 +227,19 @@ public class SdlRouterServiceTests extends AndroidTestCase {
 				pm.setBulkData(request.getBulkData());
 			}
 
+			// binary frame header
+			byte[] data = new byte[12 + pm.getJsonSize()];
+			binFrameHeader = SdlPacketFactory.createBinaryFrameHeader(pm.getRPCType(), pm.getFunctionID(), pm.getCorrID(), pm.getJsonSize());
+			System.out.println(binFrameHeader.toString());
+			System.arraycopy(binFrameHeader.assembleHeaderBytes(), 0, data, 0, 12);
+			System.arraycopy(pm.getData(), 0, data, 12, pm.getJsonSize());
+
 			// create packet and invoke sendPacketToRegisteredApp
-			byte[] data = pm.getData();
-			sdlRouterService = Class.forName("com.smartdevicelink.transport.SdlRouterService").newInstance();
-			SdlPacket packet = new SdlPacket(1, false, SdlPacket.FRAME_TYPE_SINGLE, SdlPacket.FRAME_TYPE_CONTROL, 0,sessionId,data.length,123,data);
+			SdlPacket packet = new SdlPacket(4, false, SdlPacket.FRAME_TYPE_SINGLE, SdlPacket.SERVICE_TYPE_RPC, 0, sessionId, data.length, 123, data);
 			method = sdlRouterService.getClass().getDeclaredMethod("sendPacketToRegisteredApp", SdlPacket.class);
-			method.invoke(sdlRouterService, packet);
+			Boolean success = (Boolean) method.invoke(sdlRouterService, packet);
+			System.out.println(success.booleanValue());
+
 
 		} catch (Exception e) {
 			Assert.fail("Exception in sendPacketToRegisteredApp, " + e);

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
@@ -202,7 +202,6 @@ public class SdlRouterServiceTests extends AndroidTestCase {
 			Assert.assertNotNull(sessionMapField.get(sdlRouterService));
 			Assert.assertNotNull(f.get(sdlRouterService));
 			Assert.assertNotNull(f2.get(sdlRouterService));
-			Assert.assertNotSame(f.get(sdlRouterService), f2.get(sdlRouterService));
 
 			// make da RPC
 			UnregisterAppInterface request = new UnregisterAppInterface();
@@ -294,7 +293,6 @@ public class SdlRouterServiceTests extends AndroidTestCase {
 			Assert.assertNotNull(sessionMapField.get(sdlRouterService));
 			Assert.assertNotNull(f.get(sdlRouterService));
 			Assert.assertNotNull(f2.get(sdlRouterService));
-			Assert.assertNotSame(f.get(sdlRouterService), f2.get(sdlRouterService));
 
 			// make da RPC
 			UnregisterAppInterface request = new UnregisterAppInterface();

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1486,15 +1486,15 @@ public class SdlRouterService extends Service{
 						BinaryFrameHeader binFrameHeader = BinaryFrameHeader.parseBinaryHeader(packet.getPayload());
 						if(binFrameHeader!=null && FunctionID.UNREGISTER_APP_INTERFACE.getId() == binFrameHeader.getFunctionID()){
 							Log.d(TAG, "Received an unregister app interface. Checking session hash before sending");
-							// make sure that we don't try and unregister recently added app that might have a
+							// make sure that we don't try to unregister a recently added app that might have a
 							// session ID of a removed app whose UAI was delayed
 							int hashOfRemoved = this.cleanedSessionMap.get(session, -1);
 							int currentHash = this.sessionHashIdMap.get(session, -1);
 							if (hashOfRemoved != -1 && currentHash != -1) {
 								// Current session contains key that was held before
 								if (hashOfRemoved != currentHash){
-									// App assigned same session id but is different app. keep this from being killed
-									Log.i(TAG, "same session id for different apps found, dropping packet");
+									// App assigned same session id but is a different app. Keep this from being killed
+									Log.d(TAG, "same session id for different apps found, dropping packet");
 									this.cleanedSessionMap.clear();
 									return false;
 								}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1447,14 +1447,10 @@ public class SdlRouterService extends Service{
 		 * @return whether or not the sending was successful 
 		 */
 		public boolean sendPacketToRegisteredApp(SdlPacket packet) {
-			Log.i(TAG, "SEND PACKAGE");
 			if(registeredApps!=null && (registeredApps.size()>0)){
-				Log.i(TAG, "INSIDE 1");
 				int session = packet.getSessionId();
 				boolean shouldAssertNewSession = packet.getFrameType() == FrameType.Control && (packet.getFrameInfo() == SdlPacket.FRAME_INFO_START_SERVICE_ACK || packet.getFrameInfo() == SdlPacket.FRAME_INFO_START_SERVICE_NAK);
 	    		String appid = getAppIDForSession(session, shouldAssertNewSession); //Find where this packet should go
-				Log.i(TAG, "APP ID "+ appid);
-				Log.i(TAG, "REGISTERED APPS "+ registeredApps.toString());
 	    		if(appid!=null && appid.length()>0){
 	    			RegisteredApp app;
 	    			synchronized(REGISTERED_APPS_LOCK){
@@ -1486,9 +1482,8 @@ public class SdlRouterService extends Service{
 	    					}
 	    				}
 	    			}
-					Log.i(TAG, "BEFORE CHECK");
+
 					if(packet.getFrameType() == FrameType.Single && packet.getServiceType() == SdlPacket.SERVICE_TYPE_RPC){
-						Log.i(TAG, "INSIDE FIRST IF");
 						BinaryFrameHeader binFrameHeader = BinaryFrameHeader.parseBinaryHeader(packet.getPayload());
 						if(binFrameHeader!=null && FunctionID.UNREGISTER_APP_INTERFACE.getId() == binFrameHeader.getFunctionID()){
 							Log.d(TAG, "Received an unregister app interface. Checking session hash before sending");

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1483,28 +1483,28 @@ public class SdlRouterService extends Service{
 	    				}
 	    			}
 
-					// check and prevent a UAI from being passed to an app that is using a recycled session id
-					if (cleanedSessionMap != null && cleanedSessionMap.size() > 0 ) {
-						if(packet.getFrameType() == FrameType.Single && packet.getServiceType() == SdlPacket.SERVICE_TYPE_RPC) {
-							BinaryFrameHeader binFrameHeader = BinaryFrameHeader.parseBinaryHeader(packet.getPayload());
-							if (binFrameHeader != null && FunctionID.UNREGISTER_APP_INTERFACE.getId() == binFrameHeader.getFunctionID()) {
-								Log.d(TAG, "Received an unregister app interface. Checking session hash before sending");
-								// make sure that we don't try to unregister a recently added app that might have a
-								// session ID of a removed app whose UAI was delayed
-								int hashOfRemoved = this.cleanedSessionMap.get(session, -1);
-								int currentHash = this.sessionHashIdMap.get(session, -1);
-								if (hashOfRemoved != -1) {
-									// Current session contains key that was held before
-									if (hashOfRemoved != currentHash) {
-										// App assigned same session id but is a different app. Keep this from being killed
-										Log.d(TAG, "same session id for different apps found, dropping packet");
-										this.cleanedSessionMap.delete(session);
-										return false;
-									}
+				// check and prevent a UAI from being passed to an app that is using a recycled session id
+				if (cleanedSessionMap != null && cleanedSessionMap.size() > 0 ) {
+					if(packet.getFrameType() == FrameType.Single && packet.getServiceType() == SdlPacket.SERVICE_TYPE_RPC) {
+						BinaryFrameHeader binFrameHeader = BinaryFrameHeader.parseBinaryHeader(packet.getPayload());
+						if (binFrameHeader != null && FunctionID.UNREGISTER_APP_INTERFACE.getId() == binFrameHeader.getFunctionID()) {
+							Log.d(TAG, "Received an unregister app interface. Checking session hash before sending");
+							// make sure that we don't try to unregister a recently added app that might have a
+							// session ID of a removed app whose UAI was delayed
+							int hashOfRemoved = this.cleanedSessionMap.get(session, -1);
+							int currentHash = this.sessionHashIdMap.get(session, -1);
+							if (hashOfRemoved != -1) {
+								// Current session contains key that was held before
+								if (hashOfRemoved != currentHash) {
+									// App assigned same session id but is a different app. Keep this from being killed
+									Log.d(TAG, "same session id for different apps found, dropping packet");
+									this.cleanedSessionMap.delete(session);
+									return false;
 								}
 							}
 						}
 					}
+				}
 
 	    			int packetSize = (int) (packet.getDataSize() + SdlPacket.HEADER_SIZE);
 	    			//Log.i(TAG, "Checking packet size: " + packetSize);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1496,7 +1496,7 @@ public class SdlRouterService extends Service{
 								if (hashOfRemoved != currentHash){
 									// App assigned same session id but is a different app. Keep this from being killed
 									Log.d(TAG, "same session id for different apps found, dropping packet");
-									this.cleanedSessionMap.removeAt(session);
+									this.cleanedSessionMap.delete(session);
 									return false;
 								}
 							}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1483,21 +1483,24 @@ public class SdlRouterService extends Service{
 	    				}
 	    			}
 
-					if(packet.getFrameType() == FrameType.Single && packet.getServiceType() == SdlPacket.SERVICE_TYPE_RPC){
-						BinaryFrameHeader binFrameHeader = BinaryFrameHeader.parseBinaryHeader(packet.getPayload());
-						if(binFrameHeader!=null && FunctionID.UNREGISTER_APP_INTERFACE.getId() == binFrameHeader.getFunctionID()){
-							Log.d(TAG, "Received an unregister app interface. Checking session hash before sending");
-							// make sure that we don't try to unregister a recently added app that might have a
-							// session ID of a removed app whose UAI was delayed
-							int hashOfRemoved = this.cleanedSessionMap.get(session, -1);
-							int currentHash = this.sessionHashIdMap.get(session, -1);
-							if (hashOfRemoved != -1 && currentHash != -1) {
-								// Current session contains key that was held before
-								if (hashOfRemoved != currentHash){
-									// App assigned same session id but is a different app. Keep this from being killed
-									Log.d(TAG, "same session id for different apps found, dropping packet");
-									this.cleanedSessionMap.delete(session);
-									return false;
+	    			// check and prevent a UAI from being passed to an app that is using a recycled session id
+	    			if (cleanedSessionMap != null && cleanedSessionMap.size() > 0 ) {
+						if(packet.getFrameType() == FrameType.Single && packet.getServiceType() == SdlPacket.SERVICE_TYPE_RPC) {
+							BinaryFrameHeader binFrameHeader = BinaryFrameHeader.parseBinaryHeader(packet.getPayload());
+							if (binFrameHeader != null && FunctionID.UNREGISTER_APP_INTERFACE.getId() == binFrameHeader.getFunctionID()) {
+								Log.d(TAG, "Received an unregister app interface. Checking session hash before sending");
+								// make sure that we don't try to unregister a recently added app that might have a
+								// session ID of a removed app whose UAI was delayed
+								int hashOfRemoved = this.cleanedSessionMap.get(session, -1);
+								int currentHash = this.sessionHashIdMap.get(session, -1);
+								if (hashOfRemoved != -1 && currentHash != -1) {
+									// Current session contains key that was held before
+									if (hashOfRemoved != currentHash) {
+										// App assigned same session id but is a different app. Keep this from being killed
+										Log.d(TAG, "same session id for different apps found, dropping packet");
+										this.cleanedSessionMap.delete(session);
+										return false;
+									}
 								}
 							}
 						}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1503,8 +1503,6 @@ public class SdlRouterService extends Service{
 									Log.d(TAG, "same session id for different apps found, dropping packet");
 									this.cleanedSessionMap.clear();
 									return false;
-								} else {
-									return true;
 								}
 							}
 						}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1447,16 +1447,21 @@ public class SdlRouterService extends Service{
 		 * @return whether or not the sending was successful 
 		 */
 		public boolean sendPacketToRegisteredApp(SdlPacket packet) {
+			Log.i(TAG, "SEND PACKAGE");
 			if(registeredApps!=null && (registeredApps.size()>0)){
+				Log.i(TAG, "INSIDE 1");
 				int session = packet.getSessionId();
 				boolean shouldAssertNewSession = packet.getFrameType() == FrameType.Control && (packet.getFrameInfo() == SdlPacket.FRAME_INFO_START_SERVICE_ACK || packet.getFrameInfo() == SdlPacket.FRAME_INFO_START_SERVICE_NAK);
 	    		String appid = getAppIDForSession(session, shouldAssertNewSession); //Find where this packet should go
+				Log.i(TAG, "APP ID "+ appid);
+				Log.i(TAG, "REGISTERED APPS "+ registeredApps.toString());
 	    		if(appid!=null && appid.length()>0){
 	    			RegisteredApp app;
 	    			synchronized(REGISTERED_APPS_LOCK){
 	    				 app = registeredApps.get(appid);
 	    			}
-	    			if(app==null){Log.e(TAG, "No app found for app id " + appid + " Removing session mapping and sending unregisterAI to head unit.");
+	    			if(app==null){
+	    				Log.e(TAG, "No app found for app id " + appid + " Removing session mapping and sending unregisterAI to head unit.");
 	    				//We have no app to match the app id tied to this session
 	    				removeSessionFromMap(session);
 	    				byte[] uai = createForceUnregisterApp((byte)session, (byte)packet.getVersion());
@@ -1481,8 +1486,9 @@ public class SdlRouterService extends Service{
 	    					}
 	    				}
 	    			}
-
+					Log.i(TAG, "BEFORE CHECK");
 					if(packet.getFrameType() == FrameType.Single && packet.getServiceType() == SdlPacket.SERVICE_TYPE_RPC){
+						Log.i(TAG, "INSIDE FIRST IF");
 						BinaryFrameHeader binFrameHeader = BinaryFrameHeader.parseBinaryHeader(packet.getPayload());
 						if(binFrameHeader!=null && FunctionID.UNREGISTER_APP_INTERFACE.getId() == binFrameHeader.getFunctionID()){
 							Log.d(TAG, "Received an unregister app interface. Checking session hash before sending");
@@ -1497,9 +1503,9 @@ public class SdlRouterService extends Service{
 									Log.d(TAG, "same session id for different apps found, dropping packet");
 									this.cleanedSessionMap.clear();
 									return false;
+								} else {
+									return true;
 								}
-								// clean up
-								this.cleanedSessionMap.clear();
 							}
 						}
 					}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1483,8 +1483,8 @@ public class SdlRouterService extends Service{
 	    				}
 	    			}
 
-	    			// check and prevent a UAI from being passed to an app that is using a recycled session id
-	    			if (cleanedSessionMap != null && cleanedSessionMap.size() > 0 ) {
+					// check and prevent a UAI from being passed to an app that is using a recycled session id
+					if (cleanedSessionMap != null && cleanedSessionMap.size() > 0 ) {
 						if(packet.getFrameType() == FrameType.Single && packet.getServiceType() == SdlPacket.SERVICE_TYPE_RPC) {
 							BinaryFrameHeader binFrameHeader = BinaryFrameHeader.parseBinaryHeader(packet.getPayload());
 							if (binFrameHeader != null && FunctionID.UNREGISTER_APP_INTERFACE.getId() == binFrameHeader.getFunctionID()) {
@@ -1493,7 +1493,7 @@ public class SdlRouterService extends Service{
 								// session ID of a removed app whose UAI was delayed
 								int hashOfRemoved = this.cleanedSessionMap.get(session, -1);
 								int currentHash = this.sessionHashIdMap.get(session, -1);
-								if (hashOfRemoved != -1 && currentHash != -1) {
+								if (hashOfRemoved != -1) {
 									// Current session contains key that was held before
 									if (hashOfRemoved != currentHash) {
 										// App assigned same session id but is a different app. Keep this from being killed

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1496,7 +1496,7 @@ public class SdlRouterService extends Service{
 								if (hashOfRemoved != currentHash){
 									// App assigned same session id but is a different app. Keep this from being killed
 									Log.d(TAG, "same session id for different apps found, dropping packet");
-									this.cleanedSessionMap.clear();
+									this.cleanedSessionMap.removeAt(session);
 									return false;
 								}
 							}


### PR DESCRIPTION
Fixes #660 

This PR is **ready** for review.

### Risk

This PR makes **no** API changes.

### Testing Plan

I added 2 tests to handle the 2 cases that might be presented. Using reflection, i create the rare instance where an app who just was cleaned up is beaten by an app registering using the same sessionId. In this case, we check out the sessionHash and if its different (meaning a different app, the UAI packet is dropped). The second test covers the condition where it is the same app and the UAI packet is let through.

### Summary
This PR takes care of a rare race condition. When an app is removed and another app is connecting, there is a chance that the connecting app might be assigned the same session key as the app that was removed. If this happens, the unregister app interface can come back and remove the app that just connected.

Logic:

1. When an app is cleaned up in `attemptToCleanUpModule()`, make note of it
2. When a UAI packet is received, check to see if that session key exists in both the `cleanedSessionMap` and the `sessionHashIdMap`. 
3. If the key exists in both, compare the hash. If it is different, it means another app was assigned that session key and it returns, dropping the UAI packet. If they are the same, it allows it to continue sending the UAI packet

### Remaining Tasks

- [X] - Add tests

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)