### PR TITLE
Add more recoverability to TransportBroker

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
@@ -501,6 +501,7 @@ public class TransportBroker {
 			
 			if(!sendBindingIntent()){
 				Log.e(TAG, "Something went wrong while trying to bind with the router service.");
+				SdlBroadcastReceiver.queryForConnectedService(currentContext);
 				return false;
 			}
 			return true;


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan

1. Install more than 1 SDL app.
2. Connect BT
3. Kill the app that has started the Router Service 
4. Wait
5. Router service will be started again and hardware will eventually reconnect

### Summary
Added a call to `SdlBroadcastReceiver.queryForConnectedService` if the `TransportBroker` was unable to bind to the Router Service. Likely because the service itself is not running.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)