### PR TITLE
Feature/issue 785 - SdlBroadcastReceiver throws false positive warnings

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -99,9 +99,9 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 				if (info != null) {
 					// Check if the service declaration in AndroidManifest has the intent-filter action specified correctly
 					boolean serviceFilterHasAction = false;
-					List<ResolveInfo> services = context.getPackageManager().queryIntentServices(new Intent(TransportConstants.ROUTER_SERVICE_ACTION), PackageManager.GET_RESOLVED_FILTER);
-					for (ResolveInfo service : services) {
-						if (service.serviceInfo.name.equals(localRouterClass.getName())){
+					List<SdlAppInfo> services = AndroidTools.querySdlAppInfo(context, null);
+					for (SdlAppInfo sdlAppInfo : services) {
+						if (sdlAppInfo.getRouterServiceComponentName().getClassName().equals(localRouterClass.getName())){
 							serviceFilterHasAction = true;
 							break;
 						}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -99,9 +99,10 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 				if (info != null) {
 					// Check if the service declaration in AndroidManifest has the intent-filter action specified correctly
 					boolean serviceFilterHasAction = false;
+					String className = localRouterClass.getName();
 					List<SdlAppInfo> services = AndroidTools.querySdlAppInfo(context, null);
 					for (SdlAppInfo sdlAppInfo : services) {
-						if (sdlAppInfo.getRouterServiceComponentName().getClassName().equals(localRouterClass.getName())){
+						if(sdlAppInfo != null && sdlAppInfo.getRouterServiceComponentName() != null && className.equals((sdlAppInfo.getRouterServiceComponentName().getClassName()))){
 							serviceFilterHasAction = true;
 							break;
 						}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -97,9 +97,19 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			if (localRouterClass != null) {
 				ResolveInfo info = context.getPackageManager().resolveService(new Intent(context, localRouterClass), PackageManager.GET_META_DATA);
 				if (info != null) {
-					if (info.filter == null || !info.filter.hasAction(TransportConstants.ROUTER_SERVICE_ACTION)) {
+					// Check if the service declaration in AndroidManifest has the intent-filter action specified correctly
+					boolean serviceFilterHasAction = false;
+					List<ResolveInfo> services = context.getPackageManager().queryIntentServices(new Intent(TransportConstants.ROUTER_SERVICE_ACTION), PackageManager.GET_RESOLVED_FILTER);
+					for (ResolveInfo service : services) {
+						if (service.serviceInfo.name.equals(localRouterClass.getName())){
+							serviceFilterHasAction = true;
+							break;
+						}
+					}
+					if (!serviceFilterHasAction){
 						Log.e(TAG, "WARNING: This application has not specified its intent-filter for the SdlRouterService. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
 					}
+					// Check if the service declaration in AndroidManifest has the router service version metadata specified correctly
 					if (info.serviceInfo.metaData == null || !info.serviceInfo.metaData.containsKey(context.getString(R.string.sdl_router_service_version_name))) {
 						Log.e(TAG, "WARNING: This application has not specified its metadata tags for the SdlRouterService. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
 					}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -95,22 +95,24 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			localRouterClass = defineLocalSdlRouterClass();
 			// we need to check this again because for USB apps, the returned class can still be null
 			if (localRouterClass != null) {
+
+				// Check if the service declaration in AndroidManifest has the intent-filter action specified correctly
+				boolean serviceFilterHasAction = false;
+				String className = localRouterClass.getName();
+				List<SdlAppInfo> services = AndroidTools.querySdlAppInfo(context, null);
+				for (SdlAppInfo sdlAppInfo : services) {
+					if(sdlAppInfo != null && sdlAppInfo.getRouterServiceComponentName() != null && className.equals((sdlAppInfo.getRouterServiceComponentName().getClassName()))){
+						serviceFilterHasAction = true;
+						break;
+					}
+				}
+				if (!serviceFilterHasAction){
+					Log.e(TAG, "WARNING: This application has not specified its intent-filter for the SdlRouterService. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
+				}
+
+				// Check if the service declaration in AndroidManifest has the router service version metadata specified correctly
 				ResolveInfo info = context.getPackageManager().resolveService(new Intent(context, localRouterClass), PackageManager.GET_META_DATA);
 				if (info != null) {
-					// Check if the service declaration in AndroidManifest has the intent-filter action specified correctly
-					boolean serviceFilterHasAction = false;
-					String className = localRouterClass.getName();
-					List<SdlAppInfo> services = AndroidTools.querySdlAppInfo(context, null);
-					for (SdlAppInfo sdlAppInfo : services) {
-						if(sdlAppInfo != null && sdlAppInfo.getRouterServiceComponentName() != null && className.equals((sdlAppInfo.getRouterServiceComponentName().getClassName()))){
-							serviceFilterHasAction = true;
-							break;
-						}
-					}
-					if (!serviceFilterHasAction){
-						Log.e(TAG, "WARNING: This application has not specified its intent-filter for the SdlRouterService. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
-					}
-					// Check if the service declaration in AndroidManifest has the router service version metadata specified correctly
 					if (info.serviceInfo.metaData == null || !info.serviceInfo.metaData.containsKey(context.getString(R.string.sdl_router_service_version_name))) {
 						Log.e(TAG, "WARNING: This application has not specified its metadata tags for the SdlRouterService. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
 					}


### PR DESCRIPTION
Fixes #785  

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
1. Set the transport type to `MULTIPLEX`
2. Make sure that `com.smartdevicelink.router.service` action is added to the router service's intent-filter
2. Pair the device with TDK
3. Run the app and check logcat messages
4. You should see no warnings about intent-filter in logcat

### Summary
This PR fixes an issue in the way the library is checking whether the router service has the intent-filter declared correctly in AndroidManifest. The previous way was having a bug where the `filter` is always `null`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)