### PR TITLE
Bugfix/issue 687 - send intents explicitly

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/transport/SdlRouterServiceTests.java
@@ -152,7 +152,7 @@ public class SdlRouterServiceTests extends AndroidTestCase {
 	 *
 	 * @see SdlRouterService#sendPacketToRegisteredApp(SdlPacket)
 	 */
-	public void testRegisterAppExistingSessionIDDifferntApp() {
+	public void testRegisterAppExistingSessionIDDifferentApp() {
 		if (Looper.myLooper() == null) {
 			Looper.prepare();
 		}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -2036,11 +2036,12 @@ public class SdlRouterService extends Service{
 	}
 
 	/**
-	 * Iterate through all of apps that we know are listening for this intent
+	 * Iterate through all of the apps that we know are listening for this intent
 	 * with an explicit intent (necessary for Android O SDK 26+)
 	 *
 	 * @param intent - the intent to send explicitly
-	 * @param isRepeatingPings - If this is coming from a method that will repeat pings, we will use a cached list instead of querying each ping
+	 * @param isRepeatingPings - If this is coming from a method that will repeat pings,
+	 * we will use a cached list instead of querying each ping
 	 */
 	private void sendExplicitBroadcast(Intent intent, Boolean isRepeatingPings) {
 
@@ -2048,7 +2049,7 @@ public class SdlRouterService extends Service{
 			sdlApps = getPackageManager().queryBroadcastReceivers(intent, 0);
 		}
 
-		if(sdlApps != null && sdlApps.size()>0){
+		if (sdlApps != null && sdlApps.size()>0) {
 			for(ResolveInfo app: sdlApps){
 				intent.setClassName(app.activityInfo.applicationInfo.packageName, app.activityInfo.name);
 				sendBroadcast(intent);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -2055,8 +2055,12 @@ public class SdlRouterService extends Service{
 
 		if (apps != null && apps.size()>0) {
 			for(ResolveInfo app: apps){
-				intent.setClassName(app.activityInfo.applicationInfo.packageName, app.activityInfo.name);
-				sendBroadcast(intent);
+				try {
+					intent.setClassName(app.activityInfo.applicationInfo.packageName, app.activityInfo.name);
+					sendBroadcast(intent);
+				}catch(Exception e){
+					//In case there is missing info in the app reference we want to keep moving
+				}
 			}
 		}
 	}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -2038,20 +2038,23 @@ public class SdlRouterService extends Service{
 	}
 
 	/**
-	 * Iterate through all of the apps that we know are listening for this intent
-	 * with an explicit intent (necessary for Android O SDK 26+)
+	 * Sends the provided intent to the specified destinations making it an explicit intent, rather
+	 * than an implicit intent. A direct replacement of sendBroadcast(Intent). As of Android 8.0
+	 * (API 26+) implicit broadcasts are no longer sent to broadcast receivers that are declared via
+	 * the AndroidManifest.
 	 *
 	 * @param intent - the intent to send explicitly
-	 * @param sdlApps - if needed, pass in a specific list of apps to send the broadcast to, or let us query it here
+	 * @param apps - the list of apps that this broadcast will be sent to. If null is passed in
+	 *                the intent will be sent to all SDL enabled apps via a query the package manager
 	 */
-	private void sendExplicitBroadcast(Intent intent, List<ResolveInfo> sdlApps) {
+	private void sendExplicitBroadcast(Intent intent, List<ResolveInfo> apps) {
 
-		if (sdlApps == null) {
-			sdlApps = getPackageManager().queryBroadcastReceivers(intent, 0);
+		if (apps == null) {
+			apps = getPackageManager().queryBroadcastReceivers(intent, 0);
 		}
 
-		if (sdlApps != null && sdlApps.size()>0) {
-			for(ResolveInfo app: sdlApps){
+		if (apps != null && apps.size()>0) {
+			for(ResolveInfo app: apps){
 				intent.setClassName(app.activityInfo.applicationInfo.packageName, app.activityInfo.name);
 				sendBroadcast(intent);
 			}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1266,7 +1266,7 @@ public class SdlRouterService extends Service{
 		}
 		
 		cachedModuleVersion = -1; //Reset our cached version
-		if(registeredApps != null && !registeredApps.isEmpty()){
+		if(registeredApps != null){
 			Message message = Message.obtain();
 			message.what = TransportConstants.HARDWARE_CONNECTION_EVENT;
 			Bundle bundle = new Bundle();


### PR DESCRIPTION
Fixes #687 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested new method on TDK using a local versions of Hello Sdl Android to make sure nothing bad happened. Tested on `targetSdkVersion`'s of 25 and 26

### Summary
- Some broadcast intents in the `SdlRouterService` were being sent implicitly, while android O+ requires them to be sent explicitly. Created a new private method to do just that and modified the broadcasts which need it to use the new method.

- Removed an unnecessary unregister intent in `onTransportDisconnected` in which a broadcast was sent out when there were no registered apps. 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)