### PR TITLE
Fixes #765 - Remove reflection dependency on Android SDK classes

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/BTTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/BTTransport.java
@@ -10,6 +10,7 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothServerSocket;
 import android.bluetooth.BluetoothSocket;
+import android.os.Build;
 import android.os.Build.VERSION;
 
 import com.smartdevicelink.SdlConnection.SdlConnection;
@@ -57,8 +58,14 @@ public class BTTransport extends SdlTransport {
 		super(transportListener);
 		bKeepSocketActive = bKeepSocket;		
 	} // end-ctor	
-	
+
+	@Deprecated
 	public BluetoothSocket getBTSocket(BluetoothServerSocket bsSocket){
+
+		if(bsSocket == null || Build.VERSION.SDK_INT > Build.VERSION_CODES.O) { //Reflection is no longer allowed on SDK classes)
+			return null;
+		}
+
 	    Field[] f = bsSocket.getClass().getDeclaredFields();
 
 	    @SuppressWarnings("unused")
@@ -85,11 +92,14 @@ public class BTTransport extends SdlTransport {
 
 	    return null;
 	}
-	
+
+	@Deprecated
 	public int getChannel(BluetoothSocket bsSocket){
 
 		int channel = -1;
-		if (bsSocket == null) return channel;
+		if (bsSocket == null || Build.VERSION.SDK_INT > Build.VERSION_CODES.O){ //Reflection is no longer allowed on SDK classes
+			return channel;
+		}
 	    
 		Field[] f = bsSocket.getClass().getDeclaredFields();
 	    
@@ -174,7 +184,7 @@ public class BTTransport extends SdlTransport {
 
 			sComment = "Accepting Connections on SDP Server Port Number: " + iSocket + "\r\n";
 			sComment += "Keep Server Socket Open: " + bKeepSocketActive;
-			if (iSocket < 0)
+			if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O && iSocket < 0)
 			{
 				SdlConnection.enableLegacyMode(false, null);
 				throw new SdlException("Could not open connection to SDL.", SdlExceptionCause.BLUETOOTH_SOCKET_UNAVAILABLE);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -32,6 +32,7 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothServerSocket;
 import android.bluetooth.BluetoothSocket;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -834,9 +835,9 @@ public class MultiplexBluetoothTransport {
 		return !(mState == STATE_NONE);
 	}
 
-	
+	@Deprecated
 	public BluetoothSocket getBTSocket(BluetoothServerSocket bsSocket){
-	    if(bsSocket == null){
+	    if(bsSocket == null || Build.VERSION.SDK_INT > Build.VERSION_CODES.O){ //Reflection is no longer allowed on SDK classes
 	    	return null;
 	    }
 		Field[] f = bsSocket.getClass().getDeclaredFields();
@@ -862,11 +863,12 @@ public class MultiplexBluetoothTransport {
 
 	    return null;
 	}
-	
+
+	@Deprecated
 	public int getChannel(BluetoothSocket bsSocket){
 
 		int channel = -1;
-		if (bsSocket == null){
+		if (bsSocket == null || Build.VERSION.SDK_INT > Build.VERSION_CODES.O){ //Reflection is no longer allowed on SDK classes
 			return channel;
 		}
 	    


### PR DESCRIPTION

Fixes #765 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan

1. Install Android P on device
2. Use Legacy Bluetooth
3. Connection should be successful

### Summary
Deprecating methods that used reflection on Android SDK classes that are non-SDK interfaces.

### Changelog

##### Bug Fixes
* Ignores an "invalid" channel number if the android build version is greater than Android Oreo (v26)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)