### PR TITLE
Feature/issue 778  - Create a webpage to explain why SDL notification pops up

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -108,7 +108,7 @@ public class SdlRouterService extends Service{
 	
 	public static final String REGISTER_NEWER_SERVER_INSTANCE_ACTION		= "com.sdl.android.newservice";
 
-	public static final String SDL_NOTIFICATION_FAQS_PAGE = "https://smartdevicelink.com/en/guides/pull_request/c716225aba9c037d4fb62ad868f7c890a111445a/frequently-asked-questions/sdl-notifications/";
+	public static final String SDL_NOTIFICATION_FAQS_PAGE = "https://smartdevicelink.com/en/guides/android/frequently-asked-questions/sdl-notifications/";
 
 	/**
 	 * @deprecated use {@link TransportConstants#START_ROUTER_SERVICE_ACTION} instead

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -31,6 +31,7 @@ import android.app.ActivityManager.RunningAppProcessInfo;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.app.Service;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
@@ -45,6 +46,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.DeadObjectException;
@@ -105,6 +107,9 @@ public class SdlRouterService extends Service{
 	private static final long CLIENT_PING_DELAY = 1000;
 	
 	public static final String REGISTER_NEWER_SERVER_INSTANCE_ACTION		= "com.sdl.android.newservice";
+
+	public static final String SDL_NOTIFICATION_FAQS_PAGE = "https://smartdevicelink.com/en/guides/pull_request/c716225aba9c037d4fb62ad868f7c890a111445a/frequently-asked-questions/sdl-notifications/";
+
 	/**
 	 * @deprecated use {@link TransportConstants#START_ROUTER_SERVICE_ACTION} instead
 	 */
@@ -1062,6 +1067,11 @@ public class SdlRouterService extends Service{
 		}
         builder.setLargeIcon(icon);
         builder.setOngoing(true);
+
+		// Create an intent that will be fired when the user clicks the notification.
+		Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(SDL_NOTIFICATION_FAQS_PAGE));
+		PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
+		builder.setContentIntent(pendingIntent);
 
         if(chronometerLength > 0) {
         	builder.setWhen(chronometerLength + System.currentTimeMillis());


### PR DESCRIPTION
Fixes #778 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
No testing is required for this PR

### Summary
This PR makes the router service notification clickable. When the user clicks on it, a webpage that has info about the SDL notifications opens.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)