### PR TITLE
fix IllegalStateException starting service

### DIFF
--- a/sdl_android/build.gradle
+++ b/sdl_android/build.gradle
@@ -6,7 +6,7 @@ android {
         minSdkVersion 8
         targetSdkVersion 19
         versionCode 5
-        versionName "4.6.1"
+        versionName "4.6.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         resValue "string", "SDL_LIB_VERSION", '\"' + versionName + '\"'
     }

--- a/sdl_android/build.gradle
+++ b/sdl_android/build.gradle
@@ -5,7 +5,7 @@ android {
     defaultConfig {
         minSdkVersion 8
         targetSdkVersion 19
-        versionCode 5
+        versionCode 6
         versionName "4.6.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         resValue "string", "SDL_LIB_VERSION", '\"' + versionName + '\"'

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -294,7 +294,12 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			Intent intent = new Intent();
 			intent.setClassName(packageName, className);
 			intent.putExtra(TransportConstants.PING_ROUTER_SERVICE_EXTRA, true);
-			context.startService(intent);
+			if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+				intent.putExtra(FOREGROUND_EXTRA, true);
+				context.startForegroundService(intent);
+			}else {
+				context.startService(intent);
+			}
 		}catch(SecurityException e){
 			Log.e(TAG, "Security exception, process is bad");
 			// This service could not be started


### PR DESCRIPTION
Fixes #833 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested against Ford TDK to ensure no `IllegalStateExceptions` on apps targeting O or above

### Summary
If O or above, call `startForegroundService` in the `pingRouterService` method

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)