### PR TITLE
Pinging all running BT services on wake up

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -210,6 +210,10 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 						if (altTransportWake) {
 							wakeRouterServiceAltTransport(context);
 							return;
+						}else{
+							for(ComponentName service : runningBluetoothServicePackage){
+								pingRouterService(context,service.getPackageName(),service.getClassName());
+							}
 						}
 						return;
 					}


### PR DESCRIPTION
Fixes #742 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
Tested successfully on branch 

https://github.com/smartdevicelink/sdl_android/compare/develop...feature/mt_multiplexing

with situation described in issue - Router Service running with USB transport, then BT is toggled from OFF to ON. Can look into unit tests if necessary.

##### Bug Fixes
* Fixes bug described in issue.

### CLA
- [ X ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)