### PR TITLE
Feature/issue 738 - Support for Short and Full UUID App ID

### DIFF
--- a/sdl_android/src/androidTest/assets/json/RegisterAppInterface.json
+++ b/sdl_android/src/androidTest/assets/json/RegisterAppInterface.json
@@ -18,7 +18,8 @@
         "SOCIAL",
         "MEDIA"
       ],
-      "appID":"t4weGRSWY",
+      "appID":"123e4567e8",
+      "fullAppID":"123e4567-e89b-12d3-a456-426655440000",
       "languageDesired":"PT-BR",
       "deviceInfo":{
         "hardware":"My Hardware",

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/Test.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/Test.java
@@ -263,9 +263,6 @@ public class Test {
 	public static final String                         GENERAL_APP_ID                         = "123e4567e8";
 	public static final String                         GENERAL_FULL_APP_ID                    = "123e4567-e89b-12d3-a456-426655440000";
 
-
-
-
 	public static final ModuleType 					   GENERAL_MODULETYPE           		  = ModuleType.CLIMATE;
 	public static final Temperature 				   GENERAL_TEMPERATURE                	  = new Temperature();
 	public static final TemperatureUnit 			   GENERAL_TEMPERATUREUNIT                = TemperatureUnit.CELSIUS;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/Test.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/Test.java
@@ -260,6 +260,10 @@ public class Test {
 	public static final SingleTireStatus               GENERAL_SINGLETIRESTATUS               = new SingleTireStatus();
 	public static final DriverDistractionState         GENERAL_DRIVERDISTRACTIONSTATE         = DriverDistractionState.DD_ON;
 	public static final List<LocationDetails>          GENERAL_LOCATIONDETAILS_LIST           = Arrays.asList(new LocationDetails[] { Test.GENERAL_LOCATIONDETAILS, Test.GENERAL_LOCATIONDETAILS});
+	public static final String                         GENERAL_APP_ID                         = "123e4567e8";
+	public static final String                         GENERAL_FULL_APP_ID                    = "123e4567-e89b-12d3-a456-426655440000";
+
+
 
 
 	public static final ModuleType 					   GENERAL_MODULETYPE           		  = ModuleType.CLIMATE;

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/RegisterAppInterfaceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/RegisterAppInterfaceTests.java
@@ -26,7 +26,7 @@ import com.smartdevicelink.test.json.rpc.JsonFileReader;
 
 /**
  * This is a unit test class for the SmartDeviceLink library project class : 
- * {@link com.smartdevicelink.rpc.RegisterAppInterface}
+ * {@link com.smartdevicelink.proxy.rpc.RegisterAppInterface}
  */
 public class RegisterAppInterfaceTests extends BaseRpcTests {
 
@@ -37,7 +37,7 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 		msg.setSdlMsgVersion(Test.GENERAL_SDLMSGVERSION);
 		msg.setAppName(Test.GENERAL_STRING);
 		msg.setNgnMediaScreenAppName(Test.GENERAL_STRING);
-		msg.setAppID(Test.GENERAL_STRING);
+		msg.setAppID(Test.GENERAL_FULL_APP_ID);
 		msg.setLanguageDesired(Test.GENERAL_LANGUAGE);
 		msg.setHmiDisplayLanguageDesired(Test.GENERAL_LANGUAGE);
 		msg.setHashID(Test.GENERAL_STRING);
@@ -70,7 +70,8 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 			result.put(RegisterAppInterface.KEY_SDL_MSG_VERSION, Test.JSON_SDLMSGVERSION);
 			result.put(RegisterAppInterface.KEY_APP_NAME, Test.GENERAL_STRING);
 			result.put(RegisterAppInterface.KEY_NGN_MEDIA_SCREEN_APP_NAME, Test.GENERAL_STRING);
-			result.put(RegisterAppInterface.KEY_APP_ID, Test.GENERAL_STRING);
+			result.put(RegisterAppInterface.KEY_APP_ID, Test.GENERAL_APP_ID);
+			result.put(RegisterAppInterface.KEY_FULL_APP_ID, Test.GENERAL_FULL_APP_ID);
 			result.put(RegisterAppInterface.KEY_LANGUAGE_DESIRED, Test.GENERAL_LANGUAGE);
 			result.put(RegisterAppInterface.KEY_HMI_DISPLAY_LANGUAGE_DESIRED, Test.GENERAL_LANGUAGE);
 			result.put(RegisterAppInterface.KEY_HASH_ID, Test.GENERAL_STRING);
@@ -97,6 +98,7 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 		String testName = ( (RegisterAppInterface) msg).getAppName();
 		String testNgnName = ( (RegisterAppInterface) msg).getNgnMediaScreenAppName();
 		String testAppId = ( (RegisterAppInterface) msg).getAppID();
+		String testFullAppId = ( (RegisterAppInterface) msg).getFullAppID();
 		Language testLang = ( (RegisterAppInterface) msg).getLanguageDesired();
 		Language testHmiLang = ( (RegisterAppInterface) msg).getHmiDisplayLanguageDesired();
 		String testHashId = ( (RegisterAppInterface) msg).getHashID();
@@ -112,7 +114,8 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 		assertTrue(Test.TRUE, Validator.validateSdlMsgVersion(Test.GENERAL_SDLMSGVERSION, testVersion));
 		assertEquals(Test.MATCH, Test.GENERAL_STRING, testName);
 		assertEquals(Test.MATCH, Test.GENERAL_STRING, testNgnName);
-		assertEquals(Test.MATCH, Test.GENERAL_STRING, testAppId);
+		assertEquals(Test.MATCH, Test.GENERAL_APP_ID, testAppId);
+		assertEquals(Test.MATCH, Test.GENERAL_FULL_APP_ID, testFullAppId);
 		assertEquals(Test.MATCH, Test.GENERAL_LANGUAGE, testLang);
 		assertEquals(Test.MATCH, Test.GENERAL_LANGUAGE, testHmiLang);
 		assertEquals(Test.MATCH, Test.GENERAL_STRING, testHashId);
@@ -133,6 +136,7 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 		assertNull(Test.NULL, msg.getAppName());
 		assertNull(Test.NULL, msg.getNgnMediaScreenAppName());
 		assertNull(Test.NULL, msg.getAppID());
+		assertNull(Test.NULL, msg.getFullAppID());
 		assertNull(Test.NULL, msg.getLanguageDesired());
 		assertNull(Test.NULL, msg.getHmiDisplayLanguageDesired());
 		assertNull(Test.NULL, msg.getHashID());
@@ -179,6 +183,7 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 				assertEquals(Test.MATCH, appHmiTypeItem, cmd.getAppHMIType().get(index) );
 			}
 			assertEquals(Test.MATCH, JsonUtils.readStringFromJsonObject(parameters, RegisterAppInterface.KEY_APP_ID), cmd.getAppID());
+			assertEquals(Test.MATCH, JsonUtils.readStringFromJsonObject(parameters, RegisterAppInterface.KEY_FULL_APP_ID), cmd.getFullAppID());
 			assertEquals(Test.MATCH, JsonUtils.readStringFromJsonObject(parameters, RegisterAppInterface.KEY_LANGUAGE_DESIRED), cmd.getLanguageDesired().toString());
 
 			JSONObject deviceInfoObj = JsonUtils.readJsonObjectFromJsonObject(parameters, RegisterAppInterface.KEY_DEVICE_INFO);

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/RegisterAppInterfaceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/RegisterAppInterfaceTests.java
@@ -37,7 +37,7 @@ public class RegisterAppInterfaceTests extends BaseRpcTests {
 		msg.setSdlMsgVersion(Test.GENERAL_SDLMSGVERSION);
 		msg.setAppName(Test.GENERAL_STRING);
 		msg.setNgnMediaScreenAppName(Test.GENERAL_STRING);
-		msg.setAppID(Test.GENERAL_FULL_APP_ID);
+		msg.setFullAppID(Test.GENERAL_FULL_APP_ID);
 		msg.setLanguageDesired(Test.GENERAL_LANGUAGE);
 		msg.setHmiDisplayLanguageDesired(Test.GENERAL_LANGUAGE);
 		msg.setHashID(Test.GENERAL_STRING);

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
@@ -300,18 +300,18 @@ public class RegisterAppInterface extends RPCRequest {
 	 * @param isMediaApplication a Boolean value
 	 * @param languageDesired a Language Enumeration
 	 * @param hmiDisplayLanguageDesired
-	 * @param appID a String value representing a unique ID, which an app will be given when approved <br>
+	 * @param fullAppID a String value representing a unique ID, which an app will be given when approved <br>
 	 *            <b>Notes: </b>Maxlength = 100
 	 */
 	public RegisterAppInterface(@NonNull SdlMsgVersion syncMsgVersion, @NonNull String appName, @NonNull Boolean isMediaApplication,
-								@NonNull Language languageDesired, @NonNull Language hmiDisplayLanguageDesired, @NonNull String appID) {
+								@NonNull Language languageDesired, @NonNull Language hmiDisplayLanguageDesired, @NonNull String fullAppID) {
 		this();
 		setSdlMsgVersion(syncMsgVersion);
 		setAppName(appName);
 		setIsMediaApplication(isMediaApplication);
 		setLanguageDesired(languageDesired);
 		setHmiDisplayLanguageDesired(hmiDisplayLanguageDesired);
-		setAppID(appID);
+		setFullAppID(fullAppID);
 	}
 	/**
 	 * Gets the version of the SDL&reg; SmartDeviceLink interface
@@ -606,14 +606,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 * @since SmartDeviceLink 2.0
 	 */
 	public void setAppID(@NonNull String appID) {
-		if (appID != null) {
-			setParameters(KEY_FULL_APP_ID, appID);
-			if (appID.length() <= APP_ID_MAX_LENGTH) {
-				setParameters(KEY_APP_ID, appID);
-			} else {
-				setParameters(KEY_APP_ID, appID.replace("-", "").substring(0, APP_ID_MAX_LENGTH));
-			}
-		}
+		setParameters(KEY_APP_ID, appID);
 	}
 
 	/**
@@ -625,6 +618,29 @@ public class RegisterAppInterface extends RPCRequest {
 	 */
 	public String getFullAppID() {
 		return getString(KEY_FULL_APP_ID);
+	}
+
+	/**
+	 * Sets a unique ID, which an app will be given when approved
+	 *
+	 * @param fullAppID
+	 *            a String value representing a unique ID, which an app will be
+	 *            given when approved
+	 *            <p></p>
+	 *            <b>Notes: </b>Maxlength = 100
+	 * @since SmartDeviceLink 2.0
+	 */
+	public void setFullAppID(@NonNull String fullAppID) {
+		if (fullAppID != null) {
+			setParameters(KEY_FULL_APP_ID, fullAppID);
+			String appID;
+			if (fullAppID.length() <= APP_ID_MAX_LENGTH) {
+				appID = fullAppID;
+			} else {
+				appID = fullAppID.replace("-", "").substring(0, APP_ID_MAX_LENGTH);
+			}
+			setAppID(appID);
+		}
 	}
 
 	/**

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
@@ -6,6 +6,7 @@ import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.proxy.rpc.enums.AppHMIType;
 import com.smartdevicelink.proxy.rpc.enums.Language;
+import com.smartdevicelink.util.Version;
 
 import java.util.Hashtable;
 import java.util.List;
@@ -186,9 +187,9 @@ import java.util.List;
  * 			<td>fullAppID</td>
  * 			<td>String</td>
  * 			<td>ID used to validate app with policy table entries</td>
- *                 <td>Y</td>
+ *                 <td>N</td>
  *                 <td>Maxlength: 100</td>
- * 			<td>SmartDeviceLink 4.6 </td>
+ * 			<td>SmartDeviceLink 4.6</td>
  * 		</tr>
  * 		<tr>
  * 			<td>hmiCapabilities</td>
@@ -606,7 +607,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 * @since SmartDeviceLink 2.0
 	 */
 	public void setAppID(@NonNull String appID) {
-		setParameters(KEY_APP_ID, appID);
+		setParameters(KEY_APP_ID, appID.toLowerCase());
 	}
 
 	/**
@@ -628,10 +629,11 @@ public class RegisterAppInterface extends RPCRequest {
 	 *            given when approved
 	 *            <p></p>
 	 *            <b>Notes: </b>Maxlength = 100
-	 * @since SmartDeviceLink 2.0
+	 * @since SmartDeviceLink 4.6
 	 */
-	public void setFullAppID(@NonNull String fullAppID) {
+	public void setFullAppID(String fullAppID) {
 		if (fullAppID != null) {
+			fullAppID = fullAppID.toLowerCase();
 			setParameters(KEY_FULL_APP_ID, fullAppID);
 			String appID;
 			if (fullAppID.length() <= APP_ID_MAX_LENGTH) {
@@ -640,7 +642,17 @@ public class RegisterAppInterface extends RPCRequest {
 				appID = fullAppID.replace("-", "").substring(0, APP_ID_MAX_LENGTH);
 			}
 			setAppID(appID);
+		} else {
+			setParameters(KEY_FULL_APP_ID, null);
 		}
+	}
+
+	@Override
+	public void format(Version rpcVersion, boolean formatParams) {
+		if (getFullAppID() == null){
+			setFullAppID(getAppID());
+		}
+		super.format(rpcVersion, formatParams);
 	}
 
 	/**

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
@@ -182,7 +182,14 @@ import java.util.List;
  *                 <td>Maxlength: 100</td>
  * 			<td>SmartDeviceLink 2.0 </td>
  * 		</tr>
- * 
+ * 		<tr>
+ * 			<td>fullAppID</td>
+ * 			<td>String</td>
+ * 			<td>ID used to validate app with policy table entries</td>
+ *                 <td>Y</td>
+ *                 <td>Maxlength: 100</td>
+ * 			<td>SmartDeviceLink 4.6 </td>
+ * 		</tr>
  * 		<tr>
  * 			<td>hmiCapabilities</td>
  * 			<td>HMICapabilities</td>
@@ -238,6 +245,7 @@ public class RegisterAppInterface extends RPCRequest {
 	public static final String KEY_HMI_DISPLAY_LANGUAGE_DESIRED = "hmiDisplayLanguageDesired";
 	public static final String KEY_APP_HMI_TYPE = "appHMIType";
 	public static final String KEY_APP_ID = "appID";
+	public static final String KEY_FULL_APP_ID = "fullAppID";
 	public static final String KEY_LANGUAGE_DESIRED = "languageDesired";
 	public static final String KEY_DEVICE_INFO = "deviceInfo";
 	public static final String KEY_APP_NAME = "appName";
@@ -248,6 +256,7 @@ public class RegisterAppInterface extends RPCRequest {
 	public static final String KEY_HASH_ID = "hashID";
 	public static final String KEY_DAY_COLOR_SCHEME = "dayColorScheme";
 	public static final String KEY_NIGHT_COLOR_SCHEME = "nightColorScheme";
+	private static final int APP_ID_MAX_LENGTH = 10;
 
 	/**
 	 * Constructs a new RegisterAppInterface object
@@ -573,22 +582,22 @@ public class RegisterAppInterface extends RPCRequest {
    
     public void setHashID(String hashID) {
 		setParameters(KEY_HASH_ID, hashID);
-    }        
-    
+    }
+
 	/**
 	 * Gets the unique ID, which an app will be given when approved
-	 * 
+	 *
 	 * @return String - a String value representing the unique ID, which an app
 	 *         will be given when approved
 	 * @since SmartDeviceLink 2.0
 	 */
-    public String getAppID() {
-        return getString(KEY_APP_ID);
-    }
+	public String getAppID() {
+		return getString(KEY_APP_ID);
+	}
 
 	/**
 	 * Sets a unique ID, which an app will be given when approved
-	 * 
+	 *
 	 * @param appID
 	 *            a String value representing a unique ID, which an app will be
 	 *            given when approved
@@ -596,9 +605,27 @@ public class RegisterAppInterface extends RPCRequest {
 	 *            <b>Notes: </b>Maxlength = 100
 	 * @since SmartDeviceLink 2.0
 	 */
-    public void setAppID(@NonNull String appID) {
-		setParameters(KEY_APP_ID, appID);
-    }
+	public void setAppID(@NonNull String appID) {
+		if (appID != null) {
+			setParameters(KEY_FULL_APP_ID, appID);
+			if (appID.length() <= APP_ID_MAX_LENGTH) {
+				setParameters(KEY_APP_ID, appID);
+			} else {
+				setParameters(KEY_APP_ID, appID.replace("-", "").substring(0, APP_ID_MAX_LENGTH));
+			}
+		}
+	}
+
+	/**
+	 * Gets the unique ID, which an app will be given when approved
+	 *
+	 * @return String - a String value representing the unique ID, which an app
+	 *         will be given when approved
+	 * @since SmartDeviceLink 4.6
+	 */
+	public String getFullAppID() {
+		return getString(KEY_FULL_APP_ID);
+	}
 
 	/**
 	 * Gets the color scheme that is currently used for day

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
@@ -622,8 +622,8 @@ public class RegisterAppInterface extends RPCRequest {
 	}
 
 	/**
-	 * Sets a unique ID, which an app will be given when approved
-	 *
+	 * Sets a unique ID, which an app will be given when approved <br>
+	 * Note: this will automatically parse the fullAppID into the smaller appId and set the appId value as well
 	 * @param fullAppID
 	 *            a String value representing a unique ID, which an app will be
 	 *            given when approved
@@ -649,8 +649,10 @@ public class RegisterAppInterface extends RPCRequest {
 
 	@Override
 	public void format(Version rpcVersion, boolean formatParams) {
-		if (getFullAppID() == null){
-			setFullAppID(getAppID());
+		if(rpcVersion == null || rpcVersion.getMajor() >= 5) {
+			if (getFullAppID() == null) {
+				setFullAppID(getAppID());
+			}
 		}
 		super.format(rpcVersion, formatParams);
 	}

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
@@ -607,7 +607,11 @@ public class RegisterAppInterface extends RPCRequest {
 	 * @since SmartDeviceLink 2.0
 	 */
 	public void setAppID(@NonNull String appID) {
-		setParameters(KEY_APP_ID, appID.toLowerCase());
+		if (appID != null) {
+			setParameters(KEY_APP_ID, appID.toLowerCase());
+		} else {
+			setParameters(KEY_APP_ID, appID);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #738 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
* Updated the current unit tests to work with the new `fullAppID` field in `RegisterAppInterface`.

### Summary 
This PR adds a new `fullAppID` parameter to `RegisterAppInterface` RPC as described in the proposal.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)