### PR TITLE
Minor Usb transport improvements and explicit broadcast refactor

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -25,6 +25,7 @@ import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.util.Log;
 
+import com.smartdevicelink.util.AndroidTools;
 import com.smartdevicelink.util.HttpRequestTask;
 import com.smartdevicelink.util.HttpRequestTask.HttpRequestTaskCallback;
 
@@ -166,7 +167,7 @@ public class RouterServiceValidator {
 		if(BluetoothAdapter.getDefaultAdapter()!=null && BluetoothAdapter.getDefaultAdapter().isEnabled()){
 			Intent intent = new Intent(TransportConstants.START_ROUTER_SERVICE_ACTION);
 			intent.putExtra(TransportConstants.PING_ROUTER_SERVICE_EXTRA, true);
-			context.sendBroadcast(intent);
+			AndroidTools.sendExplicitBroadcast(context,intent,null);
 		}
 	}
 	public ComponentName getService(){

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -397,7 +397,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 				Intent serviceIntent = new Intent();
 				serviceIntent.setAction(TransportConstants.START_ROUTER_SERVICE_ACTION);
 				serviceIntent.putExtra(TransportConstants.PING_ROUTER_SERVICE_EXTRA, true);
-	    		context.sendBroadcast(serviceIntent);
+	    		AndroidTools.sendExplicitBroadcast(context,serviceIntent,null);
 			}
 			if(callback!=null){
 				callback.onConnectionStatusUpdate(false, null,context);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -638,7 +638,7 @@ public class SdlRouterService extends Service{
 	        			if(service.pingIntent == null){
 	        				service.initPingIntent();
 	        			}
-	        			service.sendExplicitBroadcast(service.pingIntent, null);
+	        			AndroidTools.sendExplicitBroadcast(service.getApplicationContext(),service.pingIntent, null);
 	        		}
 	        		break;
 	        	default:
@@ -1223,7 +1223,7 @@ public class SdlRouterService extends Service{
 			startService.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
 		}
 
-		sendExplicitBroadcast(startService, null);
+		AndroidTools.sendExplicitBroadcast(getApplicationContext(),startService, null);
 
 		//HARDWARE_CONNECTED
     	if(!(registeredApps== null || registeredApps.isEmpty())){
@@ -2012,7 +2012,7 @@ public class SdlRouterService extends Service{
 					sdlApps = getPackageManager().queryBroadcastReceivers(pingIntent, 0);
 				}
 
-				sendExplicitBroadcast(pingIntent, sdlApps);
+				AndroidTools.sendExplicitBroadcast(getApplicationContext(), pingIntent, sdlApps);
 				synchronized(PING_COUNT_LOCK){
 					pingCount++;
 				}
@@ -2037,34 +2037,6 @@ public class SdlRouterService extends Service{
 		pingIntent = null;
 	}
 
-	/**
-	 * Sends the provided intent to the specified destinations making it an explicit intent, rather
-	 * than an implicit intent. A direct replacement of sendBroadcast(Intent). As of Android 8.0
-	 * (API 26+) implicit broadcasts are no longer sent to broadcast receivers that are declared via
-	 * the AndroidManifest.
-	 *
-	 * @param intent - the intent to send explicitly
-	 * @param apps - the list of apps that this broadcast will be sent to. If null is passed in
-	 *                the intent will be sent to all SDL enabled apps via a query the package manager
-	 */
-	private void sendExplicitBroadcast(Intent intent, List<ResolveInfo> apps) {
-
-		if (apps == null) {
-			apps = getPackageManager().queryBroadcastReceivers(intent, 0);
-		}
-
-		if (apps != null && apps.size()>0) {
-			for(ResolveInfo app: apps){
-				try {
-					intent.setClassName(app.activityInfo.applicationInfo.packageName, app.activityInfo.name);
-					sendBroadcast(intent);
-				}catch(Exception e){
-					//In case there is missing info in the app reference we want to keep moving
-				}
-			}
-		}
-	}
-	
 	/* ****************************************************************************************************************************************
 	// **********************************************************   TINY CLASSES   ************************************************************
 	//*****************************************************************************************************************************************/

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
@@ -2,9 +2,12 @@ package com.smartdevicelink.transport;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.ResolveInfo;
 import android.hardware.usb.UsbManager;
 import android.os.Bundle;
 import android.util.Log;
+
+import java.util.List;
 
 /**
  * The USBAccessoryAttachmentActivity is a proxy to listen for
@@ -67,7 +70,18 @@ public class USBAccessoryAttachmentActivity extends Activity {
                     .putExtra(UsbManager.EXTRA_PERMISSION_GRANTED,
                             intent.getParcelableExtra(
                                     UsbManager.EXTRA_PERMISSION_GRANTED));
-            sendBroadcast(usbAccessoryAttachedIntent);
+
+            List<ResolveInfo> apps = getPackageManager().queryBroadcastReceivers(usbAccessoryAttachedIntent, 0);
+            if (apps != null && apps.size()>0) {
+                for(ResolveInfo app: apps){
+                    try {
+                        usbAccessoryAttachedIntent.setClassName(app.activityInfo.applicationInfo.packageName, app.activityInfo.name);
+                        sendBroadcast(usbAccessoryAttachedIntent);
+                    }catch(Exception e){
+                        //In case there is missing info in the app reference we want to keep moving
+                    }
+                }
+            }
         }
 
         finish();

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
@@ -7,6 +7,8 @@ import android.hardware.usb.UsbManager;
 import android.os.Bundle;
 import android.util.Log;
 
+import com.smartdevicelink.util.AndroidTools;
+
 import java.util.List;
 
 /**
@@ -71,17 +73,9 @@ public class USBAccessoryAttachmentActivity extends Activity {
                             intent.getParcelableExtra(
                                     UsbManager.EXTRA_PERMISSION_GRANTED));
 
-            List<ResolveInfo> apps = getPackageManager().queryBroadcastReceivers(usbAccessoryAttachedIntent, 0);
-            if (apps != null && apps.size()>0) {
-                for(ResolveInfo app: apps){
-                    try {
-                        usbAccessoryAttachedIntent.setClassName(app.activityInfo.applicationInfo.packageName, app.activityInfo.name);
-                        sendBroadcast(usbAccessoryAttachedIntent);
-                    }catch(Exception e){
-                        //In case there is missing info in the app reference we want to keep moving
-                    }
-                }
-            }
+
+            AndroidTools.sendExplicitBroadcast(getApplicationContext(),usbAccessoryAttachedIntent,null);
+
         }
 
         finish();

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
@@ -199,9 +199,7 @@ public class USBTransport extends SdlTransport {
     /**
      * Sends the array of bytes over USB.
      *
-     * @param msgBytes Array of bytes to send
-     * @param offset   Offset in the array to start from
-     * @param length   Number of bytes to send
+     * @param packet The packet that is to be written out on the USB transport
      * @return true if the bytes are sent successfully
      */
     @Override
@@ -420,6 +418,12 @@ public class USBTransport extends SdlTransport {
                 String disconnectMsg = (msg == null ? "" : msg);
                 if (ex != null) {
                     disconnectMsg += ", " + ex.toString();
+
+                    if(ex instanceof SdlException
+                            && SdlExceptionCause.SDL_USB_PERMISSION_DENIED.equals(((SdlException)ex).getSdlExceptionCause())){
+                        //If the USB device disconnected we don't want to cycle the proxy ourselves
+                        ex = null;
+                    }
                 }
 
                 if (ex == null) {

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransport.java
@@ -227,13 +227,13 @@ public class USBTransport extends SdlTransport {
                         } catch (IOException e) {
                             final String msg = "Failed to send bytes over USB";
                             logW(msg, e);
-                            handleTransportError(msg, e);
+                            disconnect(msg, e);
                         }
                     } else {
                         final String msg =
                                 "Can't send bytes when output stream is null";
                         logW(msg);
-                        handleTransportError(msg, null);
+                        disconnect(msg, null);
                     }
                 break;
 

--- a/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -126,12 +126,14 @@ public class AndroidTools {
 	 * Sends the provided intent to the specified destinations making it an explicit intent, rather
 	 * than an implicit intent. A direct replacement of sendBroadcast(Intent). As of Android 8.0
 	 * (API 26+) implicit broadcasts are no longer sent to broadcast receivers that are declared via
-	 * the AndroidManifest.
+	 * the AndroidManifest. Ihe method will also send the broadcast implicitly if no list of apps is
+	 * provided for backwards comparability.
 	 *
 	 * @param intent - the intent to send explicitly
 	 * @param apps - the list of apps that this broadcast will be sent to. If null is passed in
 	 *                the intent will be sent to all apps that match the provided intent via a query
-	 *                to the package manager
+	 *                to the package manager; it will also be sent implicitly to mimic
+	 *                sendBroadcast()'s original functionality.
 	 */
 	public static void sendExplicitBroadcast(Context context, Intent intent, List<ResolveInfo> apps) {
 
@@ -141,6 +143,7 @@ public class AndroidTools {
 
 		if (apps == null) {
 			apps = context.getPackageManager().queryBroadcastReceivers(intent, 0);
+			context.sendBroadcast(intent);
 		}
 
 		if (apps != null && apps.size()>0) {

--- a/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -121,4 +121,38 @@ public class AndroidTools {
 		return sdlAppInfoList;
 	}
 
+
+	/**
+	 * Sends the provided intent to the specified destinations making it an explicit intent, rather
+	 * than an implicit intent. A direct replacement of sendBroadcast(Intent). As of Android 8.0
+	 * (API 26+) implicit broadcasts are no longer sent to broadcast receivers that are declared via
+	 * the AndroidManifest.
+	 *
+	 * @param intent - the intent to send explicitly
+	 * @param apps - the list of apps that this broadcast will be sent to. If null is passed in
+	 *                the intent will be sent to all apps that match the provided intent via a query
+	 *                to the package manager
+	 */
+	public static void sendExplicitBroadcast(Context context, Intent intent, List<ResolveInfo> apps) {
+
+		if(context == null || intent == null){
+			return;
+		}
+
+		if (apps == null) {
+			apps = context.getPackageManager().queryBroadcastReceivers(intent, 0);
+		}
+
+		if (apps != null && apps.size()>0) {
+			for(ResolveInfo app: apps){
+				try {
+					intent.setClassName(app.activityInfo.applicationInfo.packageName, app.activityInfo.name);
+					context.sendBroadcast(intent);
+				}catch(Exception e){
+					//In case there is missing info in the app reference we want to keep moving
+				}
+			}
+		}
+	}
+
 }

--- a/sdl_android/src/main/res/xml/accessory_filter.xml
+++ b/sdl_android/src/main/res/xml/accessory_filter.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resource>
+    <usb-accessory
+        manufacturer="SDL"
+        model="Core"
+        version="1.0"/>
+</resource>


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Default USB testing plan will work for this PR

### Changelog

##### Enhancements

* Added the `accessory_filter.xml` to the res values

##### Bug Fixes

* Fixed direct call to `onTransportError`
* Prevent proxy cycle from happening if USB has been disconnected
* Fixed javadoc
* Fixed USB connection intent from being implicit
* Refactored explicit broadcast method to AndroidTools
* Fix RSV implicit broadcast

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)