### PR TITLE
Fix vpm multi touch

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -6586,15 +6586,15 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}
 
 			int eventAction = sdlMotionEvent.getMotionEvent(touchType, pointerProperties);
-
-			MotionEvent motionEvent =  android.view.MotionEvent.obtain(sdlMotionEvent.startOfEvent, sdlMotionEvent.getEventTime(), eventAction, eventListSize, pointerProperties, pointerCoords, 0, 0,1,1,0,0, InputDevice.SOURCE_TOUCHSCREEN,0);
+			long startTime = sdlMotionEvent.startOfEvent;
 
 			//If the motion event should be finished we should clear our reference
 			if(eventAction == MotionEvent.ACTION_UP || eventAction == MotionEvent.ACTION_CANCEL){
 				sdlMotionEvent = null;
 			}
 
-			return  motionEvent;
+			return MotionEvent.obtain(startTime, SystemClock.uptimeMillis(), eventAction, eventListSize, pointerProperties, pointerCoords, 0, 0,1,1,0,0, InputDevice.SOURCE_TOUCHSCREEN,0);
+
 		}
 
 
@@ -6612,11 +6612,13 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			startOfEvent = SystemClock.uptimeMillis();
 		}
 
-		synchronized long getEventTime(){
-			return  SystemClock.uptimeMillis() - startOfEvent;
-		}
-
-
+		/**
+		 * Handles the SDL Touch Event to keep track of pointer status and returns the appropirate
+		 * Android MotionEvent according to this events status
+		 * @param touchType The SDL TouchType that was received from the module
+		 * @param pointerProperties the parsed pointer properties built from the OnTouchEvent RPC
+		 * @return the correct native Andorid MotionEvent action to dispatch
+		 */
 		synchronized int  getMotionEvent(TouchType touchType, MotionEvent.PointerProperties[] pointerProperties){
 			int motionEvent = MotionEvent.ACTION_DOWN;
 			switch (touchType){
@@ -6639,7 +6641,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					setPointerStatuses(MotionEvent.ACTION_UP, pointerProperties);
 
 					if(pointerStatuses.size() == 0){
-						//The motion event has just begun
+						//The motion event has just ended
 						motionEvent = MotionEvent.ACTION_UP;
 					}else{
 						motionEvent = MotionEvent.ACTION_POINTER_UP;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -6587,8 +6587,14 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 			int eventAction = sdlMotionEvent.getMotionEvent(touchType, pointerProperties);
 
-			return android.view.MotionEvent.obtain(sdlMotionEvent.startOfEvent, sdlMotionEvent.getEventTime(), eventAction, eventListSize, pointerProperties, pointerCoords, 0, 0,1,1,0,0, InputDevice.SOURCE_TOUCHSCREEN,0);
+			MotionEvent motionEvent =  android.view.MotionEvent.obtain(sdlMotionEvent.startOfEvent, sdlMotionEvent.getEventTime(), eventAction, eventListSize, pointerProperties, pointerCoords, 0, 0,1,1,0,0, InputDevice.SOURCE_TOUCHSCREEN,0);
 
+			//If the motion event should be finished we should clear our reference
+			if(eventAction == MotionEvent.ACTION_UP || eventAction == MotionEvent.ACTION_CANCEL){
+				sdlMotionEvent = null;
+			}
+
+			return  motionEvent;
 		}
 
 

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -37,6 +37,7 @@ import android.telephony.TelephonyManager;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.SparseArray;
+import android.util.SparseIntArray;
 import android.view.Display;
 import android.view.InputDevice;
 import android.view.MotionEvent;
@@ -6379,6 +6380,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		IVideoStreamListener streamListener;
 		float[] touchScalar = {1.0f,1.0f}; //x, y
 		private HapticInterfaceManager hapticManager;
+		SdlMotionEvent sdlMotionEvent = null;
 
 		public VideoStreamingManager(Context context,ISdl iSdl){
 			this.context = context;
@@ -6575,27 +6577,94 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}
 
 
-			int eventAction = MotionEvent.ACTION_DOWN;
-			long downTime = 0;
-
-			if (touchType == TouchType.BEGIN) {
-				downTime = SystemClock.uptimeMillis();
-				eventAction = MotionEvent.ACTION_DOWN;
+			if(sdlMotionEvent == null) {
+				if (touchType == TouchType.BEGIN) {
+					sdlMotionEvent = new SdlMotionEvent();
+				}else{
+					return  null;
+				}
 			}
 
-			long eventTime = SystemClock.uptimeMillis();
-			if (downTime == 0){ downTime = eventTime - 100;}
+			int eventAction = sdlMotionEvent.getMotionEvent(touchType, pointerProperties);
 
-			if (touchType == TouchType.MOVE) {
-				eventAction = MotionEvent.ACTION_MOVE;
+			return android.view.MotionEvent.obtain(sdlMotionEvent.startOfEvent, sdlMotionEvent.getEventTime(), eventAction, eventListSize, pointerProperties, pointerCoords, 0, 0,1,1,0,0, InputDevice.SOURCE_TOUCHSCREEN,0);
+
+		}
+
+
+
+	}
+
+	/**
+	 * Keeps track of the current motion event for VPM
+	 */
+	private static class SdlMotionEvent{
+		long startOfEvent;
+		SparseIntArray pointerStatuses = new SparseIntArray();
+
+		SdlMotionEvent(){
+			startOfEvent = SystemClock.uptimeMillis();
+		}
+
+		synchronized long getEventTime(){
+			return  SystemClock.uptimeMillis() - startOfEvent;
+		}
+
+
+		synchronized int  getMotionEvent(TouchType touchType, MotionEvent.PointerProperties[] pointerProperties){
+			int motionEvent = MotionEvent.ACTION_DOWN;
+			switch (touchType){
+				case BEGIN:
+					if(pointerStatuses.size() == 0){
+						//The motion event has just begun
+						motionEvent = MotionEvent.ACTION_DOWN;
+					}else{
+						motionEvent = MotionEvent.ACTION_POINTER_DOWN;
+					}
+					setPointerStatuses(motionEvent, pointerProperties);
+					break;
+				case MOVE:
+					motionEvent = MotionEvent.ACTION_MOVE;
+					setPointerStatuses(motionEvent, pointerProperties);
+
+					break;
+				case END:
+					//Clears out pointers that have ended
+					setPointerStatuses(MotionEvent.ACTION_UP, pointerProperties);
+
+					if(pointerStatuses.size() == 0){
+						//The motion event has just begun
+						motionEvent = MotionEvent.ACTION_UP;
+					}else{
+						motionEvent = MotionEvent.ACTION_POINTER_UP;
+					}
+					break;
+				case CANCEL:
+					//Assuming this cancels the entire event
+					motionEvent = MotionEvent.ACTION_CANCEL;
+					pointerStatuses.clear();
+					break;
+				default:
+					break;
 			}
+			return motionEvent;
+		}
 
-			if (touchType == TouchType.END) {
-				eventAction = MotionEvent.ACTION_UP;
+		private void setPointerStatuses(int motionEvent, MotionEvent.PointerProperties[] pointerProperties){
+
+					for(int i = 0; i < pointerProperties.length; i ++){
+						MotionEvent.PointerProperties properties = pointerProperties[i];
+						if(properties != null){
+							if(motionEvent == MotionEvent.ACTION_UP || motionEvent == MotionEvent.ACTION_POINTER_UP){
+								pointerStatuses.delete(properties.id);
+							}else if(motionEvent == MotionEvent.ACTION_DOWN && properties.id == 0){
+								pointerStatuses.put(properties.id, MotionEvent.ACTION_DOWN);
+							}else{
+								pointerStatuses.put(properties.id, motionEvent);
+							}
+
+					}
 			}
-
-			return MotionEvent.obtain(downTime, eventTime, eventAction, eventListSize, pointerProperties, pointerCoords, 0, 0,1,1,0,0, InputDevice.SOURCE_TOUCHSCREEN,0);
-
 		}
 	}
 } // end-class


### PR DESCRIPTION

Fixes #787 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan

1. Prepare a VPM app and connect to Core
2. Use a single touch to press down, move and release. Correction Action items received
3. Touch one pointer; receive an ACTION_DOWN, touch another pointer without release first; receive an ACTION_POINTER_DOWN. Release one of the pointers; ACTION_POINTER_UP is received. Release the other pointer; ACTION_UP is received.

### Summary
A private static class was introduced to handle the translation of SDL touch events to Android motion events. 

### Changelog

##### Bug Fixes
* Multitouch is now better supported
* ACTION_CANCEL should not be received between multiple pointer touch begins


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)