### PR TITLE
Add ManagerListener with way to notify of disposal

### DIFF
--- a/sdl_android/build.gradle
+++ b/sdl_android/build.gradle
@@ -5,8 +5,8 @@ android {
     defaultConfig {
         minSdkVersion 8
         targetSdkVersion 19
-        versionCode 5
-        versionName "4.6.1"
+        versionCode 6
+        versionName "4.6.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         resValue "string", "SDL_LIB_VERSION", '\"' + versionName + '\"'
     }

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/api/SdlManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/api/SdlManagerTests.java
@@ -145,11 +145,16 @@ public class SdlManagerTests extends AndroidTestCase {
 	public void testStartingManager(){
 		listenerCalledCounter = 0;
 
-		sdlManager.start(new CompletionListener() {
+		sdlManager.start(new ManagerListener() {
 			@Override
-			public void onComplete(boolean success) {
+			public void onStart(boolean success) {
 				assertTrue(success);
 				listenerCalledCounter++;
+			}
+
+			@Override
+			public void onDestroy() {
+
 			}
 		});
 

--- a/sdl_android/src/main/java/com/smartdevicelink/api/ManagerListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/ManagerListener.java
@@ -1,0 +1,15 @@
+package com.smartdevicelink.api;
+
+public interface ManagerListener {
+
+	/**
+	 * Called when a manager is ready for use or failed setup
+	 * @param success - success or fail
+	 */
+	void onStart(boolean success);
+
+	/**
+	 * Called when the manager is destroyed
+	 */
+	void onDestroy();
+}

--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
@@ -64,7 +64,7 @@ public class SdlManager{
 	private Vector<TTSChunk> ttsChunks;
 	private TemplateColorScheme dayColorScheme, nightColorScheme;
 
-	private CompletionListener initListener;
+	private ManagerListener managerListener;
 	private int state = -1;
 	//public LockScreenConfig lockScreenConfig;
 
@@ -127,9 +127,8 @@ public class SdlManager{
 					*/
 					){
 				state = BaseSubManager.READY;
-				if(initListener != null){
-					initListener.onComplete(true);
-					initListener = null;
+				if(managerListener != null){
+					managerListener.onStart(true);
 				}
 			}
 		}
@@ -165,6 +164,10 @@ public class SdlManager{
 		this.videoStreamingManager.dispose();
 		this.audioStreamManager.dispose();
 		*/
+		if(managerListener != null){
+			managerListener.onDestroy();
+			managerListener = null;
+		}
 	}
 
 	/**
@@ -503,12 +506,11 @@ public class SdlManager{
 
 	/**
 	 * Starts up a SdlManager, and calls provided callback called once all BaseSubManagers are done setting up
-	 * @param listener CompletionListener that is called once the SdlManager state transitions
-	 * from SETTING_UP to READY or ERROR
+	 * @param listener ManagerListener that is called when the SdlManager is ready / failed to start, or is destroyed
 	 */
 	@SuppressWarnings("unchecked")
-	public void start(@NonNull CompletionListener listener){
-		initListener = listener;
+	public void start(@NonNull ManagerListener listener){
+		managerListener = listener;
 		if (proxy == null) {
 			try {
 				proxy = new SdlProxyBase(proxyBridge, appName, shortAppName, isMediaApp, hmiLanguage,
@@ -516,7 +518,7 @@ public class SdlManager{
 						nightColorScheme) {
 				};
 			} catch (SdlException e) {
-				listener.onComplete(false);
+				listener.onStart(false);
 			}
 		}
 	}

--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
@@ -500,6 +500,22 @@ public class SdlManager{
 		}
 	}
 
+	/**
+	 * Add an OnRPCNotificationListener for HMI status notifications
+	 * @param listener listener that will be called when the HMI status changes
+	 */
+	public void addOnHmiStatusListener(OnRPCNotificationListener listener){
+		proxy.addOnRPCNotificationListener(FunctionID.ON_HMI_STATUS,listener);
+	}
+
+	/**
+	 * Remove an OnRPCNotificationListener for HMI status notifications
+	 * @param listener listener that was previously added for the HMI status notifications
+	 */
+	public void removeOnHmiStatusListener(OnRPCNotificationListener listener){
+		proxy.removeOnRPCNotificationListener(FunctionID.ON_HMI_STATUS, listener);
+	}
+
 	// LIFECYCLE / OTHER
 
 	// STARTUP

--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
@@ -64,7 +64,7 @@ public class SdlManager{
 	private Vector<TTSChunk> ttsChunks;
 	private TemplateColorScheme dayColorScheme, nightColorScheme;
 
-	private ManagerListener managerListener;
+	private SdlManagerListener managerListener;
 	private int state = -1;
 	//public LockScreenConfig lockScreenConfig;
 
@@ -500,22 +500,6 @@ public class SdlManager{
 		}
 	}
 
-	/**
-	 * Add an OnRPCNotificationListener for HMI status notifications
-	 * @param listener listener that will be called when the HMI status changes
-	 */
-	public void addOnHmiStatusListener(OnRPCNotificationListener listener){
-		proxy.addOnRPCNotificationListener(FunctionID.ON_HMI_STATUS,listener);
-	}
-
-	/**
-	 * Remove an OnRPCNotificationListener for HMI status notifications
-	 * @param listener listener that was previously added for the HMI status notifications
-	 */
-	public void removeOnHmiStatusListener(OnRPCNotificationListener listener){
-		proxy.removeOnRPCNotificationListener(FunctionID.ON_HMI_STATUS, listener);
-	}
-
 	// LIFECYCLE / OTHER
 
 	// STARTUP
@@ -525,7 +509,7 @@ public class SdlManager{
 	 * @param listener ManagerListener that is called when the SdlManager is ready / failed to start, or is destroyed
 	 */
 	@SuppressWarnings("unchecked")
-	public void start(@NonNull ManagerListener listener){
+	public void start(@NonNull SdlManagerListener listener){
 		managerListener = listener;
 		if (proxy == null) {
 			try {

--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManagerListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManagerListener.java
@@ -1,6 +1,6 @@
 package com.smartdevicelink.api;
 
-public interface ManagerListener {
+public interface SdlManagerListener {
 
 	/**
 	 * Called when a manager is ready for use or failed setup
@@ -12,4 +12,11 @@ public interface ManagerListener {
 	 * Called when the manager is destroyed
 	 */
 	void onDestroy();
+
+	/**
+	 * Called when there is an error
+	 * @param info info regarding the error
+	 * @param e the exception
+	 */
+	void onError(String info, Exception e);
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2130,7 +2130,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					_proxyVersionInfo = msg.getProxyVersionInfo();
 					_iconResumed = msg.getIconResumed();
 					
-
+					if (_iconResumed == null){
+						_iconResumed = false;
+					}
 
 					if (_bAppResumeEnabled)
 					{

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
@@ -380,11 +380,22 @@ public class RegisterAppInterfaceResponse extends RPCResponse {
         return getString(KEY_SYSTEM_SOFTWARE_VERSION);
     }
 
-    public void setIconResumed(Boolean iconResumed){
-        setParameters(KEY_ICON_RESUMED, iconResumed);
-    }
+	/**
+	 * Sets Icon Resumed Boolean
+	 * @param iconResumed - if param not included, set to false
+	 */
+	public void setIconResumed(Boolean iconResumed){
+		if(iconResumed == null){
+			iconResumed = false;
+		}
+		setParameters(KEY_ICON_RESUMED, iconResumed);
+	}
 
-    public Boolean getIconResumed() {
-        return getBoolean(KEY_ICON_RESUMED);
-    }
+	/**
+	 * Tells developer whether or not their app icon has been resumed on core.
+	 * @return boolean - true if icon was resumed, false if not
+	 */
+	public Boolean getIconResumed() {
+		return getBoolean(KEY_ICON_RESUMED);
+	}
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -294,7 +294,12 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			Intent intent = new Intent();
 			intent.setClassName(packageName, className);
 			intent.putExtra(TransportConstants.PING_ROUTER_SERVICE_EXTRA, true);
-			context.startService(intent);
+			if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+				intent.putExtra(FOREGROUND_EXTRA, true);
+				context.startForegroundService(intent);
+			}else {
+				context.startService(intent);
+			}
 		}catch(SecurityException e){
 			Log.e(TAG, "Security exception, process is bad");
 			// This service could not be started


### PR DESCRIPTION
- SdlManager now takes in a ManagerListener with callbacks for start up and destroy
- Destroy callback is called in dispose() method
- Gives a way for SdlManager to “restart”

This PR is **[ready]** for review.