### PR TITLE
App Icon Resumption Revision

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2053,7 +2053,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					_proxyVersionInfo = msg.getProxyVersionInfo();
 					_iconResumed = msg.getIconResumed();
 					
-
+					if (_iconResumed == null){
+						_iconResumed = false;
+					}
 
 					if (_bAppResumeEnabled)
 					{

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
@@ -380,11 +380,22 @@ public class RegisterAppInterfaceResponse extends RPCResponse {
         return getString(KEY_SYSTEM_SOFTWARE_VERSION);
     }
 
-    public void setIconResumed(Boolean iconResumed){
-        setParameters(KEY_ICON_RESUMED, iconResumed);
-    }
+	/**
+	 * Sets Icon Resumed Boolean
+	 * @param iconResumed - if param not included, set to false
+	 */
+	public void setIconResumed(Boolean iconResumed){
+		if(iconResumed == null){
+			iconResumed = false;
+		}
+		setParameters(KEY_ICON_RESUMED, iconResumed);
+	}
 
-    public Boolean getIconResumed() {
-        return getBoolean(KEY_ICON_RESUMED);
-    }
+	/**
+	 * Tells developer whether or not their app icon has been resumed on core.
+	 * @return boolean - true if icon was resumed, false if not
+	 */
+	public Boolean getIconResumed() {
+		return getBoolean(KEY_ICON_RESUMED);
+	}
 }


### PR DESCRIPTION
Fixes #453 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

This is a follow up commit on the revision of the proposal. It simply sets the `iconResumed` value to false if it is not set. 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)