### PR TITLE
#703 Logging library version

### DIFF
--- a/sdl_android/build.gradle
+++ b/sdl_android/build.gradle
@@ -9,6 +9,7 @@ android {
         versionCode 2
         versionName "4.3.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        resValue "string", "SDL_LIB_VERSION", '\"' + versionName + '\"'
     }
     buildTypes {
         release {

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -41,6 +41,7 @@ import android.view.Display;
 import android.view.MotionEvent;
 import android.view.Surface;
 
+import com.smartdevicelink.BuildConfig;
 import com.smartdevicelink.Dispatcher.IDispatchingStrategy;
 import com.smartdevicelink.Dispatcher.ProxyMessageDispatcher;
 import com.smartdevicelink.SdlConnection.ISdlConnectionListener;
@@ -592,6 +593,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 								   String autoActivateID, boolean callbackToUIThread, Boolean preRegister, String sHashID, Boolean bAppResumeEnab,
 								   BaseTransportConfig transportConfig) throws SdlException
 	{
+		Log.i(TAG, "SDL_LIB_VERSION: " + BuildConfig.VERSION_NAME);
 		setWiProVersion((byte)PROX_PROT_VER_ONE);
 		
 		if (preRegister != null && preRegister)

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -593,7 +593,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 								   String autoActivateID, boolean callbackToUIThread, Boolean preRegister, String sHashID, Boolean bAppResumeEnab,
 								   BaseTransportConfig transportConfig) throws SdlException
 	{
-		Log.i(TAG, "SDL_LIB_VERSION: " + BuildConfig.VERSION_NAME);
+		Log.i(TAG, "SDL_LIB_VERSION: " + Version.VERSION);
 		setWiProVersion((byte)PROX_PROT_VER_ONE);
 		
 		if (preRegister != null && preRegister)

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/Version.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/Version.java
@@ -1,5 +1,7 @@
 package com.smartdevicelink.proxy;
 
+import com.smartdevicelink.BuildConfig;
+
 public class Version {
-	public static final String VERSION = "VERSION-INFO";
+	public static final String VERSION = BuildConfig.VERSION_NAME;
 }


### PR DESCRIPTION
- Add log line in SdlProxyBase.performCommon()
- Add line in gradle file to generate xml file that has library version string

Fixes [#703](https://github.com/smartdevicelink/sdl_android/issues/703)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Connect with head unit and verify library version is logged.
Verify that xml file is generated with library version string.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)