### PR TITLE
Catch NetworkOnMainThreadException when writing to TCP

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/TCPTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/TCPTransport.java
@@ -6,6 +6,9 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.os.NetworkOnMainThreadException;
 import android.util.Log;
 
 import com.smartdevicelink.exception.SdlException;
@@ -107,6 +110,7 @@ public class TCPTransport extends SdlTransport {
      * @param length Number of bytes to send
      * @return True if data was sent successfully, False otherwise
      */
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     @Override
     protected boolean sendBytesOverTransport(SdlPacket packet) {
         TCPTransportState currentState = getCurrentState();
@@ -123,7 +127,7 @@ public class TCPTransport extends SdlTransport {
                         mOutputStream.write(msgBytes, 0, msgBytes.length);
                         bResult = true;
                         logInfo("TCPTransport.sendBytesOverTransport: successfully send data");
-                    } catch (IOException e) {
+                    } catch (IOException | NetworkOnMainThreadException e) {
                         logError("TCPTransport.sendBytesOverTransport: error during sending data: " + e.getMessage());
                         bResult = false;
                     }


### PR DESCRIPTION
This will catch a previously unresolved case.

Fixes #721 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.
* `sendBytesOverTransport()` function must target API 11. Shouldn't be an issue since other parts of the library target this version or higher, and TCP transport is geared for development purposes only

### Testing Plan
In testing the scenario provided in the issue, the previous exception that was causing a crash (`NetworkOnMainThreadException`) is caught and handled instead of causing the app to crash.

### Summary
- Catch block was expanded to catch `NetworkOnMainThreadException` in addition to `IOException`
- Correspondingly, `sendBytesOverTransport()` function must target API 11

### Changelog
##### Breaking Changes
##### Enhancements
##### Bug Fixes

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)