### PR TITLE
#688 Handle a RuntimeException crash

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
@@ -18,6 +18,7 @@ import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
 import android.util.Log;
+import android.os.Looper;
 
 public class SdlRouterStatusProvider {
 

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
@@ -128,6 +128,7 @@ public class SdlRouterStatusProvider {
 		final WeakReference<SdlRouterStatusProvider> provider;
 
 		 public ClientHandler(SdlRouterStatusProvider provider){
+			 super(Looper.getMainLooper());
 			 this.provider = new WeakReference<SdlRouterStatusProvider>(provider);
 		 }
 		 


### PR DESCRIPTION
Fixes [issue 688](https://github.com/smartdevicelink/sdl_android/issues/688).

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Manual testing, verify that library does not crash when flow is initiated from a background thread.

### Summary
Attach the main looper when creating ClientHandler in SdlRouterStatusProvider

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)