### PR TITLE
#480 fixed deadlock when exception is thrown in BTTransport.disconnect

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/BTTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/BTTransport.java
@@ -46,6 +46,8 @@ public class BTTransport extends SdlTransport {
 	
 	// Boolean to monitor if the transport is in a disconnecting state
     private boolean _disconnecting = false;
+
+	private final Object DISCONNECT_LOCK = new Object();
 	
 	public BTTransport(ITransportListener transportListener) {
 		super(transportListener);
@@ -229,13 +231,15 @@ public class BTTransport extends SdlTransport {
 	 * @param msg
 	 * @param ex
 	 */
-	private synchronized void disconnect(String msg, Exception ex) {		
-		// If already disconnecting, return
-		if (_disconnecting) {
-			// No need to recursively call
-			return;
-		}		
-		_disconnecting = true;
+	private void disconnect(String msg, Exception ex) {
+		synchronized(DISCONNECT_LOCK) {
+			// If already disconnecting, return
+			if (_disconnecting) {
+				// No need to recursively call
+				return;
+			}
+			_disconnecting = true;
+		}
 		
 		String disconnectMsg = (msg == null ? "" : msg);
 		if (ex != null) {


### PR DESCRIPTION
Fixes #480

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
-/-

### Summary
switched BTTransport.disconnect from snychronized method to synchronized code block

### Changelog
##### Bug Fixes
* fixed deadlock when exception occurs in BTTransport.disconnect

### Tasks Remaining:
### CLA
- [X ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)