### PR TITLE
[WIP] Bugfix/issue 570 USB disconnecting is causing a deadlock 

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -14,6 +14,7 @@ import com.smartdevicelink.protocol.ProtocolMessage;
 import com.smartdevicelink.protocol.SdlPacket;
 import com.smartdevicelink.protocol.WiProProtocol;
 import com.smartdevicelink.protocol.enums.SessionType;
+import com.smartdevicelink.proxy.SdlProxyBase;
 import com.smartdevicelink.transport.BTTransport;
 import com.smartdevicelink.transport.BTTransportConfig;
 import com.smartdevicelink.transport.BaseTransportConfig;
@@ -385,8 +386,13 @@ public class SdlConnection implements IProtocolListener, ITransportListener {
 			}else{
 				cachedMultiConfig = null; //It should now be consumed
 			}
-			for (SdlSession session : listenerList) {
-				session.onTransportError(info, e);
+
+			// If proxy disposing is in progress, then we don't have to worry about the listenerList
+			// because proxy.dispose() will take care of the sessions
+			if (!SdlProxyBase._disposing) {
+				for (SdlSession session : listenerList) {
+					session.onTransportError(info, e);
+				}
 			}
 
 		}

--- a/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -325,10 +325,6 @@ public class SdlConnection implements IProtocolListener, ITransportListener {
 	
 	public void unregisterSession(SdlSession registerListener) {
 		boolean didRemove = listenerList.remove(registerListener);
-		// Notify the thread that is running onTransportError() to continue
-		synchronized (SESSION_LOCK) {
-			SESSION_LOCK.notify();
-		}
 		if(didRemove && _transport !=null  && _transport.getTransportType()== TransportType.MULTIPLEX){ //If we're connected we can request the extra session now
 			((MultiplexTransport)_transport).removeSession(registerListener.getSessionId());
 		}		
@@ -388,17 +384,6 @@ public class SdlConnection implements IProtocolListener, ITransportListener {
 				cachedMultiConfig.setService(null); //Make sure we're clearning this out
 			}else{
 				cachedMultiConfig = null; //It should now be consumed
-			}
-			// Wait for the sessions to be unregistered
-			// if the thread didn't wait, it will continue looping through the sessions
-			// even though, other thread may be closing them, which may cause a deadlock
-			try {
-				synchronized (SESSION_LOCK) {
-					// if we have any deadlock issues in the future, we may need to increase the wait duration
-					SESSION_LOCK.wait(250);
-				}
-			} catch (InterruptedException e1) {
-				e1.printStackTrace();
 			}
 			for (SdlSession session : listenerList) {
 				session.onTransportError(info, e);

--- a/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -121,7 +121,7 @@ public class SdlConnection implements IProtocolListener, ITransportListener {
 			{
                 _transport = new TCPTransport((TCPTransportConfig) transportConfig, this);
             } else if (transportConfig.getTransportType() == TransportType.USB) {
-                _transport = new USBTransport((USBTransportConfig) transportConfig, this);
+                _transport = USBTransport.getInstance((USBTransportConfig) transportConfig, this);
             }
 		}
 		

--- a/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -385,8 +385,14 @@ public class SdlConnection implements IProtocolListener, ITransportListener {
 			}else{
 				cachedMultiConfig = null; //It should now be consumed
 			}
-			for (SdlSession session : listenerList) {
-				session.onTransportError(info, e);
+
+			// Prevents current thread from locking CONNECTION_REFERENCE_LOCK
+			// if it has already locked PROTOCOL_REFERENCE_LOCK
+			// without this condition, a deadlock may happen
+			if (!Thread.holdsLock(PROTOCOL_REFERENCE_LOCK)) {
+				for (SdlSession session : listenerList) {
+					session.onTransportError(info, e);
+				}
 			}
 
 		}

--- a/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -394,7 +394,7 @@ public class SdlConnection implements IProtocolListener, ITransportListener {
 			// even though, other thread may be closing them, which may cause a deadlock
 			try {
 				synchronized (SESSION_LOCK) {
-					// if we have any deadlocks] issues in the future, we may need to increase the wait duration
+					// if we have any deadlock issues in the future, we may need to increase the wait duration
 					SESSION_LOCK.wait(250);
 				}
 			} catch (InterruptedException e1) {

--- a/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlSession.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlSession.java
@@ -65,8 +65,8 @@ public class SdlSession implements ISdlConnectionListener, IHeartbeatMonitorList
 	private HashMap<SessionType, CopyOnWriteArrayList<ISdlServiceListener>> serviceListeners;
 	private VideoStreamingParameters desiredVideoParams = null;
 	private VideoStreamingParameters acceptedVideoParams = null;
+	private boolean isRegistered = false;
 
-    
 	public static SdlSession createSession(byte wiproVersion, ISdlConnectionListener listener, BaseTransportConfig btConfig) {
 		
 		SdlSession session =  new SdlSession();
@@ -133,6 +133,14 @@ public class SdlSession implements ISdlConnectionListener, IHeartbeatMonitorList
 		} else {
 			return 0;
 		}
+	}
+
+	public boolean getIsRegistered() {
+		return isRegistered;
+	}
+
+	public void setIsRegistered(boolean isRegistered) {
+		this.isRegistered = isRegistered;
 	}
 
 	public void close() {

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -155,6 +155,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	private boolean pcmServiceEndResponse = false;
 	private boolean rpcProtectedResponseReceived = false;
 	private boolean rpcProtectedStartResponse = false;
+	public static volatile boolean _disposing = false;
 	
 	// Device Info for logging
 	private TraceDeviceInfo _traceDeviceInterrogator = null;
@@ -1426,7 +1427,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * Terminates the App's Interface Registration, closes the transport connection, ends the protocol session, and frees any resources used by the proxy.
 	 */
 	public void dispose() throws SdlException
-	{		
+	{
+		_disposing = true;
+
 		if (_proxyDisposed) {
 			throw new SdlException("This object has been disposed, it is no long capable of executing methods.", SdlExceptionCause.SDL_PROXY_DISPOSED);
 		}
@@ -1469,6 +1472,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			
 		} finally {
 			SdlTrace.logProxyEvent("SdlProxy disposed.", SDL_LIB_TRACE_KEY);
+			_disposing = false;
 		}
 	} // end-method
 

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -155,7 +155,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	private boolean pcmServiceEndResponse = false;
 	private boolean rpcProtectedResponseReceived = false;
 	private boolean rpcProtectedStartResponse = false;
-	public static volatile boolean _disposing = false;
 	
 	// Device Info for logging
 	private TraceDeviceInfo _traceDeviceInterrogator = null;
@@ -372,7 +371,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				if(SdlConnection.isLegacyModeEnabled()){
 					cycleProxy(SdlDisconnectedReason.LEGACY_BLUETOOTH_MODE_ENABLED);
 
-				}else{
+				}else if (sdlSession != null && sdlSession.getIsRegistered()){
 					cycleProxy(SdlDisconnectedReason.TRANSPORT_ERROR);
 				}
 			} else {
@@ -1428,8 +1427,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 */
 	public void dispose() throws SdlException
 	{
-		_disposing = true;
-
 		if (_proxyDisposed) {
 			throw new SdlException("This object has been disposed, it is no long capable of executing methods.", SdlExceptionCause.SDL_PROXY_DISPOSED);
 		}
@@ -1472,7 +1469,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			
 		} finally {
 			SdlTrace.logProxyEvent("SdlProxy disposed.", SDL_LIB_TRACE_KEY);
-			_disposing = false;
 		}
 	} // end-method
 

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
@@ -36,7 +36,7 @@ import com.smartdevicelink.util.DebugTool;
 public class USBTransport extends SdlTransport {
 
 	// Boolean to monitor if the transport is in a disconnecting state
-	private static volatile boolean _disconnected = false;
+	private boolean _disconnecting = false;
 	/**
      * Broadcast action: sent when a USB accessory is attached.
      *
@@ -354,11 +354,11 @@ public class USBTransport extends SdlTransport {
     private void disconnect(String msg, Exception ex) {
 	    
 		// If already disconnecting, return
-        if (_disconnected) {
+        if (_disconnecting) {
             // No need to recursively call
             return;
         }
-        _disconnected = true;
+        _disconnecting = true;
 
         mConfig.setUsbAccessory(null);
 
@@ -440,6 +440,7 @@ public class USBTransport extends SdlTransport {
                         "; doing nothing");
                 break;
         }
+        _disconnecting = false;
     }
 
     /**

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
@@ -162,7 +162,10 @@ public class USBTransport extends SdlTransport {
      * @see USBTransportReader
      */
     private Thread mReaderThread = null;
-
+    /**
+     * Reference to the singleton instance of the class.
+     */
+    private static USBTransport instance = null;
     /**
      * Constructs the USBTransport instance.
      *
@@ -170,11 +173,24 @@ public class USBTransport extends SdlTransport {
      * @param transportListener  Listener that gets notified on different
      *                           transport events
      */
-    public USBTransport(USBTransportConfig usbTransportConfig,
+    private USBTransport(USBTransportConfig usbTransportConfig,
                         ITransportListener transportListener) {
         super(transportListener);
         this.mConfig = usbTransportConfig;
     	registerReciever();
+    }
+    /**
+     * Get the singlton instance of the class.
+     *
+     * @param usbTransportConfig Config object for the USB transport
+     * @param transportListener  Listener that gets notified on different
+     *                           transport events
+     */
+    public static USBTransport getInstance(USBTransportConfig usbTransportConfig, ITransportListener transportListener){
+        if (instance == null){
+            instance = new USBTransport(usbTransportConfig, transportListener);
+        }
+        return instance;
     }
 
     /**
@@ -351,7 +367,7 @@ public class USBTransport extends SdlTransport {
      * @param msg Disconnect reason message, if any
      * @param ex  Disconnect exception, if any
      */
-    private void disconnect(String msg, Exception ex) {
+    private synchronized void disconnect(String msg, Exception ex) {
 	    
 		// If already disconnecting, return
         if (_disconnecting) {

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
@@ -36,7 +36,7 @@ import com.smartdevicelink.util.DebugTool;
 public class USBTransport extends SdlTransport {
 
 	// Boolean to monitor if the transport is in a disconnecting state
-	private boolean _disconnecting = false;
+	private static volatile boolean _disconnected = false;
 	/**
      * Broadcast action: sent when a USB accessory is attached.
      *
@@ -227,13 +227,13 @@ public class USBTransport extends SdlTransport {
                         } catch (IOException e) {
                             final String msg = "Failed to send bytes over USB";
                             logW(msg, e);
-                            handleTransportError(msg, e);
+                            disconnect(msg, e);
                         }
                     } else {
                         final String msg =
                                 "Can't send bytes when output stream is null";
                         logW(msg);
-                        handleTransportError(msg, null);
+                        disconnect(msg,null);
                     }
                 break;
 
@@ -354,11 +354,11 @@ public class USBTransport extends SdlTransport {
     private void disconnect(String msg, Exception ex) {
 	    
 		// If already disconnecting, return
-        if (_disconnecting) {
+        if (_disconnected) {
             // No need to recursively call
             return;
         }
-        _disconnecting = true;
+        _disconnected = true;
 
         mConfig.setUsbAccessory(null);
 
@@ -440,7 +440,6 @@ public class USBTransport extends SdlTransport {
                         "; doing nothing");
                 break;
         }
-        _disconnecting = false;
     }
 
     /**

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
@@ -162,10 +162,7 @@ public class USBTransport extends SdlTransport {
      * @see USBTransportReader
      */
     private Thread mReaderThread = null;
-    /**
-     * Reference to the singleton instance of the class.
-     */
-    private static USBTransport instance = null;
+
     /**
      * Constructs the USBTransport instance.
      *
@@ -173,24 +170,11 @@ public class USBTransport extends SdlTransport {
      * @param transportListener  Listener that gets notified on different
      *                           transport events
      */
-    private USBTransport(USBTransportConfig usbTransportConfig,
+    public USBTransport(USBTransportConfig usbTransportConfig,
                         ITransportListener transportListener) {
         super(transportListener);
         this.mConfig = usbTransportConfig;
-    	registerReciever();
-    }
-    /**
-     * Get the singlton instance of the class.
-     *
-     * @param usbTransportConfig Config object for the USB transport
-     * @param transportListener  Listener that gets notified on different
-     *                           transport events
-     */
-    public static USBTransport getInstance(USBTransportConfig usbTransportConfig, ITransportListener transportListener){
-        if (instance == null){
-            instance = new USBTransport(usbTransportConfig, transportListener);
-        }
-        return instance;
+        registerReciever();
     }
 
     /**
@@ -368,7 +352,9 @@ public class USBTransport extends SdlTransport {
      * @param ex  Disconnect exception, if any
      */
     private synchronized void disconnect(String msg, Exception ex) {
-	    
+
+        stopReaderThread();
+
 		// If already disconnecting, return
         if (_disconnecting) {
             // No need to recursively call
@@ -386,12 +372,9 @@ public class USBTransport extends SdlTransport {
                     logI("Disconnect from state " + getState() + "; message: " +
                             msg + "; exception: " + ex);
                     setState(State.IDLE);
-
                     SdlTrace.logTransportEvent(TAG + ": disconnect", null,
                             InterfaceActivityDirection.None, null, 0,
                             SDL_LIB_TRACE_KEY);
-
-                    stopReaderThread();
 
                     if (mAccessory != null) {
                         if (mOutputStream != null) {


### PR DESCRIPTION
Fixes #570 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
I tested the fix manually by trying to connect/disconnect the USB cable 30 times continuously for multiple times. The app didn't freeze after disconnecting the cable.


### Summary
The deadlock happens when:
* USBTransportReader thread locks PROTOCOL_REFERENCE_LOCK in SdlConnection.java
* Main thread locks CONNECTION_REFERENCE_LOCK in SdlProxyBase.java 
* Main thread waits to lock PROTOCOL_REFERENCE_LOCK that is already locked by USBTransportReader thread 
* After that, in most case, USBTransportReader thread releases PROTOCOL_REFERENCE_LOCK and things go without a problem. But in some rare cases, USBTransportReader thread waits to lock CONNECTION_REFERENCE_LOCK  before releasing PROTOCOL_REFERENCE_LOCK which causes a deadlock between the two threads.

The scenario is little complicated but basically, when the connection is broken, the following  might happen:
* When we call proxy.dispose(), main thread tries to clean the proxy, unregister the sessions, and remove them from listenerList
* Main thread gets delayed and execution is switched to USBTransportReader thread
* USBTransportReader thread tries to run the following loop: 

     > for (SdlSession session : listenerList) {
&nbsp;&nbsp;session.onTransportError(info, e);
}

In normal cases, The loop shouldn't run because main thread should have already cleaned listenerList. But because the main thread got delayed, the loop runs and causes a deadlock.

The PR prevents the rare case from happening by:
* adding a flag to SdlSession to check if one thread unregistered the session, the other threads don't do actions on it
* making USBTransport.disconnect() synchronized 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)