### PR TITLE
Feature/issue 739 choice vr optional

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/ChoiceTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/ChoiceTests.java
@@ -18,7 +18,7 @@ import com.smartdevicelink.test.Validator;
 
 /**
  * This is a unit test class for the SmartDeviceLink library project class : 
- * {@link com.smartdevicelink.rpc.Choice}
+ * {@link com.smartdevicelink.proxy.rpc.Choice}
  */
 public class ChoiceTests extends TestCase{
 	

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
@@ -86,6 +86,21 @@ public class Choice extends RPCStruct {
         setMenuName(menuName);
     }
     /**
+     * Constructs a newly allocated Choice object
+     * @param choiceID Min: 0  Max: 65535
+     * @param menuName the menu name
+     * @param vrCommands the List of  vrCommands
+     *
+     * Deprecated - use constructor without the forced use of vrCommands
+     */
+    @Deprecated
+    public Choice(@NonNull Integer choiceID, @NonNull String menuName, @NonNull List<String> vrCommands) {
+        this();
+        setChoiceID(choiceID);
+        setMenuName(menuName);
+        setVrCommands(vrCommands);
+    }
+    /**
      * Get the application-scoped identifier that uniquely identifies this choice.
      * @return choiceID Min: 0;  Max: 65535
      */

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
@@ -79,13 +79,11 @@ public class Choice extends RPCStruct {
      * Constructs a newly allocated Choice object
      * @param choiceID Min: 0  Max: 65535
      * @param menuName the menu name
-     * @param vrCommands the List of  vrCommands
      */
-    public Choice(@NonNull Integer choiceID, @NonNull String menuName, @NonNull List<String> vrCommands) {
+    public Choice(@NonNull Integer choiceID, @NonNull String menuName) {
         this();
         setChoiceID(choiceID);
         setMenuName(menuName);
-        setVrCommands(vrCommands);
     }
     /**
      * Get the application-scoped identifier that uniquely identifies this choice.

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
@@ -91,7 +91,7 @@ public class Choice extends RPCStruct {
      * @param menuName the menu name
      * @param vrCommands the List of  vrCommands
      *
-     * Deprecated - use constructor without the forced use of vrCommands
+     * Deprecated - use {@link #Choice(Integer, String)}
      */
     @Deprecated
     public Choice(@NonNull Integer choiceID, @NonNull String menuName, @NonNull List<String> vrCommands) {

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
@@ -146,7 +146,7 @@ public class Choice extends RPCStruct {
      * @param vrCommands the List of  vrCommands
      * @since SmartDeviceLink 2.0
      */    
-    public void setVrCommands(@NonNull List<String> vrCommands) {
+    public void setVrCommands(List<String> vrCommands) {
         setValue(KEY_VR_COMMANDS, vrCommands);
     }
     /**

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
@@ -3,7 +3,9 @@ package com.smartdevicelink.proxy.rpc;
 import android.support.annotation.NonNull;
 
 import com.smartdevicelink.proxy.RPCStruct;
+import com.smartdevicelink.util.Version;
 
+import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
 
@@ -85,6 +87,38 @@ public class Choice extends RPCStruct {
         setChoiceID(choiceID);
         setMenuName(menuName);
     }
+
+    /**
+     * VrCommands became optional as of RPC Spec 5.0. On legacy systems, we must still set VrCommands, as
+     * they are expected, even though the developer may not specify them. <br>
+     *
+     * Additionally, VrCommands must be unique, therefore we will use the string value of the command's ID
+     *
+     * @param rpcVersion the rpc spec version that has been negotiated. If value is null the
+     *                   the max value of RPC spec version this library supports should be used.
+     * @param formatParams if true, the format method will be called on subsequent params
+     */
+    @Override
+    public void format(Version rpcVersion, boolean formatParams){
+
+        if (rpcVersion == null || rpcVersion.getMajor() < 5){
+
+            // make sure there is at least one vr param
+            List<String> existingVrCommands = getVrCommands();
+
+            if (existingVrCommands == null || existingVrCommands.size() == 0) {
+                // if no commands set, set one due to a legacy head unit requirement
+                Integer choiceID = getChoiceID();
+                List<String> vrCommands = new ArrayList<>();
+                vrCommands.add(String.valueOf(choiceID));
+                setVrCommands(vrCommands);
+            }
+        }
+
+        super.format(rpcVersion, formatParams);
+    }
+
+
     /**
      * Constructs a newly allocated Choice object
      * @param choiceID Min: 0  Max: 65535

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/Choice.java
@@ -66,10 +66,12 @@ public class Choice extends RPCStruct {
 	public static final String KEY_VR_COMMANDS = "vrCommands";
 	public static final String KEY_CHOICE_ID = "choiceID";
 	public static final String KEY_IMAGE = "image";
+
 	/**
 	 * Constructs a newly allocated Choice object
 	 */
     public Choice() { }
+
     /**
      * Constructs a newly allocated Choice object indicated by the Hashtable parameter
      * @param hash The Hashtable to use
@@ -77,6 +79,7 @@ public class Choice extends RPCStruct {
     public Choice(Hashtable<String, Object> hash) {
         super(hash);
     }
+
     /**
      * Constructs a newly allocated Choice object
      * @param choiceID Min: 0  Max: 65535
@@ -86,6 +89,22 @@ public class Choice extends RPCStruct {
         this();
         setChoiceID(choiceID);
         setMenuName(menuName);
+    }
+    
+    /**
+     * Constructs a newly allocated Choice object
+     * @param choiceID Min: 0  Max: 65535
+     * @param menuName the menu name
+     * @param vrCommands the List of  vrCommands
+     *
+     * Deprecated - use {@link #Choice(Integer, String)}
+     */
+    @Deprecated
+    public Choice(@NonNull Integer choiceID, @NonNull String menuName, @NonNull List<String> vrCommands) {
+        this();
+        setChoiceID(choiceID);
+        setMenuName(menuName);
+        setVrCommands(vrCommands);
     }
 
     /**
@@ -118,22 +137,6 @@ public class Choice extends RPCStruct {
         super.format(rpcVersion, formatParams);
     }
 
-
-    /**
-     * Constructs a newly allocated Choice object
-     * @param choiceID Min: 0  Max: 65535
-     * @param menuName the menu name
-     * @param vrCommands the List of  vrCommands
-     *
-     * Deprecated - use {@link #Choice(Integer, String)}
-     */
-    @Deprecated
-    public Choice(@NonNull Integer choiceID, @NonNull String menuName, @NonNull List<String> vrCommands) {
-        this();
-        setChoiceID(choiceID);
-        setMenuName(menuName);
-        setVrCommands(vrCommands);
-    }
     /**
      * Get the application-scoped identifier that uniquely identifies this choice.
      * @return choiceID Min: 0;  Max: 65535


### PR DESCRIPTION
Fixes #739 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
unit tests as they existed, no logic changed, just adding a constructor

### Summary
- deprecate old constructor
- add new one without vr commands

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)