### PR TITLE
Handle router service foreground notification removal

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1063,10 +1063,10 @@ public class SdlRouterService extends Service{
         builder.setOngoing(true);
 
         if(chronometerLength > 0) {
-			builder.setWhen(chronometerLength + System.currentTimeMillis());
-			builder.setUsesChronometer(true);
-			builder.setChronometerCountDown(true);
-		}
+        	builder.setWhen(chronometerLength + System.currentTimeMillis());
+        	builder.setUsesChronometer(true);
+        	builder.setChronometerCountDown(true);
+        }
         
         Notification notification;
         if(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN){

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1110,6 +1110,7 @@ public class SdlRouterService extends Service{
 			}
 
 			this.stopForeground(true);
+			isForeground = false;
 		}
 	}
 	


### PR DESCRIPTION
Fixes #698 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan

##### Adapter power cycle

###### Test 1: Target <= 25
1. Turn off bluetooth adapter on device
2. Change targetAPI to 25 or lower and deploy app
3. Turn on Bluetooth
4. Router service notification should be displayed
5a. If no connection is made, notification should disappear after 10 seconds. 
5b. If a connection is made, notification should remain and contain connected devices bluetooth name

###### Test 2: Target >= 26
1. Turn off bluetooth adapter on device
2. Change targetAPI to 26 or higher and deploy app
3. Turn on Bluetooth
4. Router service notification should not be displayed as the implicit intent is not received from the OS

### Summary
A new handler and runnable were added to the router service that will be run 10 seconds after the service enters the foreground, or 20 seconds if A2DP is in the process of or already connected. The timeout will be canceled if a connection is made. 

Even if the service is to be removed from the foreground, the service will remain in the background until Android kills it or a connection is made. 

### Changelog

##### Bug Fixes
* Fixes #698 where the notification would remain even if there was no connection made. It is believed that in 8.0 when targeting API 25 or lower the intent `android.bluetooth.adapter.action.STATE_CHANGED` was never sent, however, in 8.1 it is which caused the issue to be more apparent. 

### Tasks Remaining:
- [x] Create timer to remove notification
- [x] Update notification to display better text

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)