### PR TITLE
Less intrusive Router Service Notification

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -55,6 +55,7 @@ public class MultiplexBluetoothTransport {
     private static final String NAME_SECURE =" SdlRouterService";
     // Key names received from the BluetoothSerialServer Handler
     public static final String DEVICE_NAME = "device_name";
+    public static final String DEVICE_ADDRESS = "device_address";
     public static final String TOAST = "toast";
     private static final long MS_TILL_TIMEOUT = 2500;
     private static final int READ_BUFFER_SIZE = 4096;
@@ -259,15 +260,17 @@ public class MultiplexBluetoothTransport {
         mConnectedWriteThread = new ConnectedWriteThread(socket);
         mConnectedWriteThread.start();
 
-        //Store a static name of the device that is connected.
-        if(device!=null){
-        	currentlyConnectedDevice = device.getName();
-        }
+
         
         // Send the name of the connected device back to the UI Activity
         Message msg = mHandler.obtainMessage(SdlRouterService.MESSAGE_DEVICE_NAME);
         Bundle bundle = new Bundle();
-        bundle.putString(DEVICE_NAME, currentlyConnectedDevice);
+        //Store a static name of the device that is connected.
+        currentlyConnectedDevice = device.getName();
+        if(currentlyConnectedDevice != null){
+            bundle.putString(DEVICE_NAME, currentlyConnectedDevice);
+            bundle.putString(DEVICE_ADDRESS, device.getAddress());
+        }
         msg.setData(bundle);
         mHandler.sendMessage(msg);
         setState(STATE_CONNECTED);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -6,7 +6,6 @@ import static com.smartdevicelink.transport.TransportConstants.HARDWARE_DISCONNE
 import static com.smartdevicelink.transport.TransportConstants.SEND_PACKET_TO_APP_LOCATION_EXTRA_NAME;
 
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -34,12 +33,12 @@ import android.app.NotificationManager;
 import android.app.Service;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
-import android.bluetooth.BluetoothProfile;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
@@ -122,7 +121,12 @@ public class SdlRouterService extends Service{
 	
     @SuppressWarnings("FieldCanBeLocal")
 	private final int UNREGISTER_APP_INTERFACE_CORRELATION_ID = 65530;
-    
+
+	/**
+	 * Preference location where the service stores known SDL status based on device address
+	 */
+	protected static final String SDL_DEVICE_STATUS_SHARED_PREFS = "sdl.device.status";
+
 	private MultiplexBluetoothTransport mSerialService = null;
 
 	private static boolean connectAsClient = false;
@@ -891,15 +895,14 @@ public class SdlRouterService extends Service{
 		}
 		if(intent != null ){
 			if(intent.getBooleanExtra(FOREGROUND_EXTRA, false)){
-
-				BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
-				int timeout = FOREGROUND_TIMEOUT;
-				int state = adapter.getProfileConnectionState(BluetoothProfile.A2DP);
-				if(state == BluetoothAdapter.STATE_CONNECTED){
-					//If we've just connected over A2DP there is a fair chance we want to wait to
-					// listen for a connection so we double our wait time
-					timeout *= 2;
+				String address = null;
+				if(intent.hasExtra(BluetoothDevice.EXTRA_DEVICE)){
+					BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+					if(device != null){
+						address = device.getAddress();
+					}
 				}
+				int timeout = getNotificationTimeout(address);
 				enterForeground("Waiting for connection...", timeout);
 				resetForegroundTimeOut(timeout);
 			}
@@ -991,6 +994,31 @@ public class SdlRouterService extends Service{
 				e.printStackTrace();
 			}
 		}
+	}
+
+	/**
+	 * Gets the correct timeout for the foreground notification.
+	 * @param address the address of the device that is currently connected
+	 * @return the amount of time for a timeout handler to remove the notification.
+	 */
+	@SuppressLint("MissingPermission")
+	private int getNotificationTimeout(String address){
+		BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+		if(address != null){
+			if(hasSDLConnected(address)){
+				return FOREGROUND_TIMEOUT * 2;
+			}else if(this.isFirstStatusCheck(address)){
+				// If this is the first time the service has ever connected to this device we want
+				// to give it a few extra seconds.
+				setSDLConnectedStatus(address,false);
+				return FOREGROUND_TIMEOUT;
+			}else{
+				// If the service has seen this device before but hasn't ever connected, the
+				// notification can be removed ASAP.
+				return FOREGROUND_TIMEOUT/100;
+			}
+		}
+		return FOREGROUND_TIMEOUT/100;
 	}
 
 	public void resetForegroundTimeOut(long delay){
@@ -1320,7 +1348,11 @@ public class SdlRouterService extends Service{
 				SdlRouterService service = this.provider.get();
 	            switch (msg.what) {
 	            	case MESSAGE_DEVICE_NAME:
-						service.connectedDeviceName = msg.getData().getString(MultiplexBluetoothTransport.DEVICE_NAME);
+						Bundle bundle = msg.getData();
+						if(bundle !=null) {
+							service.connectedDeviceName = bundle.getString(MultiplexBluetoothTransport.DEVICE_NAME);
+							service.setSDLConnectedStatus(bundle.getString(MultiplexBluetoothTransport.DEVICE_ADDRESS),true);
+						}
 	            		break;
 	            	case MESSAGE_STATE_CHANGE:
 	            		switch (msg.arg1) {
@@ -1716,6 +1748,39 @@ public class SdlRouterService extends Service{
 		{		
 			return 0;
 		}
+
+	/**
+	 * Set the connection establishment status of the particular device
+	 * @param address address of the device in quesiton
+	 * @param hasSDLConnected true if a connection has been established, false if not
+	 */
+	protected void setSDLConnectedStatus(String address, boolean hasSDLConnected){
+		SharedPreferences preferences = this.getSharedPreferences(SDL_DEVICE_STATUS_SHARED_PREFS, Context.MODE_PRIVATE);
+		SharedPreferences.Editor editor = preferences.edit();
+		editor.putBoolean(address,hasSDLConnected);
+		editor.commit();
+	}
+
+	/**
+	 * Checks to see if a device address has connected to SDL before.
+	 * @param address the mac address of the device in quesiton
+	 * @return if this is the first status check of this device
+	 */
+	protected boolean isFirstStatusCheck(String address){
+		SharedPreferences preferences = this.getSharedPreferences(SDL_DEVICE_STATUS_SHARED_PREFS, Context.MODE_PRIVATE);
+		return !preferences.contains(address) ;
+	}
+	/**
+	 * Checks to see if a device address has connected to SDL before.
+	 * @param address the mac address of the device in quesiton
+	 * @return if an SDL connection has ever been established with this device
+	 */
+	protected boolean hasSDLConnected(String address){
+		SharedPreferences preferences = this.getSharedPreferences(SDL_DEVICE_STATUS_SHARED_PREFS, Context.MODE_PRIVATE);
+		return preferences.contains(address) && preferences.getBoolean(address,false);
+	}
+
+
 	
 	/* ***********************************************************************************************************************************************************************
 	 * *****************************************************************  CUSTOM ADDITIONS  ************************************************************************************


### PR DESCRIPTION

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
1. Clear testing app memory or reinstall it from device
2. Connect bluetooth to device (TDK, bluetooth headset)
3. First time should have a timeout of 10 seconds
4. Disconnect device
5. Reconnect device
    1.  If device previously connected through SDL the timeout should be upped to 20 seconds. 
    2. If device did not connect through SDL, timeout should be 100ms.


### Summary
Add better logic to create less intrusive notifications for end users. The first time a device is connected to through normal BT profiles the router service will remain open for 10 seconds. If the device is found to not connect through SDL, the timeout will decrease significantly and the notification will essentially not be displayed.


### Changelog

##### Enhancements
* Less intrusive notifications for end users

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)