### PR TITLE
Feature/issue 606 send multiple RPCS

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
@@ -83,6 +83,7 @@ import com.smartdevicelink.proxy.rpc.UnsubscribeButtonResponse;
 import com.smartdevicelink.proxy.rpc.UnsubscribeVehicleDataResponse;
 import com.smartdevicelink.proxy.rpc.UnsubscribeWayPointsResponse;
 import com.smartdevicelink.proxy.rpc.UpdateTurnListResponse;
+import com.smartdevicelink.proxy.rpc.enums.Result;
 import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
 import com.smartdevicelink.streaming.video.SdlRemoteDisplay;
@@ -201,7 +202,7 @@ public class SdlProxyBaseTests extends AndroidTestCase{
 			}
 
 			@Override
-			public void onError(int correlationID, RPCResponse response) {
+			public void onError(int correlationId, Result resultCode, String info) {
 				assert false;
 			}
 
@@ -255,7 +256,7 @@ public class SdlProxyBaseTests extends AndroidTestCase{
 			}
 
 			@Override
-			public void onError(int correlationID, RPCResponse response) {
+			public void onError(int correlationId, Result resultCode, String info) {
 				assert false;
 			}
 

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
@@ -202,7 +202,7 @@ public class SdlProxyBaseTests extends AndroidTestCase{
 
 			@Override
 			public void onError(int correlationID, RPCResponse response) {
-
+				assert false;
 			}
 
 			@Override
@@ -211,7 +211,7 @@ public class SdlProxyBaseTests extends AndroidTestCase{
 			}
 		};
 		try{
-			//	public void sendRequests(List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
+			// public void sendRequests(List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
 			Method m = SdlProxyBase.class.getDeclaredMethod("sendRequests", SdlProxyBase.class);
 			assertNotNull(m);
 			m.setAccessible(true);
@@ -256,7 +256,7 @@ public class SdlProxyBaseTests extends AndroidTestCase{
 
 			@Override
 			public void onError(int correlationID, RPCResponse response) {
-
+				assert false;
 			}
 
 			@Override
@@ -265,7 +265,7 @@ public class SdlProxyBaseTests extends AndroidTestCase{
 			}
 		};
 		try{
-			//	public void sendSequentialRequests(List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
+			// public void sendSequentialRequests(List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
 			Method m = SdlProxyBase.class.getDeclaredMethod("sendSequentialRequests", SdlProxyBase.class);
 			assertNotNull(m);
 			m.setAccessible(true);

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
@@ -8,7 +8,10 @@ import android.util.Log;
 
 import com.smartdevicelink.exception.SdlException;
 import com.smartdevicelink.exception.SdlExceptionCause;
+import com.smartdevicelink.proxy.RPCRequest;
+import com.smartdevicelink.proxy.RPCResponse;
 import com.smartdevicelink.proxy.SdlProxyALM;
+import com.smartdevicelink.proxy.SdlProxyBase;
 import com.smartdevicelink.proxy.SdlProxyBuilder;
 import com.smartdevicelink.proxy.SdlProxyConfigurationResources;
 import com.smartdevicelink.proxy.callbacks.OnServiceEnded;
@@ -66,6 +69,7 @@ import com.smartdevicelink.proxy.rpc.SetDisplayLayoutResponse;
 import com.smartdevicelink.proxy.rpc.SetGlobalPropertiesResponse;
 import com.smartdevicelink.proxy.rpc.SetInteriorVehicleDataResponse;
 import com.smartdevicelink.proxy.rpc.SetMediaClockTimerResponse;
+import com.smartdevicelink.proxy.rpc.Show;
 import com.smartdevicelink.proxy.rpc.ShowConstantTbtResponse;
 import com.smartdevicelink.proxy.rpc.ShowResponse;
 import com.smartdevicelink.proxy.rpc.SliderResponse;
@@ -80,6 +84,7 @@ import com.smartdevicelink.proxy.rpc.UnsubscribeVehicleDataResponse;
 import com.smartdevicelink.proxy.rpc.UnsubscribeWayPointsResponse;
 import com.smartdevicelink.proxy.rpc.UpdateTurnListResponse;
 import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
+import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
 import com.smartdevicelink.streaming.video.SdlRemoteDisplay;
 import com.smartdevicelink.streaming.video.VideoStreamingParameters;
 import com.smartdevicelink.test.streaming.video.SdlRemoteDisplayTest;
@@ -87,6 +92,8 @@ import com.smartdevicelink.test.streaming.video.SdlRemoteDisplayTest;
 import junit.framework.Assert;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class SdlProxyBaseTests extends AndroidTestCase{
@@ -164,10 +171,110 @@ public class SdlProxyBaseTests extends AndroidTestCase{
 
     public void testMultipleRPCSendSynchronous() {
 
+		List<RPCRequest> rpcs = new ArrayList<>();
+
+		// rpc 1
+		Show show = new Show();
+		show.setMainField1("hey y'all");
+		show.setMainField2("");
+		show.setMainField3("");
+		show.setMainField4("");
+		rpcs.add(show);
+
+		// rpc 2
+		Show show2 = new Show();
+		show2.setMainField1("");
+		show2.setMainField2("It is Wednesday My Dudes");
+		show2.setMainField3("");
+		show2.setMainField4("");
+		rpcs.add(show2);
+
+		OnMultipleRequestListener mrl = new OnMultipleRequestListener() {
+			@Override
+			public void onUpdate(int remainingRequests) {
+
+			}
+
+			@Override
+			public void onFinished() {
+
+			}
+
+			@Override
+			public void onError(int correlationID, RPCResponse response) {
+
+			}
+
+			@Override
+			public void onResponse(int correlationId, RPCResponse response) {
+
+			}
+		};
+		try{
+			//	public void sendRequests(List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
+			Method m = SdlProxyBase.class.getDeclaredMethod("sendRequests", SdlProxyBase.class);
+			assertNotNull(m);
+			m.setAccessible(true);
+			m.invoke(rpcs,mrl);
+			assert true;
+
+		}catch (Exception e){
+			assert false;
+		}
 	}
 
 	public void testMultipleRPCSendAsynchronous() {
 
+		List<RPCRequest> rpcs = new ArrayList<>();
+
+		// rpc 1
+		Show show = new Show();
+		show.setMainField1("hey y'all");
+		show.setMainField2("");
+		show.setMainField3("");
+		show.setMainField4("");
+		rpcs.add(show);
+
+		// rpc 2
+		Show show2 = new Show();
+		show2.setMainField1("");
+		show2.setMainField2("It is Wednesday My Dudes");
+		show2.setMainField3("");
+		show2.setMainField4("");
+		rpcs.add(show2);
+
+		OnMultipleRequestListener mrl = new OnMultipleRequestListener() {
+			@Override
+			public void onUpdate(int remainingRequests) {
+
+			}
+
+			@Override
+			public void onFinished() {
+
+			}
+
+			@Override
+			public void onError(int correlationID, RPCResponse response) {
+
+			}
+
+			@Override
+			public void onResponse(int correlationId, RPCResponse response) {
+
+			}
+		};
+		try{
+			//	public void sendSequentialRequests(List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
+			Method m = SdlProxyBase.class.getDeclaredMethod("sendSequentialRequests", SdlProxyBase.class);
+			assertNotNull(m);
+			m.setAccessible(true);
+			m.invoke(rpcs,mrl);
+			assert true;
+
+		}catch (Exception e){
+			assert false;
+		}
 	}
 
     public class ProxyListenerTest implements IProxyListenerALM {

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SdlProxyBaseTests.java
@@ -162,6 +162,14 @@ public class SdlProxyBaseTests extends AndroidTestCase{
         }
     }
 
+    public void testMultipleRPCSendSynchronous() {
+
+	}
+
+	public void testMultipleRPCSendAsynchronous() {
+
+	}
+
     public class ProxyListenerTest implements IProxyListenerALM {
 
         @Override

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3480,6 +3480,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 						sendSequentialRequests(rpcs, listener);
 					} catch (SdlException e) {
 						e.printStackTrace();
+						listener.onError(correlationId, Result.GENERIC_ERROR, e.toString());
 					}
 				}
 			}

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -142,9 +142,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 								ON_NOTIFICATION_LISTENER_LOCK = new Object();
 	
 	private final Object APP_INTERFACE_REGISTERED_LOCK = new Object();
-
-	// index for sequential RPC sends
-	private int index = 0;
 		
 	private int iFileCount = 0;
 
@@ -3438,7 +3435,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 *
 	 * @param rpcs is the list of RPCRequests being sent
 	 * @param listener listener for updates and completions
-	 * @throws SdlException if an unrecoverable error is encountered  if an unrecoverable error is encountered
+	 * @throws SdlException if an unrecoverable error is encountered
 	 */
 	@SuppressWarnings("unused")
 	public void sendSequentialRequests(final List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
@@ -3455,7 +3452,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}
 		}
 
-		if (rpcs == null || (index == 0 && rpcs.size() == 0)){
+		if (rpcs == null){
 			//Log error here
 			throw new SdlException("You must send some RPCs", SdlExceptionCause.INVALID_ARGUMENT);
 		}
@@ -3465,8 +3462,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		// Break out of recursion, we have finished the requests
 		if (requestCount == 0) {
 			listener.onFinished();
-			// reset index
-			index = 0;
 			return;
 		}
 
@@ -3482,7 +3477,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					// success
 					rpcs.remove(0);
 					listener.onUpdate(rpcs.size());
-					index++;
 					try {
 						// recurse after successful response of RPC
 						sendSequentialRequests(rpcs, listener);
@@ -3505,7 +3499,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 *
 	 * @param rpcs is the list of RPCRequests being sent
 	 * @param listener listener for updates and completions
-	 * @throws SdlException if an unrecoverable error is encountered  if an unrecoverable error is encountered
+	 * @throws SdlException if an unrecoverable error is encountered
 	 */
 	@SuppressWarnings("unused")
 	public void sendRequests(List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
@@ -3584,7 +3578,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * Takes an RPCRequest and sends it to SDL.  Responses are captured through callback on IProxyListener.  
 	 * 
 	 * @param request is the RPCRequest being sent
-	 * @throws SdlException if an unrecoverable error is encountered  if an unrecoverable error is encountered
+	 * @throws SdlException if an unrecoverable error is encountered
 	 */
 	public void sendRPCRequest(RPCRequest request) throws SdlException {
 		if (_proxyDisposed) {

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -93,6 +93,7 @@ import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 import com.smartdevicelink.proxy.rpc.enums.TextAlignment;
 import com.smartdevicelink.proxy.rpc.enums.TouchType;
 import com.smartdevicelink.proxy.rpc.enums.UpdateMode;
+import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
 import com.smartdevicelink.proxy.rpc.listeners.OnPutFileUpdateListener;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCNotificationListener;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
@@ -3424,6 +3425,16 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		} // end-if notification
 
 		SdlTrace.logProxyEvent("Proxy received RPC Message: " + functionName, SDL_LIB_TRACE_KEY);
+	}
+
+	public void sendSequentialRequests(List<RPCMessage> rpcs, OnMultipleRequestListener listener ){
+
+
+	}
+
+	public void sendRequests(List<RPCMessage> rpcs, OnMultipleRequestListener listener){
+
+
 	}
 	
 	/**

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3428,6 +3428,14 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		SdlTrace.logProxyEvent("Proxy received RPC Message: " + functionName, SDL_LIB_TRACE_KEY);
 	}
 
+	/**
+	 * Takes a list of RPCRequests and sends it to SDL in a synchronous fashion. Responses are captured through callback on OnMultipleRequestListener.
+	 * For sending requests asynchronously, use sendRequests
+	 *
+	 * @param rpcs is the list of RPCRequests being sent
+	 * @param listener listener for updates and completions
+	 * @throws SdlException if an unrecoverable error is encountered  if an unrecoverable error is encountered
+	 */
 	@SuppressWarnings("unused")
 	public void sendSequentialRequests(List<RPCMessage> rpcs, OnMultipleRequestListener listener) throws SdlException {
 		if (_proxyDisposed) {
@@ -3446,6 +3454,14 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 	}
 
+	/**
+	 * Takes a list of RPCRequests and sends it to SDL. Responses are captured through callback on OnMultipleRequestListener.
+	 * For sending requests synchronously, use sendSequentialRequests
+	 *
+	 * @param rpcs is the list of RPCRequests being sent
+	 * @param listener listener for updates and completions
+	 * @throws SdlException if an unrecoverable error is encountered  if an unrecoverable error is encountered
+	 */
 	@SuppressWarnings("unused")
 	public void sendRequests(List<RPCMessage> rpcs, OnMultipleRequestListener listener) throws SdlException {
 		if (_proxyDisposed) {

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3494,9 +3494,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			listener.addCorrelationId(rpc.getCorrelationID());
 			rpc.setOnRPCResponseListener(listener.getSingleRpcResponseListener());
 			sendRPCRequestMultiple(rpc);
-		}
 
-		listener.onFinished();
+		}
 	}
 
 	private void sendRPCRequestMultiple(RPCRequest request) throws SdlException {

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -138,7 +138,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 								OUTGOING_MESSAGE_QUEUE_THREAD_LOCK = new Object(),
 								INTERNAL_MESSAGE_QUEUE_THREAD_LOCK = new Object(),
 								ON_UPDATE_LISTENER_LOCK = new Object(),
-								ON_UPDATE_MULTIPLE_LISTENER_LOCK = new Object(),
 								ON_NOTIFICATION_LISTENER_LOCK = new Object();
 	
 	private final Object APP_INTERFACE_REGISTERED_LOCK = new Object();

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3448,7 +3448,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 		SdlTrace.logProxyEvent("Application called sendSequentialRequests", SDL_LIB_TRACE_KEY);
 
-		// Test if SdlConnection is null
 		synchronized(CONNECTION_REFERENCE_LOCK) {
 			if (!getIsConnected()) {
 				SdlTrace.logProxyEvent("Application attempted to call sendSequentialRequests without a connected transport.", SDL_LIB_TRACE_KEY);
@@ -3497,7 +3496,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}
 		});
 
-		sendRPCRequestMultiple(rpc);
+		sendRPCRequestWithCustomListener(rpc);
 	}
 
 	/**
@@ -3517,7 +3516,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 		SdlTrace.logProxyEvent("Application called sendRequests", SDL_LIB_TRACE_KEY);
 
-		// Test if SdlConnection is null
 		synchronized(CONNECTION_REFERENCE_LOCK) {
 			if (!getIsConnected()) {
 				SdlTrace.logProxyEvent("Application attempted to call sendRequests without a connected transport.", SDL_LIB_TRACE_KEY);
@@ -3531,19 +3529,17 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 
 		for (int i = 0; i < rpcs.size(); i++) {
-
 			RPCRequest rpc = rpcs.get(i);
 			if (rpc.getCorrelationID() == null) {
 				rpc.setCorrelationID(CorrelationIdGenerator.generateId());
 			}
 			listener.addCorrelationId(rpc.getCorrelationID());
 			rpc.setOnRPCResponseListener(listener.getSingleRpcResponseListener());
-			sendRPCRequestMultiple(rpc);
-
+			sendRPCRequestWithCustomListener(rpc);
 		}
 	}
 
-	private void sendRPCRequestMultiple(RPCRequest request) throws SdlException {
+	private void sendRPCRequestWithCustomListener(RPCRequest request) throws SdlException {
 		try {
 			SdlTrace.logRPCEvent(InterfaceActivityDirection.Transmit, request, SDL_LIB_TRACE_KEY);
 

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -131,12 +131,13 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 						UNREGISTER_APP_INTERFACE_CORRELATION_ID = 65530,
 						POLICIES_CORRELATION_ID = 65535;
 	
-	// Sdlhronization Objects
+	// Sdl Synchronization Objects
 	private static final Object CONNECTION_REFERENCE_LOCK = new Object(),
 								INCOMING_MESSAGE_QUEUE_THREAD_LOCK = new Object(),
 								OUTGOING_MESSAGE_QUEUE_THREAD_LOCK = new Object(),
 								INTERNAL_MESSAGE_QUEUE_THREAD_LOCK = new Object(),
 								ON_UPDATE_LISTENER_LOCK = new Object(),
+								ON_UPDATE_MULTIPLE_LISTENER_LOCK = new Object(),
 								ON_NOTIFICATION_LISTENER_LOCK = new Object();
 	
 	private final Object APP_INTERFACE_REGISTERED_LOCK = new Object();
@@ -3427,13 +3428,39 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		SdlTrace.logProxyEvent("Proxy received RPC Message: " + functionName, SDL_LIB_TRACE_KEY);
 	}
 
-	public void sendSequentialRequests(List<RPCMessage> rpcs, OnMultipleRequestListener listener ){
+	@SuppressWarnings("unused")
+	public void sendSequentialRequests(List<RPCMessage> rpcs, OnMultipleRequestListener listener) throws SdlException {
+		if (_proxyDisposed) {
+			throw new SdlException("This object has been disposed, it is no long capable of executing methods.", SdlExceptionCause.SDL_PROXY_DISPOSED);
+		}
 
+		SdlTrace.logProxyEvent("Application called sendSequentialRequests", SDL_LIB_TRACE_KEY);
+
+		// Test if SdlConnection is null
+		synchronized(CONNECTION_REFERENCE_LOCK) {
+			if (!getIsConnected()) {
+				SdlTrace.logProxyEvent("Application attempted to call sendSequentialRequests without a connected transport.", SDL_LIB_TRACE_KEY);
+				throw new SdlException("There is no valid connection to SDL. sendSequentialRequests cannot be called until SDL has been connected.", SdlExceptionCause.SDL_UNAVAILABLE);
+			}
+		}
 
 	}
 
-	public void sendRequests(List<RPCMessage> rpcs, OnMultipleRequestListener listener){
+	@SuppressWarnings("unused")
+	public void sendRequests(List<RPCMessage> rpcs, OnMultipleRequestListener listener) throws SdlException {
+		if (_proxyDisposed) {
+			throw new SdlException("This object has been disposed, it is no long capable of executing methods.", SdlExceptionCause.SDL_PROXY_DISPOSED);
+		}
 
+		SdlTrace.logProxyEvent("Application called sendRequests", SDL_LIB_TRACE_KEY);
+
+		// Test if SdlConnection is null
+		synchronized(CONNECTION_REFERENCE_LOCK) {
+			if (!getIsConnected()) {
+				SdlTrace.logProxyEvent("Application attempted to call sendRequests without a connected transport.", SDL_LIB_TRACE_KEY);
+				throw new SdlException("There is no valid connection to SDL. sendRequests cannot be called until SDL has been connected.", SdlExceptionCause.SDL_UNAVAILABLE);
+			}
+		}
 
 	}
 	
@@ -3485,7 +3512,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				
 				SdlTrace.logProxyEvent("Application attempted to send a RegisterAppInterface or UnregisterAppInterface while using ALM.", SDL_LIB_TRACE_KEY);
 				throw new SdlException("The RPCRequest, " + request.getFunctionName() + 
-						", is unallowed using the Advanced Lifecycle Management Model.", SdlExceptionCause.INCORRECT_LIFECYCLE_MODEL);
+						", is un-allowed using the Advanced Lifecycle Management Model.", SdlExceptionCause.INCORRECT_LIFECYCLE_MODEL);
 			}
 		}
 		

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3533,6 +3533,13 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 	}
 
+	/**
+	 * This is very similar to sendRPCRequestPrivate, but does not create a new
+	 * listener object when sending the RPC, since we are using our own custom listeners
+	 *
+	 * @param request is the RPC being sent
+	 * @throws SdlException if an unrecoverable error is encountered
+	 */
 	private void sendRPCRequestWithCustomListener(RPCRequest request) throws SdlException {
 		try {
 			SdlTrace.logRPCEvent(InterfaceActivityDirection.Transmit, request, SDL_LIB_TRACE_KEY);

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3468,9 +3468,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		}
 
 		RPCRequest rpc = rpcs.remove(0);
-		if (rpc.getCorrelationID() == null) {
-			rpc.setCorrelationID(CorrelationIdGenerator.generateId());
-		}
+		rpc.setCorrelationID(CorrelationIdGenerator.generateId());
 
 		rpc.setOnRPCResponseListener(new OnRPCResponseListener() {
 			@Override
@@ -3535,9 +3533,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 		for (int i = 0; i < arraySize; i++) {
 			RPCRequest rpc = rpcs.get(i);
-			if (rpc.getCorrelationID() == null) {
-				rpc.setCorrelationID(CorrelationIdGenerator.generateId());
-			}
+			rpc.setCorrelationID(CorrelationIdGenerator.generateId());
 			listener.addCorrelationId(rpc.getCorrelationID());
 			rpc.setOnRPCResponseListener(listener.getSingleRpcResponseListener());
 			sendRPCRequestPrivate(rpc);

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
@@ -14,15 +14,14 @@ import java.util.Vector;
  */
 public abstract class OnMultipleRequestListener extends OnRPCResponseListener {
 
-	Vector<Integer> correlationIds;
+	final Vector<Integer> correlationIds;
 	OnRPCResponseListener rpcResponseListener;
 	private static String TAG = "OnMultipleRequestListener";
 
 	public OnMultipleRequestListener(){
 		setListenerType(UPDATE_LISTENER_TYPE_MULTIPLE_REQUESTS);
-		if(correlationIds == null){
-			correlationIds = new Vector<>();
-		}
+		correlationIds = new Vector<>();
+
 		rpcResponseListener = new OnRPCResponseListener() {
 			@Override
 			public void onResponse(int correlationId, RPCResponse response) {
@@ -37,12 +36,7 @@ public abstract class OnMultipleRequestListener extends OnRPCResponseListener {
 	}
 
 	public void addCorrelationId(int correlationid){
-		if(correlationIds == null){
-			correlationIds = new Vector<>();
-		}
-
 		correlationIds.add(correlationid);
-		Log.i(TAG, "ADD "+correlationIds.toString());
 	}
 	/**
 	 * onUpdate is called during multiple stream request

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
@@ -1,0 +1,50 @@
+package com.smartdevicelink.proxy.rpc.listeners;
+
+import com.smartdevicelink.proxy.RPCResponse;
+
+import java.util.Vector;
+
+/**
+ * This is the listener for sending Multiple RPCs.
+ */
+public abstract class OnMultipleRequestListener extends OnRPCResponseListener {
+
+	Vector<Integer> correlationIds;
+	OnRPCResponseListener rpcResponseListener;
+
+	public OnMultipleRequestListener(){
+		setListenerType(UPDATE_LISTENER_TYPE_MULTIPLE_REQUESTS);
+		correlationIds = new Vector<>();
+		rpcResponseListener = new OnRPCResponseListener() {
+			@Override
+			public void onResponse(int correlationId, RPCResponse response) {
+				correlationIds.remove(correlationId);
+				if(correlationIds.size()>0){
+					onUpdate(correlationIds.size());
+				}else{
+					onFinished();
+				}
+			}
+		};
+	}
+	public void setCorrelationIds(Vector<Integer> correlationIds){
+		this.correlationIds = correlationIds;
+	}
+
+	public void addCorrelationId(int correlationid){
+		if(correlationIds == null){
+			correlationIds = new Vector<>();
+		}
+		correlationIds.add(correlationid);
+	}
+	/**
+	 * onUpdate is called during multiple stream request
+	 * @param remainingRequests of the original request
+	 */
+	public abstract void onUpdate(int remainingRequests);
+	public abstract void onFinished();
+
+	public OnRPCResponseListener getSingleRpcResponseListener(){
+		return rpcResponseListener;
+	}
+}

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
@@ -50,7 +50,7 @@ public abstract class OnMultipleRequestListener extends OnRPCResponseListener {
 	 */
 	public abstract void onUpdate(int remainingRequests);
 	public abstract void onFinished();
-	public abstract void onError(int correlationID, RPCResponse response);
+	public abstract void onError(int correlationId, Result resultCode, String info);
 
 	public OnRPCResponseListener getSingleRpcResponseListener(){
 		return rpcResponseListener;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
@@ -1,5 +1,7 @@
 package com.smartdevicelink.proxy.rpc.listeners;
 
+import android.util.Log;
+
 import com.smartdevicelink.proxy.RPCResponse;
 
 import java.util.Vector;
@@ -11,14 +13,18 @@ public abstract class OnMultipleRequestListener extends OnRPCResponseListener {
 
 	Vector<Integer> correlationIds;
 	OnRPCResponseListener rpcResponseListener;
+	private static String TAG = "OnMultipleRequestListener";
 
 	public OnMultipleRequestListener(){
 		setListenerType(UPDATE_LISTENER_TYPE_MULTIPLE_REQUESTS);
-		correlationIds = new Vector<>();
+		if(correlationIds == null){
+			correlationIds = new Vector<>();
+		}
 		rpcResponseListener = new OnRPCResponseListener() {
 			@Override
 			public void onResponse(int correlationId, RPCResponse response) {
-				correlationIds.remove(correlationId);
+				Log.i(TAG, "OR "+correlationIds.toString());
+				correlationIds.remove(Integer.valueOf(correlationId));
 				if(correlationIds.size()>0){
 					onUpdate(correlationIds.size());
 				}else{
@@ -27,15 +33,14 @@ public abstract class OnMultipleRequestListener extends OnRPCResponseListener {
 			}
 		};
 	}
-	public void setCorrelationIds(Vector<Integer> correlationIds){
-		this.correlationIds = correlationIds;
-	}
 
 	public void addCorrelationId(int correlationid){
 		if(correlationIds == null){
 			correlationIds = new Vector<>();
 		}
+
 		correlationIds.add(correlationid);
+		Log.i(TAG, "ADD "+correlationIds.toString());
 	}
 	/**
 	 * onUpdate is called during multiple stream request

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
@@ -3,6 +3,9 @@ package com.smartdevicelink.proxy.rpc.listeners;
 import android.util.Log;
 
 import com.smartdevicelink.proxy.RPCResponse;
+import com.smartdevicelink.proxy.rpc.enums.Result;
+
+import org.json.JSONException;
 
 import java.util.Vector;
 
@@ -23,13 +26,17 @@ public abstract class OnMultipleRequestListener extends OnRPCResponseListener {
 		rpcResponseListener = new OnRPCResponseListener() {
 			@Override
 			public void onResponse(int correlationId, RPCResponse response) {
-				Log.i(TAG, "OR "+correlationIds.toString());
 				correlationIds.remove(Integer.valueOf(correlationId));
 				if(correlationIds.size()>0){
 					onUpdate(correlationIds.size());
 				}else{
 					onFinished();
 				}
+			}
+
+			@Override
+			public void onError(int correlationId, Result resultCode, String info){
+				// bad stuff happening
 			}
 		};
 	}

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnMultipleRequestListener.java
@@ -33,11 +33,6 @@ public abstract class OnMultipleRequestListener extends OnRPCResponseListener {
 					onFinished();
 				}
 			}
-
-			@Override
-			public void onError(int correlationId, Result resultCode, String info){
-				// bad stuff happening
-			}
 		};
 	}
 
@@ -55,6 +50,7 @@ public abstract class OnMultipleRequestListener extends OnRPCResponseListener {
 	 */
 	public abstract void onUpdate(int remainingRequests);
 	public abstract void onFinished();
+	public abstract void onError(int correlationID, RPCResponse response);
 
 	public OnRPCResponseListener getSingleRpcResponseListener(){
 		return rpcResponseListener;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnRPCResponseListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnRPCResponseListener.java
@@ -12,6 +12,10 @@ public abstract class OnRPCResponseListener {
 	 * Listener type specific to putfile
 	 */
 	public final static int UPDATE_LISTENER_TYPE_PUT_FILE 		= 1;
+	/**
+	 * Listener type specific to putfile
+	 */
+	public final static int UPDATE_LISTENER_TYPE_MULTIPLE_REQUESTS 		= 2;
 
 	/**
 	 * Stores what type of listener this instance is. This prevents of from having to use reflection

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnRPCResponseListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/listeners/OnRPCResponseListener.java
@@ -13,7 +13,7 @@ public abstract class OnRPCResponseListener {
 	 */
 	public final static int UPDATE_LISTENER_TYPE_PUT_FILE 		= 1;
 	/**
-	 * Listener type specific to putfile
+	 * Listener type specific to sendRequests and sendSequentialRequests
 	 */
 	public final static int UPDATE_LISTENER_TYPE_MULTIPLE_REQUESTS 		= 2;
 


### PR DESCRIPTION
Fixes #606 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
As testing this is challenging (requiring response from a core instance), the tests were mainly carried out against Manticore. Unit tests were added, but at this point cannot test full functionality as we cannot mock core. 

### Summary
Added 2 public methods:

- sendSequentialRequests - Allows multiple RPCRequests to be sent in an ArrayList and guarantees that they are executed in order.
- sendRequests - Allows multiple RPCRequests to be send in an ArrayList with no guarantee for order.

### Tasks Remaining:
- [x] Finish Async method
- [x] Finish synchronous method
- [x] Unit tests

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)