### PR TITLE
Fixes #706 & #708

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3464,7 +3464,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 		// Break out of recursion, we have finished the requests
 		if (requestCount == 0) {
-			listener.onFinished();
+			if(listener != null){
+				listener.onFinished();
+			}
 			return;
 		}
 
@@ -3476,20 +3478,26 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			public void onResponse(int correlationId, RPCResponse response) {
 				if (response.getSuccess()) {
 					// success
-					listener.onUpdate(rpcs.size());
+					if(listener!=null){
+						listener.onUpdate(rpcs.size());
+					}
 					try {
 						// recurse after successful response of RPC
 						sendSequentialRequests(rpcs, listener);
 					} catch (SdlException e) {
 						e.printStackTrace();
-						listener.onError(correlationId, Result.GENERIC_ERROR, e.toString());
+						if(listener != null){
+							listener.onError(correlationId, Result.GENERIC_ERROR, e.toString());
+						}
 					}
 				}
 			}
 
 			@Override
 			public void onError(int correlationId, Result resultCode, String info){
-				listener.onError(correlationId, resultCode, info);
+				if(listener != null){
+					listener.onError(correlationId, resultCode, info);
+				}
 			}
 		});
 
@@ -3536,8 +3544,10 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		for (int i = 0; i < arraySize; i++) {
 			RPCRequest rpc = rpcs.get(i);
 			rpc.setCorrelationID(CorrelationIdGenerator.generateId());
-			listener.addCorrelationId(rpc.getCorrelationID());
-			rpc.setOnRPCResponseListener(listener.getSingleRpcResponseListener());
+			if(listener != null) {
+				listener.addCorrelationId(rpc.getCorrelationID());
+				rpc.setOnRPCResponseListener(listener.getSingleRpcResponseListener());
+			}
 			sendRPCRequestPrivate(rpc);
 		}
 	}

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3441,7 +3441,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @throws SdlException if an unrecoverable error is encountered
 	 */
 	@SuppressWarnings("unused")
-	public void sendSequentialRequests(final List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
+	public void sendSequentialRequests(final List<? extends RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
 		if (_proxyDisposed) {
 			throw new SdlException("This object has been disposed, it is no long capable of executing methods.", SdlExceptionCause.SDL_PROXY_DISPOSED);
 		}
@@ -3507,7 +3507,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @throws SdlException if an unrecoverable error is encountered
 	 */
 	@SuppressWarnings("unused")
-	public void sendRequests(List<RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
+	public void sendRequests(List<? extends RPCRequest> rpcs, final OnMultipleRequestListener listener) throws SdlException {
 
 		if (_proxyDisposed) {
 			throw new SdlException("This object has been disposed, it is no long capable of executing methods.", SdlExceptionCause.SDL_PROXY_DISPOSED);


### PR DESCRIPTION
Fixes #706 & #708

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.



### Summary
Instead of requiring type of strictly `RPCRequest`, list param was changed to `? extends RPCRequest` type.

Also adds check for null around listener for same methods.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)