### PR TITLE
Add ManagerListener with way to notify of disposal

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/api/SdlManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/api/SdlManagerTests.java
@@ -98,6 +98,22 @@ public class SdlManagerTests extends AndroidTestCase {
 		builder.setNightColorScheme(templateColorScheme);
 		builder.setVrSynonyms(Test.GENERAL_VECTOR_STRING);
 		builder.setTtsName(Test.GENERAL_VECTOR_TTS_CHUNKS);
+		builder.setManagerListener(new SdlManagerListener() {
+			@Override
+			public void onStart() {
+				listenerCalledCounter++;
+			}
+
+			@Override
+			public void onDestroy() {
+
+			}
+
+			@Override
+			public void onError(String info, Exception e) {
+
+			}
+		});
 		manager = builder.build();
 
 		// mock SdlProxyBase and set it manually
@@ -145,23 +161,7 @@ public class SdlManagerTests extends AndroidTestCase {
 	public void testStartingManager(){
 		listenerCalledCounter = 0;
 
-		sdlManager.start(new SdlManagerListener() {
-			@Override
-			public void onStart(boolean success) {
-				assertTrue(success);
-				listenerCalledCounter++;
-			}
-
-			@Override
-			public void onDestroy() {
-
-			}
-
-			@Override
-			public void onError(String info, Exception e) {
-
-			}
-		});
+		sdlManager.start();
 
 		// Create and force all sub managers to be ready manually. Because SdlManager will not start until all sub managers are ready.
 		// Note : SdlManager.initialize() will not be called automatically by proxy as in real life because we have mock proxy not a real one

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/api/SdlManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/api/SdlManagerTests.java
@@ -145,7 +145,7 @@ public class SdlManagerTests extends AndroidTestCase {
 	public void testStartingManager(){
 		listenerCalledCounter = 0;
 
-		sdlManager.start(new ManagerListener() {
+		sdlManager.start(new SdlManagerListener() {
 			@Override
 			public void onStart(boolean success) {
 				assertTrue(success);
@@ -154,6 +154,11 @@ public class SdlManagerTests extends AndroidTestCase {
 
 			@Override
 			public void onDestroy() {
+
+			}
+
+			@Override
+			public void onError(String info, Exception e) {
 
 			}
 		});

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/api/SdlManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/api/SdlManagerTests.java
@@ -85,20 +85,7 @@ public class SdlManagerTests extends AndroidTestCase {
 	private SdlManager createSampleManager(String appName, String appId){
 		SdlManager manager;
 
-		// build manager object - use all setters, will test using getters below
-		SdlManager.Builder builder = new SdlManager.Builder();
-		builder.setAppId(appId);
-		builder.setAppName(appName);
-		builder.setShortAppName(appName);
-		builder.setAppTypes(appType);
-		builder.setTransportType(transport);
-		builder.setContext(getTestContext());
-		builder.setLanguage(Language.EN_US);
-		builder.setDayColorScheme(templateColorScheme);
-		builder.setNightColorScheme(templateColorScheme);
-		builder.setVrSynonyms(Test.GENERAL_VECTOR_STRING);
-		builder.setTtsName(Test.GENERAL_VECTOR_TTS_CHUNKS);
-		builder.setManagerListener(new SdlManagerListener() {
+		SdlManagerListener listener = new SdlManagerListener() {
 			@Override
 			public void onStart() {
 				listenerCalledCounter++;
@@ -113,7 +100,18 @@ public class SdlManagerTests extends AndroidTestCase {
 			public void onError(String info, Exception e) {
 
 			}
-		});
+		};
+
+		// build manager object - use all setters, will test using getters below
+		SdlManager.Builder builder = new SdlManager.Builder(getTestContext(),appId,appName,listener);
+		builder.setShortAppName(appName);
+		builder.setAppTypes(appType);
+		builder.setTransportType(transport);
+		builder.setLanguage(Language.EN_US);
+		builder.setDayColorScheme(templateColorScheme);
+		builder.setNightColorScheme(templateColorScheme);
+		builder.setVrSynonyms(Test.GENERAL_VECTOR_STRING);
+		builder.setTtsName(Test.GENERAL_VECTOR_TTS_CHUNKS);
 		manager = builder.build();
 
 		// mock SdlProxyBase and set it manually

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/api/SdlManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/api/SdlManagerTests.java
@@ -145,11 +145,16 @@ public class SdlManagerTests extends AndroidTestCase {
 	public void testStartingManager(){
 		listenerCalledCounter = 0;
 
-		sdlManager.start(new CompletionListener() {
+		sdlManager.start(new ManagerListener() {
 			@Override
-			public void onComplete(boolean success) {
+			public void onStart(boolean success) {
 				assertTrue(success);
 				listenerCalledCounter++;
+			}
+
+			@Override
+			public void onDestroy() {
+
 			}
 		});
 

--- a/sdl_android/src/main/java/com/smartdevicelink/api/ManagerListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/ManagerListener.java
@@ -1,0 +1,15 @@
+package com.smartdevicelink.api;
+
+public interface ManagerListener {
+
+	/**
+	 * Called when a manager is ready for use or failed setup
+	 * @param success - success or fail
+	 */
+	void onStart(boolean success);
+
+	/**
+	 * Called when the manager is destroyed
+	 */
+	void onDestroy();
+}

--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
@@ -184,15 +184,18 @@ public class SdlManager{
 		SdlManager sdlManager;
 
 		/**
-		 * Main Builder for SDL Manager<br>
-		 *
-		 * The following setters are <strong>REQUIRED:</strong><br>
-		 *
-		 * • setAppId <br>
-		 * • setAppName
+		 * Builder for the SdlManager. Parameters in the constructor are required.
+		 * @param context the current context
+		 * @param appId the app's ID
+		 * @param appName the app's name
+		 * @param listener a SdlManagerListener object
 		 */
-		public Builder(){
+		public Builder(@NonNull Context context, @NonNull final String appId, @NonNull final String appName, @NonNull final SdlManagerListener listener){
 			sdlManager = new SdlManager();
+			setContext(context);
+			setAppId(appId);
+			setAppName(appName);
+			setManagerListener(listener);
 		}
 
 		/**
@@ -312,7 +315,7 @@ public class SdlManager{
 		 * Set the SdlManager Listener
 		 * @param listener the listener
 		 */
-		public Builder setManagerListener(@NonNull SdlManagerListener listener){
+		public Builder setManagerListener(@NonNull final SdlManagerListener listener){
 			sdlManager.managerListener = listener;
 			return this;
 		}

--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
@@ -64,7 +64,7 @@ public class SdlManager{
 	private Vector<TTSChunk> ttsChunks;
 	private TemplateColorScheme dayColorScheme, nightColorScheme;
 
-	private ManagerListener managerListener;
+	private SdlManagerListener managerListener;
 	private int state = -1;
 	//public LockScreenConfig lockScreenConfig;
 
@@ -500,22 +500,6 @@ public class SdlManager{
 		}
 	}
 
-	/**
-	 * Add an OnRPCNotificationListener for HMI status notifications
-	 * @param listener listener that will be called when the HMI status changes
-	 */
-	public void addOnHmiStatusListener(OnRPCNotificationListener listener){
-		proxy.addOnRPCNotificationListener(FunctionID.ON_HMI_STATUS,listener);
-	}
-
-	/**
-	 * Remove an OnRPCNotificationListener for HMI status notifications
-	 * @param listener listener that was previously added for the HMI status notifications
-	 */
-	public void removeOnHmiStatusListener(OnRPCNotificationListener listener){
-		proxy.removeOnRPCNotificationListener(FunctionID.ON_HMI_STATUS, listener);
-	}
-
 	// LIFECYCLE / OTHER
 
 	// STARTUP
@@ -525,7 +509,7 @@ public class SdlManager{
 	 * @param listener ManagerListener that is called when the SdlManager is ready / failed to start, or is destroyed
 	 */
 	@SuppressWarnings("unchecked")
-	public void start(@NonNull ManagerListener listener){
+	public void start(@NonNull SdlManagerListener listener){
 		managerListener = listener;
 		if (proxy == null) {
 			try {

--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
@@ -128,7 +128,7 @@ public class SdlManager{
 					){
 				state = BaseSubManager.READY;
 				if(managerListener != null){
-					managerListener.onStart(true);
+					managerListener.onStart();
 				}
 			}
 		}
@@ -308,13 +308,27 @@ public class SdlManager{
 			return this;
 		}
 
+		/**
+		 * Set the SdlManager Listener
+		 * @param listener the listener
+		 */
+		public Builder setManagerListener(@NonNull SdlManagerListener listener){
+			sdlManager.managerListener = listener;
+			return this;
+		}
+
 		public SdlManager build() {
+
 			if (sdlManager.appName == null) {
 				throw new IllegalArgumentException("You must specify an app name by calling setAppName");
 			}
 
 			if (sdlManager.appId == null) {
 				throw new IllegalArgumentException("You must specify an app ID by calling setAppId");
+			}
+
+			if (sdlManager.managerListener == null) {
+				throw new IllegalArgumentException("You must set a SdlManagerListener object");
 			}
 
 			if (sdlManager.hmiTypes == null) {
@@ -506,11 +520,9 @@ public class SdlManager{
 
 	/**
 	 * Starts up a SdlManager, and calls provided callback called once all BaseSubManagers are done setting up
-	 * @param listener ManagerListener that is called when the SdlManager is ready / failed to start, or is destroyed
 	 */
 	@SuppressWarnings("unchecked")
-	public void start(@NonNull SdlManagerListener listener){
-		managerListener = listener;
+	public void start(){
 		if (proxy == null) {
 			try {
 				proxy = new SdlProxyBase(proxyBridge, appName, shortAppName, isMediaApp, hmiLanguage,
@@ -518,7 +530,9 @@ public class SdlManager{
 						nightColorScheme) {
 				};
 			} catch (SdlException e) {
-				listener.onStart(false);
+				if (managerListener != null) {
+					managerListener.onError("Unable to start manager", e);
+				}
 			}
 		}
 	}

--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManagerListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManagerListener.java
@@ -1,6 +1,6 @@
 package com.smartdevicelink.api;
 
-public interface ManagerListener {
+public interface SdlManagerListener {
 
 	/**
 	 * Called when a manager is ready for use or failed setup
@@ -12,4 +12,11 @@ public interface ManagerListener {
 	 * Called when the manager is destroyed
 	 */
 	void onDestroy();
+
+	/**
+	 * Called when the manager encounters an error
+	 * @param info info regarding the error
+	 * @param e the exception
+	 */
+	void onError(String info, Exception e);
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManagerListener.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManagerListener.java
@@ -3,10 +3,9 @@ package com.smartdevicelink.api;
 public interface SdlManagerListener {
 
 	/**
-	 * Called when a manager is ready for use or failed setup
-	 * @param success - success or fail
+	 * Called when a manager is ready for use
 	 */
-	void onStart(boolean success);
+	void onStart();
 
 	/**
 	 * Called when the manager is destroyed


### PR DESCRIPTION
-SdlManager now takes in a ManagerListener with callbacks for start up and destroy
-Destroy callback is called in dispose() method
-Gives a way for SdlManager to “restart”
-Adds HMI listener methods to let developer know when to start video or audio stream

This PR is **[ready]** for review.