### PR TITLE
 Pass Proguard Settings to Dev App

### DIFF
--- a/sdl_android/build.gradle
+++ b/sdl_android/build.gradle
@@ -9,11 +9,11 @@ android {
         versionName "4.5.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         resValue "string", "SDL_LIB_VERSION", '\"' + versionName + '\"'
+        consumerProguardFiles 'proguard-rules.pro'
     }
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         debug {
             testCoverageEnabled = true

--- a/sdl_android/proguard-rules.pro
+++ b/sdl_android/proguard-rules.pro
@@ -9,6 +9,7 @@
 
 # Add any project specific keep options here:
 -keep class com.smartdevicelink** { *; }
+-keep class com.livio.BSON** { *; }
 
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface

--- a/sdl_android/proguard-rules.pro
+++ b/sdl_android/proguard-rules.pro
@@ -8,6 +8,7 @@
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
 # Add any project specific keep options here:
+-keep class com.smartdevicelink** { *; }
 
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface


### PR DESCRIPTION
Fixes #766 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Follow steps described in issue.

### Summary
Added Proguard setting to prevent obfuscation of `com.smartdevicelink` package and another line in `build.gradle` to pass this setting to any app using SDL.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* Prevents described issue

##### Bug Fixes
* Fixes #766 

### CLA
- [ X ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)