### PR TITLE
WIP Bugfix/issue 761 potential NPE with usb and multiplexing app

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -87,16 +87,19 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 		boolean didStart = false;
 		if (localRouterClass == null){
 			localRouterClass = defineLocalSdlRouterClass();
-			ResolveInfo info = context.getPackageManager().resolveService(new Intent(context,localRouterClass),PackageManager.GET_META_DATA);
-			if(info != null){
-					if(info.filter == null || !info.filter.hasAction(TransportConstants.ROUTER_SERVICE_ACTION)){
+			// we need to check this again because for USB apps, the returned class can still be null
+			if (localRouterClass != null) {
+				ResolveInfo info = context.getPackageManager().resolveService(new Intent(context, localRouterClass), PackageManager.GET_META_DATA);
+				if (info != null) {
+					if (info.filter == null || !info.filter.hasAction(TransportConstants.ROUTER_SERVICE_ACTION)) {
 						Log.e(TAG, "WARNING: This application has not specified its intent-filter for the SdlRouterService. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
 					}
-					if( info.serviceInfo.metaData == null || !info.serviceInfo.metaData.containsKey(context.getString(R.string.sdl_router_service_version_name))) {
+					if (info.serviceInfo.metaData == null || !info.serviceInfo.metaData.containsKey(context.getString(R.string.sdl_router_service_version_name))) {
 						Log.e(TAG, "WARNING: This application has not specified its metadata tags for the SdlRouterService. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
 					}
-			}else{
-				Log.e(TAG, "WARNING: This application has not specified its SdlRouterService correctly in the manifest. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
+				} else {
+					Log.e(TAG, "WARNING: This application has not specified its SdlRouterService correctly in the manifest. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
+				}
 			}
 		}
         


### PR DESCRIPTION
Fixes #761 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test against Ford TDK unit to ensure no crashing

### Summary
Because USB app sets `defineLocalSdlRouterClass()` as null since it does not use multiplexing, a multiplexing app can still try and send a broadcast to it, resulting in an NPE. We add a second check to the `localRouterClass` object to ensure its not null to satisfy this case.

### Tasks Remaining:
- [ ] Test it out

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)