### PR TITLE
added list check to speechcapabilities

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
@@ -9,6 +9,7 @@ import com.smartdevicelink.proxy.rpc.enums.PrerecordedSpeech;
 import com.smartdevicelink.proxy.rpc.enums.SpeechCapabilities;
 import com.smartdevicelink.proxy.rpc.enums.VrCapabilities;
 
+import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
 
@@ -229,7 +230,16 @@ public class RegisterAppInterfaceResponse extends RPCResponse {
 	 */
     @SuppressWarnings("unchecked")
     public List<SpeechCapabilities> getSpeechCapabilities() {
-		return (List<SpeechCapabilities>) getObject(SpeechCapabilities.class, KEY_SPEECH_CAPABILITIES);
+    	Object speechCapabilities = getObject(SpeechCapabilities.class, KEY_SPEECH_CAPABILITIES);
+		if (speechCapabilities instanceof List<?>) {
+			return (List<SpeechCapabilities>) speechCapabilities;
+		} else if (speechCapabilities instanceof SpeechCapabilities) {
+			// this is a known issue observed with some core implementations
+			List<SpeechCapabilities> newSpeechCapList = new ArrayList<>();
+			newSpeechCapList.add((SpeechCapabilities) speechCapabilities);
+			return newSpeechCapList;
+		}
+		return null;
     }
     /**
      * Sets speechCapabilities
@@ -355,5 +365,5 @@ public class RegisterAppInterfaceResponse extends RPCResponse {
 
     public String getSystemSoftwareVersion() {    
     	 return getString(KEY_SYSTEM_SOFTWARE_VERSION);
-    } 
+    }
 }


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This was tested against a Ford TDK

### Summary
There are some rare occurrences where the stored `speechCapability` object is a not a list, and it is supposed to be. We check to see if the response is a list, and if not, that its an instance of `SpeechCapabilities` and return a list with that as its only object. If neither of these happen we return null as something went wrong. 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)