### PR TITLE
Even less intrusive notification

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -788,7 +788,7 @@ public class MultiplexBluetoothTransport {
             while (true) {
                 try {
                     bytesRead = mmInStream.read(buffer);
-                    Log.i(getClass().getName(), "Received " + bytesRead + " bytes from Bluetooth");
+                    //Log.i(getClass().getName(), "Received " + bytesRead + " bytes from Bluetooth");
                     for (int i = 0; i < bytesRead; i++) {
                         input = buffer[i];
 

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -32,10 +32,6 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 	
 	private static final String TAG = "Sdl Broadcast Receiver";
 
-	private static final String BOOT_COMPLETE = "android.intent.action.BOOT_COMPLETED";
-	private static final String ACL_CONNECTED = "android.bluetooth.device.action.ACL_CONNECTED";
-	private static final String STATE_CHANGED = "android.bluetooth.adapter.action.STATE_CHANGED" ;
-	
 	protected static final String SDL_ROUTER_SERVICE_CLASS_NAME 			= "sdlrouterservice";
 	
 	public static final String LOCAL_ROUTER_SERVICE_EXTRA					= "router_service";
@@ -69,9 +65,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			return;
 		}
 		
-        if(!(action.equalsIgnoreCase(BOOT_COMPLETE)
-        		|| action.equalsIgnoreCase(ACL_CONNECTED)
-        		|| action.equalsIgnoreCase(STATE_CHANGED)
+        if(!(action.equalsIgnoreCase(BluetoothDevice.ACTION_ACL_CONNECTED)
         		|| action.equalsIgnoreCase(USBTransport.ACTION_USB_ACCESSORY_ATTACHED)
         		|| action.equalsIgnoreCase(TransportConstants.START_ROUTER_SERVICE_ACTION))){
         	//We don't want anything else here if the child class called super and has different intent filters
@@ -155,20 +149,8 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 				didStart = wakeUpRouterService(context, false,altServiceWake,device );
 				
 			}
-
 		}
-		
-	    if (action.contains("android.bluetooth.adapter.action.STATE_CHANGED")){
-	    	int state = intent.getIntExtra("android.bluetooth.adapter.extra.STATE",-1);
-	    		if (state == BluetoothAdapter.STATE_OFF || 
-	    			state == BluetoothAdapter.STATE_TURNING_OFF){
-	    			//onProtocolDisabled(context);
-	    			//Let's let the service that is running manage what to do for this
-	    			//If we were to do it here, for every instance of this BR it would send
-	    			//an intent to stop service, where it's only one that is needed.
-	    			return;
-	    		}
-	    }
+
 
 	    Log.d(TAG, "Check for local router");
 	    if(localRouterClass!=null){ //If there is a supplied router service lets run some logic regarding starting one

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -418,7 +418,6 @@ public class SdlRouterService extends Service{
 	                	
 	                    break;
 	                case TransportConstants.ROUTER_SEND_PACKET:
-	                	Log.d(TAG, "Received packet to send");
 	                	if(receivedBundle!=null){
 	                		Runnable packetRun = new Runnable(){
 	                			@Override
@@ -2514,7 +2513,7 @@ public class SdlRouterService extends Service{
 			bytesToWrite = bundle.getByteArray(TransportConstants.BYTES_TO_SEND_EXTRA_NAME); 
 			offset = bundle.getInt(TransportConstants.BYTES_TO_SEND_EXTRA_OFFSET, 0); //If nothing, start at the beginning of the array
 			size = bundle.getInt(TransportConstants.BYTES_TO_SEND_EXTRA_COUNT, bytesToWrite.length);  //In case there isn't anything just send the whole packet.
-			this.priorityCoefficient = bundle.getInt(TransportConstants.PACKET_PRIORITY_COEFFICIENT,0); Log.d(TAG, "packet priority coef: "+ this.priorityCoefficient);
+			this.priorityCoefficient = bundle.getInt(TransportConstants.PACKET_PRIORITY_COEFFICIENT,0);
 		}
 		
 		@Override

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -908,7 +908,7 @@ public class SdlRouterService extends Service{
 					}
 				}
 				int timeout = getNotificationTimeout(address);
-				enterForeground("Waiting for connection...", timeout);
+				enterForeground("Waiting for connection...", timeout, false);
 				resetForegroundTimeOut(timeout);
 			}
 			if(intent.hasExtra(TransportConstants.PING_ROUTER_SERVICE_EXTRA)){
@@ -1012,18 +1012,15 @@ public class SdlRouterService extends Service{
 		if(address != null){
 			if(hasSDLConnected(address)){
 				return FOREGROUND_TIMEOUT * 2;
-			}else if(this.isFirstStatusCheck(address)){
+			}else if(this.isFirstStatusCheck(address)) {
 				// If this is the first time the service has ever connected to this device we want
-				// to give it a few extra seconds.
-				setSDLConnectedStatus(address,false);
-				return FOREGROUND_TIMEOUT;
-			}else{
-				// If the service has seen this device before but hasn't ever connected, the
-				// notification can be removed ASAP.
-				return FOREGROUND_TIMEOUT/100;
+				// to ensure we have a record of it
+				setSDLConnectedStatus(address, false);
 			}
 		}
-		return FOREGROUND_TIMEOUT/100;
+		// If this is a new device or hasn't connected through SDL we want to limit the exposure
+		// of the SDL service in the foreground
+		return FOREGROUND_TIMEOUT/1000;
 	}
 
 	public void resetForegroundTimeOut(long delay){
@@ -1056,7 +1053,7 @@ public class SdlRouterService extends Service{
 
 	@SuppressLint("NewApi")
 	@SuppressWarnings("deprecation")
-	private void enterForeground(String content, long chronometerLength) {
+	private void enterForeground(String content, long chronometerLength, boolean ongoing) {
 		if(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.HONEYCOMB){
 			Log.w(TAG, "Unable to start service as foreground due to OS SDK version being lower than 11");
 			isForeground = false;
@@ -1094,7 +1091,7 @@ public class SdlRouterService extends Service{
 			 builder.setSmallIcon(android.R.drawable.stat_sys_data_bluetooth);
 		}
         builder.setLargeIcon(icon);
-        builder.setOngoing(true);
+        builder.setOngoing(ongoing);
 
 		// Create an intent that will be fired when the user clicks the notification.
 		Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(SDL_NOTIFICATION_FAQS_PAGE));
@@ -1240,7 +1237,7 @@ public class SdlRouterService extends Service{
 	public void onTransportConnected(final TransportType type){
 		isTransportConnected = true;
 		cancelForegroundTimeOut();
-		enterForeground("Connected to " + this.getConnectedDeviceName(),0);
+		enterForeground("Connected to " + this.getConnectedDeviceName(),0, true);
 		if(packetWriteTaskMaster!=null){
 			packetWriteTaskMaster.close();
 			packetWriteTaskMaster = null;


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
1. Clear testing app memory or reinstall it from device
2. Connect bluetooth to device (TDK, bluetooth headset)
3. First time should have a timeout of 10 milliseconds
4. Disconnect device
5. Reconnect device
    1.  If device previously connected through SDL the timeout should be upped to 20 seconds. 
    2. If device did not connect through SDL, timeout should be 10ms.


### Summary
Add better logic to create an even less intrusive notifications for end users. If a device is found to have not connected through SDL, the timeout will decrease significantly (10ms) and the notification will essentially not be displayed.

### Changelog

##### Enhancements
* Less intrusive notifications for end users
* Notification while waiting for a connection is now swipeable

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)