### PR TITLE
Put timeoutHandler for ServiceFinder on MainLooper so it doesn’t fail

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/util/ServiceFinder.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/util/ServiceFinder.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ResolveInfo;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 
 import com.smartdevicelink.transport.SdlRouterService;
@@ -51,7 +52,7 @@ public class ServiceFinder {
                 onFinished();
             }
         };
-        timeoutHandler = new Handler();
+        timeoutHandler = new Handler(Looper.getMainLooper());
         timeoutHandler.postDelayed(timeoutRunnable, TIMEOUT + (50 * packageName.length()));
 
         //Send out our broadcast


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan

1. Install more than 1 SDL app.
2. Connect BT
3. Kill the app that has started the Router Service
4. Wait
5. Router service will be started again and hardware will eventually reconnect
6. Repeat test a few times

### Changelog
##### Bug Fixes
* Put the handler inside the `ServiceFinder` class on the main looper to avoid the runnable not being posted


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)