### PR TITLE
Add ability for RPCs to be versioned/formatted

### DIFF
--- a/sdl_android/build.gradle
+++ b/sdl_android/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     })
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.9.0'
-    api 'com.android.support:support-annotations:27.1.1'
+    api 'com.android.support:support-annotations:27.+'
 }
 
 buildscript {

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/notifications/OnHMIStatusTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/notifications/OnHMIStatusTests.java
@@ -12,6 +12,7 @@ import com.smartdevicelink.proxy.rpc.enums.SystemContext;
 import com.smartdevicelink.proxy.rpc.enums.VideoStreamingState;
 import com.smartdevicelink.test.BaseRpcTests;
 import com.smartdevicelink.test.Test;
+import com.smartdevicelink.util.Version;
 
 /**
  * This is a unit test class for the SmartDeviceLink library project class : 
@@ -80,6 +81,9 @@ public class OnHMIStatusTests extends BaseRpcTests{
         testNullBase(msg);
 
         assertNull(Test.NULL, msg.getAudioStreamingState());
+
+        assertNull(Test.NULL, msg.getVideoStreamingState());
+        msg.format(new Version(4,5,0),true);
         assertEquals(Test.MATCH, VideoStreamingState.STREAMABLE, msg.getVideoStreamingState());
         assertNull(Test.NULL, msg.getHmiLevel());
         assertNull(Test.NULL, msg.getSystemContext());

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/MockPacketizer.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/streaming/MockPacketizer.java
@@ -5,6 +5,7 @@ import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.streaming.AbstractPacketizer;
 import com.smartdevicelink.streaming.IStreamListener;
+import com.smartdevicelink.util.Version;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,6 +16,7 @@ import java.io.InputStream;
  */
 public class MockPacketizer extends AbstractPacketizer {
 	public MockPacketizer (IStreamListener l, InputStream i, SessionType s, byte sid, SdlSession sdlsession) throws IOException { super (l, i, s, sid, sdlsession); }
+	public MockPacketizer (IStreamListener l, InputStream i, RPCRequest r, SessionType s, byte sid, Version protocolVersion,SdlSession sdlsession) throws IOException { super (l, i, r, s, sid, protocolVersion, sdlsession); }
 	public MockPacketizer (IStreamListener l, InputStream i, RPCRequest r, SessionType s, byte sid, byte w, SdlSession sdlsession) throws IOException { super (l, i, r, s, sid, w, sdlsession); }
 
 	@Override public void start() throws IOException { }
@@ -26,7 +28,9 @@ public class MockPacketizer extends AbstractPacketizer {
 	public SdlSession getSdlSession    () { return _session;    	}
 	public byte getSessionId           () { return _rpcSessionID;   }
 	public RPCRequest getRPCRequest    () { return _request;        }
-	public byte getWiproVersion        () { return _wiproVersion;   }
+	@Deprecated
+	public byte getWiproVersion        () { if(_wiproVersion != null){return (byte)_wiproVersion.getMajor(); }else{return 5;}}
+	public Version getProtocolVersion  () { return _wiproVersion;   }
 
 	@Override public void pause() { }
 	@Override public void resume() { }

--- a/sdl_android/src/main/java/com/smartdevicelink/marshal/JsonRPCMarshaller.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/marshal/JsonRPCMarshaller.java
@@ -26,7 +26,7 @@ public class JsonRPCMarshaller {
 	private static final String SDL_LIB_PRIVATE_KEY = "42baba60-eb57-11df-98cf-0800200c9a66";
 
 	@Deprecated
-	public static byte[] marshall(RPCMessage msg, byte version, boolean test) {
+	public static byte[] marshall(RPCMessage msg, byte version) {
 		return marshall(msg,new Version(version+""),null);
 	}
 
@@ -89,7 +89,7 @@ public class JsonRPCMarshaller {
 
     @SuppressWarnings("unchecked")
 	@Deprecated
-	private static JSONArray serializeList(List<?> list, boolean test) throws JSONException{
+	private static JSONArray serializeList(List<?> list) throws JSONException{
 		return serializeList(list,null);
 
 	}
@@ -114,7 +114,7 @@ public class JsonRPCMarshaller {
 
 	@SuppressWarnings({"unchecked" })
 	@Deprecated
-    public static JSONObject serializeHashtable(Hashtable<String, Object> hash, boolean test) throws JSONException{
+    public static JSONObject serializeHashtable(Hashtable<String, Object> hash) throws JSONException{
 		return serializeHashtable(hash,null);
 	}
 

--- a/sdl_android/src/main/java/com/smartdevicelink/marshal/JsonRPCMarshaller.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/marshal/JsonRPCMarshaller.java
@@ -27,7 +27,7 @@ public class JsonRPCMarshaller {
 
 	@Deprecated
 	public static byte[] marshall(RPCMessage msg, byte version) {
-		return marshall(msg,new Version(version+""),null);
+		return marshall(msg,new Version(version,0,0),null);
 	}
 
 	public static byte[] marshall(RPCMessage msg, Version protocolVersion, Version rpcMsgVersion) {

--- a/sdl_android/src/main/java/com/smartdevicelink/marshal/JsonRPCMarshaller.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/marshal/JsonRPCMarshaller.java
@@ -25,15 +25,15 @@ public class JsonRPCMarshaller {
 	
 	private static final String SDL_LIB_PRIVATE_KEY = "42baba60-eb57-11df-98cf-0800200c9a66";
 
-	@Deprecated
+	/**
+	 * @param msg RPC message to be marshaled
+	 * @param version protocol version
+	 * @return byte array of the marshalled message
+	 */
 	public static byte[] marshall(RPCMessage msg, byte version) {
-		return marshall(msg,new Version(version,0,0),null);
-	}
-
-	public static byte[] marshall(RPCMessage msg, Version protocolVersion, Version rpcMsgVersion) {
 		byte[] jsonBytes = null;
 		try {
-			JSONObject jsonObject = msg.serializeJSON(protocolVersion, rpcMsgVersion);
+			JSONObject jsonObject = msg.serializeJSON(version);
 			jsonBytes = jsonObject.toString().getBytes();
 			
 			SdlTrace.logMarshallingEvent(InterfaceActivityDirection.Transmit, jsonBytes, SDL_LIB_PRIVATE_KEY);
@@ -87,24 +87,17 @@ public class JsonRPCMarshaller {
 		return ret;
 	}
 
-    @SuppressWarnings("unchecked")
-	@Deprecated
 	private static JSONArray serializeList(List<?> list) throws JSONException{
-		return serializeList(list,null);
-
-	}
-
-	private static JSONArray serializeList(List<?> list, Version rpcVersion) throws JSONException{
 		JSONArray toPut = new JSONArray();
 		Iterator<Object> valueIterator = (Iterator<Object>) list.iterator();
 		while(valueIterator.hasNext()){
 			Object anObject = valueIterator.next();
 			if (anObject instanceof RPCStruct) {
 				RPCStruct toSerialize = (RPCStruct) anObject;
-				toPut.put(toSerialize.serializeStoreJSON(rpcVersion));
+				toPut.put(toSerialize.serializeJSON());
 			} else if(anObject instanceof Hashtable){
 				Hashtable<String, Object> toSerialize = (Hashtable<String, Object>)anObject;
-				toPut.put(serializeHashtable(toSerialize,rpcVersion));
+				toPut.put(serializeHashtable(toSerialize));
 			} else {
 				toPut.put(anObject);
 			}
@@ -113,23 +106,18 @@ public class JsonRPCMarshaller {
 	}
 
 	@SuppressWarnings({"unchecked" })
-	@Deprecated
     public static JSONObject serializeHashtable(Hashtable<String, Object> hash) throws JSONException{
-		return serializeHashtable(hash,null);
-	}
-
-    public static JSONObject serializeHashtable(Hashtable<String, Object> hash, Version rpcVersion) throws JSONException{
 		JSONObject obj = new JSONObject();
 		Iterator<String> hashKeyIterator = hash.keySet().iterator();
 		while (hashKeyIterator.hasNext()){
 			String key = (String) hashKeyIterator.next();
 			Object value = hash.get(key);
 			if (value instanceof RPCStruct) {
-				obj.put(key, ((RPCStruct) value).serializeStoreJSON(rpcVersion));
+				obj.put(key, ((RPCStruct) value).serializeJSON());
 			} else if (value instanceof List<?>) {
-				obj.put(key, serializeList((List<?>) value,rpcVersion));
+				obj.put(key, serializeList((List<?>) value));
 			} else if (value instanceof Hashtable) {
-				obj.put(key, serializeHashtable((Hashtable<String, Object>)value, rpcVersion));
+				obj.put(key, serializeHashtable((Hashtable<String, Object>)value));
 			} else {
 				obj.put(key, value);
 			}

--- a/sdl_android/src/main/java/com/smartdevicelink/marshal/JsonRPCMarshaller.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/marshal/JsonRPCMarshaller.java
@@ -11,7 +11,6 @@ import org.json.JSONObject;
 
 import com.smartdevicelink.proxy.RPCMessage;
 import com.smartdevicelink.proxy.RPCStruct;
-import com.smartdevicelink.util.Version;
 import com.smartdevicelink.trace.*;
 import com.smartdevicelink.trace.enums.InterfaceActivityDirection;
 import com.smartdevicelink.util.DebugTool;
@@ -87,6 +86,7 @@ public class JsonRPCMarshaller {
 		return ret;
 	}
 
+	@SuppressWarnings({"unchecked" })
 	private static JSONArray serializeList(List<?> list) throws JSONException{
 		JSONArray toPut = new JSONArray();
 		Iterator<Object> valueIterator = (Iterator<Object>) list.iterator();

--- a/sdl_android/src/main/java/com/smartdevicelink/marshal/JsonRPCMarshaller.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/marshal/JsonRPCMarshaller.java
@@ -86,7 +86,7 @@ public class JsonRPCMarshaller {
 		return ret;
 	}
 
-	@SuppressWarnings({"unchecked" })
+	@SuppressWarnings("unchecked" )
 	private static JSONArray serializeList(List<?> list) throws JSONException{
 		JSONArray toPut = new JSONArray();
 		Iterator<Object> valueIterator = (Iterator<Object>) list.iterator();

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
@@ -89,7 +89,7 @@ public class RPCStruct {
 		formatRequested = true;
 		rpcSpecVersion = rpcVersion;
 		//Should override this method when breaking changes are made to the RPC spec
-		if(formatParams == true && store != null){
+		if(formatParams && store != null){
 			Hashtable<String, Object> parameters;
 
 			if(this instanceof RPCMessage) {

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
@@ -57,7 +57,7 @@ public class RPCStruct {
 		return JsonRPCMarshaller.deserializeJSONObject(jsonObject);
 	}
 	
-	public JSONObject serializeJSON(boolean test) throws JSONException {
+	public JSONObject serializeJSON() throws JSONException {
 		return serializeStoreJSON(null);
 	}
 
@@ -67,7 +67,7 @@ public class RPCStruct {
 	}
 	
 	@SuppressWarnings("unchecked")
-    public JSONObject serializeJSON(byte protocolVersion,boolean test) throws JSONException {
+    public JSONObject serializeJSON(byte protocolVersion) throws JSONException {
 		return serializeJSON(new Version(protocolVersion+".0.0"), null);
 	}
 

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
@@ -1,5 +1,7 @@
 package com.smartdevicelink.proxy;
 
+import android.util.Log;
+
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
 import com.smartdevicelink.util.Version;
 
@@ -20,6 +22,10 @@ public class RPCStruct {
     
 	private byte[] _bulkData = null;
 	private Boolean protectedPayload = false;
+
+	private boolean formatRequested = false;
+	private Version rpcSpecVersion = null;
+
 
 	protected Hashtable<String, Object> store = null;
 	
@@ -57,37 +63,68 @@ public class RPCStruct {
 		return JsonRPCMarshaller.deserializeJSONObject(jsonObject);
 	}
 
-	@Deprecated
 	public JSONObject serializeJSON() throws JSONException {
-		return serializeStoreJSON(null);
-	}
-
-	public JSONObject serializeStoreJSON(Version rpcMsgVersion) throws JSONException {
-		format(rpcMsgVersion);
-		return JsonRPCMarshaller.serializeHashtable(store, rpcMsgVersion);
+		return JsonRPCMarshaller.serializeHashtable(store);
 	}
 	
 	@SuppressWarnings("unchecked")
     public JSONObject serializeJSON(byte protocolVersion) throws JSONException {
-		return serializeJSON(new Version(protocolVersion,0,0), null);
-	}
-
-    public JSONObject serializeJSON(Version version, Version rpcMsgVersion) throws JSONException {
-		if (version.getMajor() > 1) {
+		if (protocolVersion > 1) {
 			String messageType = getMessageTypeName(store.keySet());
 			Hashtable<String, Object> function = (Hashtable<String, Object>) store.get(messageType);
 			Hashtable<String, Object> parameters = (Hashtable<String, Object>) function.get(RPCMessage.KEY_PARAMETERS);
-			return JsonRPCMarshaller.serializeHashtable(parameters,rpcMsgVersion);
-		} else return JsonRPCMarshaller.serializeHashtable(store, rpcMsgVersion);
+			return JsonRPCMarshaller.serializeHashtable(parameters);
+		} else return JsonRPCMarshaller.serializeHashtable(store);
 	}
 
 	/**
-	 * This method should clean the the RPC to make sure it is compliant with the spec
+	 * This method should clean the the RPC to make sure it is compliant with the spec.
+	 * <br><br><b> NOTE:</b> Super needs to be called at the END of the method
+	 *
 	 * @param rpcVersion the rpc spec version that has been negotiated. If value is null the
 	 *                   the max value of RPC spec version this library supports should be used.
+	 *  @param formatParams if true, the format method will be called on subsequent params
 	 */
-	protected void format(Version rpcVersion){
+	public void format(Version rpcVersion, boolean formatParams){
+		formatRequested = true;
+		rpcSpecVersion = rpcVersion;
 		//Should override this method when breaking changes are made to the RPC spec
+		if(formatParams == true && store != null){
+			Hashtable<String, Object> parameters;
+
+			if(this instanceof RPCMessage) {
+				//If this is a message (request, response, notification) the parameters have to be
+				//retrieved from the store object.
+				String messageType = getMessageTypeName(store.keySet());
+				Hashtable<String, Object> function = (Hashtable<String, Object>) store.get(messageType);
+				parameters = (Hashtable<String, Object>) function.get(RPCMessage.KEY_PARAMETERS);
+			} else {
+				//If this is just an RPC struct the store itself should be used
+				parameters = store;
+			}
+
+			for(Object value:parameters.values()){
+				internalFormat(rpcVersion, value);
+			}
+		}
+	}
+
+	/**
+	 * Cycles through parameters in this RPC to ensure they all get formated
+	 * @param rpcVersion version of the rpc spec that should be used to format this rpc
+	 * @param value the object to investigate if it needs to be formated
+	 */
+	private void internalFormat(Version rpcVersion, Object value) {
+		if(value instanceof RPCStruct) {
+			((RPCStruct)value).format(rpcVersion,true);
+		} else if(value instanceof List<?>) {
+			List<?> list = (List<?>)value;
+			if(list != null && list.size() > 0) {
+				for(Object listItem: list){
+					internalFormat(rpcVersion, listItem);
+				}
+			}
+		}
 	}
 
 
@@ -178,7 +215,12 @@ public class RPCStruct {
 		} else if (obj instanceof Hashtable) {
 			try {
 				Constructor constructor = tClass.getConstructor(Hashtable.class);
-				return constructor.newInstance((Hashtable<String, Object>) obj);
+				Object customObject = constructor.newInstance((Hashtable<String, Object>) obj);
+				if(formatRequested && customObject instanceof RPCStruct){
+					((RPCStruct)customObject).format(rpcSpecVersion,true);
+				}
+
+				return customObject;
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
@@ -190,10 +232,17 @@ public class RPCStruct {
 					return list;
 				} else if (item instanceof Hashtable) {
 					List<Object> newList = new ArrayList<Object>();
+					Object customObject;
 					for (Object hashObj : list) {
 						try {
 							Constructor constructor = tClass.getConstructor(Hashtable.class);
-							newList.add(constructor.newInstance((Hashtable<String, Object>)hashObj));
+							customObject = constructor.newInstance((Hashtable<String, Object>) hashObj);
+							if(formatRequested
+									&& customObject != null
+									&& customObject instanceof RPCStruct){
+								((RPCStruct)customObject).format(rpcSpecVersion,true);
+							}
+							newList.add(customObject);
 						} catch (Exception e) {
 							e.printStackTrace();
 							return null;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCStruct.java
@@ -56,7 +56,8 @@ public class RPCStruct {
 			throws JSONException {
 		return JsonRPCMarshaller.deserializeJSONObject(jsonObject);
 	}
-	
+
+	@Deprecated
 	public JSONObject serializeJSON() throws JSONException {
 		return serializeStoreJSON(null);
 	}
@@ -68,7 +69,7 @@ public class RPCStruct {
 	
 	@SuppressWarnings("unchecked")
     public JSONObject serializeJSON(byte protocolVersion) throws JSONException {
-		return serializeJSON(new Version(protocolVersion+".0.0"), null);
+		return serializeJSON(new Version(protocolVersion,0,0), null);
 	}
 
     public JSONObject serializeJSON(Version version, Version rpcMsgVersion) throws JSONException {
@@ -82,7 +83,8 @@ public class RPCStruct {
 
 	/**
 	 * This method should clean the the RPC to make sure it is compliant with the spec
-	 * @param rpcVersion
+	 * @param rpcVersion the rpc spec version that has been negotiated. If value is null the
+	 *                   the max value of RPC spec version this library supports should be used.
 	 */
 	protected void format(Version rpcVersion){
 		//Should override this method when breaking changes are made to the RPC spec

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -127,7 +127,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	private static final int PROX_PROT_VER_ONE = 1;
 	private static final int RESPONSE_WAIT_TIME = 2000;
 
-	private static final com.smartdevicelink.util.Version MAX_SUPPORTED_RPC_VERSION = new com.smartdevicelink.util.Version("4.5.0");
+	public static final com.smartdevicelink.util.Version MAX_SUPPORTED_RPC_VERSION = new com.smartdevicelink.util.Version("5.0.0");
 
 	private SdlSession sdlSession = null;
 	private proxyListenerType _proxyListener = null;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -1647,20 +1647,16 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	
 	public String serializeJSON(RPCMessage msg)
 	{
-		String sReturn;
 		try
 		{
-			//sReturn = msg.serializeJSON(getWiProVersion()).toString(2);
-			sReturn = msg.serializeJSON(new com.smartdevicelink.util.Version(getWiProVersion(),0,0),
-					rpcSpecVersion ).toString(2);
-		}
+			return msg.serializeJSON(getWiProVersion()).toString(2);
+        }
 		catch (final Exception e) 
 		{
 			DebugTool.logError("Error handing proxy event.", e);
 			passErrorToProxyListener("Error serializing message.", e);
 			return null;
 		}
-		return sReturn;
 	}
 
 	private void handleErrorsFromIncomingMessageDispatcher(String info, Exception e) {
@@ -1804,8 +1800,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	private void sendRPCRequestPrivate(RPCRequest request) throws SdlException {
 			try {
 			SdlTrace.logRPCEvent(InterfaceActivityDirection.Transmit, request, SDL_LIB_TRACE_KEY);
-						
-			byte[] msgBytes = JsonRPCMarshaller.marshall(request, new com.smartdevicelink.util.Version(_wiproVersion,0,0), rpcSpecVersion);
+
+			request.format(rpcSpecVersion,true);
+			byte[] msgBytes = JsonRPCMarshaller.marshall(request, _wiproVersion);
 	
 			ProtocolMessage pm = new ProtocolMessage();
 			pm.setData(msgBytes);
@@ -2014,7 +2011,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	private void handleRPCMessage(Hashtable<String, Object> hash) {
 		RPCMessage rpcMsg = new RPCMessage(hash);
 		//Call format to ensure the RPC is ready to be handled regardless of RPC spec version
-		rpcMsg.format(rpcSpecVersion);
 
 		String functionName = rpcMsg.getFunctionName();
 		String messageType = rpcMsg.getMessageType();
@@ -2030,6 +2026,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 						&& _advancedLifecycleManagementEnabled 
 						&& functionName.equals(FunctionID.REGISTER_APP_INTERFACE.toString())) {
 					final RegisterAppInterfaceResponse msg = new RegisterAppInterfaceResponse(hash);
+					msg.format(rpcSpecVersion, true);
 					if (msg.getSuccess()) {
 						_appInterfaceRegisterd = true;
 					}
@@ -2054,7 +2051,11 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					_sdlLanguage = msg.getLanguage();
 					_hmiDisplayLanguage = msg.getHmiDisplayLanguage();
 					_sdlMsgVersion = msg.getSdlMsgVersion();
-					rpcSpecVersion = new com.smartdevicelink.util.Version(_sdlMsgVersion.getMajorVersion(),_sdlMsgVersion.getMinorVersion(), _sdlMsgVersion.getPatchVersion());
+					if(_sdlMsgVersion != null){
+						rpcSpecVersion = new com.smartdevicelink.util.Version(_sdlMsgVersion.getMajorVersion(),_sdlMsgVersion.getMinorVersion(), _sdlMsgVersion.getPatchVersion());
+					}else{
+						rpcSpecVersion = MAX_SUPPORTED_RPC_VERSION;
+					}
 					_vehicleType = msg.getVehicleType();
 					_systemSoftwareVersion = msg.getSystemSoftwareVersion();
 					_proxyVersionInfo = msg.getProxyVersionInfo();
@@ -2175,6 +2176,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 							APP_INTERFACE_REGISTERED_LOCK.notify();
 						}
 						final UnregisterAppInterfaceResponse msg = new UnregisterAppInterfaceResponse(hash);
+						msg.format(rpcSpecVersion, true);
 						Intent sendIntent = createBroadcastIntent();
 						updateBroadcastIntent(sendIntent, "RPC_NAME", FunctionID.UNREGISTER_APP_INTERFACE.toString());
 						updateBroadcastIntent(sendIntent, "TYPE", RPCMessage.KEY_RESPONSE);
@@ -2190,6 +2192,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			
 			if (functionName.equals(FunctionID.REGISTER_APP_INTERFACE.toString())) {
 				final RegisterAppInterfaceResponse msg = new RegisterAppInterfaceResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (msg.getSuccess()) {
 					_appInterfaceRegisterd = true;
 				}
@@ -2264,6 +2267,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// SpeakResponse
 				
 				final SpeakResponse msg = new SpeakResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2281,6 +2285,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// AlertResponse
 				
 				final AlertResponse msg = new AlertResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2298,6 +2303,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// ShowResponse
 				
 				final ShowResponse msg = new ShowResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2315,6 +2321,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// AddCommand
 				
 				final AddCommandResponse msg = new AddCommandResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2332,6 +2339,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// DeleteCommandResponse
 				
 				final DeleteCommandResponse msg = new DeleteCommandResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2349,6 +2357,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// AddSubMenu
 				
 				final AddSubMenuResponse msg = new AddSubMenuResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2366,6 +2375,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// DeleteSubMenu
 				
 				final DeleteSubMenuResponse msg = new DeleteSubMenuResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2383,6 +2393,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// SubscribeButton
 				
 				final SubscribeButtonResponse msg = new SubscribeButtonResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2400,6 +2411,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// UnsubscribeButton
 				
 				final UnsubscribeButtonResponse msg = new UnsubscribeButtonResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2417,6 +2429,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// SetMediaClockTimer
 				
 				final SetMediaClockTimerResponse msg = new SetMediaClockTimerResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2433,7 +2446,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			} else if (functionName.equals(FunctionID.ENCODED_SYNC_P_DATA.toString())) {
 				
 				final SystemRequestResponse msg = new SystemRequestResponse(hash);
-				
+				msg.format(rpcSpecVersion,true);
 				Intent sendIntent = createBroadcastIntent();
 				updateBroadcastIntent(sendIntent, "RPC_NAME", FunctionID.SYSTEM_REQUEST.toString());
 				updateBroadcastIntent(sendIntent, "TYPE", RPCMessage.KEY_RESPONSE);
@@ -2460,6 +2473,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// CreateInteractionChoiceSet
 				
 				final CreateInteractionChoiceSetResponse msg = new CreateInteractionChoiceSetResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2477,6 +2491,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// DeleteInteractionChoiceSet
 				
 				final DeleteInteractionChoiceSetResponse msg = new DeleteInteractionChoiceSetResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2494,6 +2509,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// PerformInteraction
 				
 				final PerformInteractionResponse msg = new PerformInteractionResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2511,6 +2527,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// SetGlobalPropertiesResponse 
 				
 				final SetGlobalPropertiesResponse msg = new SetGlobalPropertiesResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 						// Run in UI thread
 						_mainUIHandler.post(new Runnable() {
@@ -2528,6 +2545,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// ResetGlobalProperties				
 				
 				final ResetGlobalPropertiesResponse msg = new ResetGlobalPropertiesResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2550,7 +2568,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				}
 				
 				final UnregisterAppInterfaceResponse msg = new UnregisterAppInterfaceResponse(hash);
-				
+				msg.format(rpcSpecVersion,true);
 				Intent sendIntent = createBroadcastIntent();
 				updateBroadcastIntent(sendIntent, "RPC_NAME", FunctionID.UNREGISTER_APP_INTERFACE.toString());
 				updateBroadcastIntent(sendIntent, "TYPE", RPCMessage.KEY_RESPONSE);
@@ -2583,6 +2601,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			} else if (functionName.equals(FunctionID.GENERIC_RESPONSE.toString())) {
 				// GenericResponse (Usually and error)
 				final GenericResponse msg = new GenericResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -2599,6 +2618,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			} else if (functionName.equals(FunctionID.SLIDER.toString())) {
                 // Slider
                 final SliderResponse msg = new SliderResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2615,6 +2635,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.PUT_FILE.toString())) {
                 // PutFile
                 final PutFileResponse msg = new PutFileResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2633,6 +2654,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.DELETE_FILE.toString())) {
                 // DeleteFile
                 final DeleteFileResponse msg = new DeleteFileResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2649,6 +2671,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.LIST_FILES.toString())) {
                 // ListFiles
                 final ListFilesResponse msg = new ListFilesResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2665,6 +2688,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.SET_APP_ICON.toString())) {
                 // SetAppIcon
                 final SetAppIconResponse msg = new SetAppIconResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2681,6 +2705,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.SCROLLABLE_MESSAGE.toString())) {
                 // ScrollableMessage
                 final ScrollableMessageResponse msg = new ScrollableMessageResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2697,6 +2722,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.CHANGE_REGISTRATION.toString())) {
                 // ChangeLanguageRegistration
                 final ChangeRegistrationResponse msg = new ChangeRegistrationResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2713,7 +2739,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.SET_DISPLAY_LAYOUT.toString())) {
                 // SetDisplayLayout
                 final SetDisplayLayoutResponse msg = new SetDisplayLayoutResponse(hash);
-                
+				msg.format(rpcSpecVersion,true);
                 // successfully changed display layout - update layout capabilities
                 if(msg.getSuccess() && _systemCapabilityManager!=null){
 					_systemCapabilityManager.setCapability(SystemCapabilityType.DISPLAY, msg.getDisplayCapabilities());
@@ -2738,6 +2764,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.PERFORM_AUDIO_PASS_THRU.toString())) {
                 // PerformAudioPassThru
                 final PerformAudioPassThruResponse msg = new PerformAudioPassThruResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2754,6 +2781,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.END_AUDIO_PASS_THRU.toString())) {
                 // EndAudioPassThru
                 final EndAudioPassThruResponse msg = new EndAudioPassThruResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2770,6 +2798,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.SUBSCRIBE_VEHICLE_DATA.toString())) {
             	// SubscribeVehicleData
                 final SubscribeVehicleDataResponse msg = new SubscribeVehicleDataResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2786,6 +2815,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.UNSUBSCRIBE_VEHICLE_DATA.toString())) {
             	// UnsubscribeVehicleData
                 final UnsubscribeVehicleDataResponse msg = new UnsubscribeVehicleDataResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2802,6 +2832,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.GET_VEHICLE_DATA.toString())) {
            		// GetVehicleData
                 final GetVehicleDataResponse msg = new GetVehicleDataResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2818,6 +2849,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.SUBSCRIBE_WAY_POINTS.toString())) {
             	// SubscribeWayPoints
                 final SubscribeWayPointsResponse msg = new SubscribeWayPointsResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2834,6 +2866,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.UNSUBSCRIBE_WAY_POINTS.toString())) {
             	// UnsubscribeWayPoints
                 final UnsubscribeWayPointsResponse msg = new UnsubscribeWayPointsResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2850,6 +2883,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             } else if (functionName.equals(FunctionID.GET_WAY_POINTS.toString())) {
            		// GetWayPoints
                 final GetWayPointsResponse msg = new GetWayPointsResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2865,6 +2899,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
                     }            	               
             } else if (functionName.equals(FunctionID.READ_DID.toString())) {
                 final ReadDIDResponse msg = new ReadDIDResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2880,6 +2915,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
                 }            	            	
             } else if (functionName.equals(FunctionID.GET_DTCS.toString())) {
                 final GetDTCsResponse msg = new GetDTCsResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2895,6 +2931,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
                 }
             } else if (functionName.equals(FunctionID.DIAGNOSTIC_MESSAGE.toString())) {
                 final DiagnosticMessageResponse msg = new DiagnosticMessageResponse(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -2912,6 +2949,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             else if (functionName.equals(FunctionID.SYSTEM_REQUEST.toString())) {
 
    				final SystemRequestResponse msg = new SystemRequestResponse(hash);
+   				msg.format(rpcSpecVersion, true);
    				if (_callbackToUIThread) {
    					// Run in UI thread
    					_mainUIHandler.post(new Runnable() {
@@ -2929,6 +2967,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             else if (functionName.equals(FunctionID.SEND_LOCATION.toString())) {
 
    				final SendLocationResponse msg = new SendLocationResponse(hash);
+   				msg.format(rpcSpecVersion, true);
    				if (_callbackToUIThread) {
    					// Run in UI thread
    					_mainUIHandler.post(new Runnable() {
@@ -2946,6 +2985,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             else if (functionName.equals(FunctionID.DIAL_NUMBER.toString())) {
 
    				final DialNumberResponse msg = new DialNumberResponse(hash);
+   				msg.format(rpcSpecVersion, true);
    				if (_callbackToUIThread) {
    					// Run in UI thread
    					_mainUIHandler.post(new Runnable() {
@@ -2962,6 +3002,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
             }
             else if (functionName.equals(FunctionID.SHOW_CONSTANT_TBT.toString())) {
 				final ShowConstantTbtResponse msg = new ShowConstantTbtResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					_mainUIHandler.post(new Runnable() {
 						@Override
@@ -2977,6 +3018,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}
 			else if (functionName.equals(FunctionID.ALERT_MANEUVER.toString())) {
 				final AlertManeuverResponse msg = new AlertManeuverResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					_mainUIHandler.post(new Runnable() {
 						@Override
@@ -2991,6 +3033,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				}
 			} else if (functionName.equals(FunctionID.UPDATE_TURN_LIST.toString())) {
 				final UpdateTurnListResponse msg = new UpdateTurnListResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					_mainUIHandler.post(new Runnable() {
 						@Override
@@ -3005,6 +3048,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				}
 			} else if (functionName.equals(FunctionID.SET_INTERIOR_VEHICLE_DATA.toString())) {
 				final SetInteriorVehicleDataResponse msg = new SetInteriorVehicleDataResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					_mainUIHandler.post(new Runnable() {
 						@Override
@@ -3019,6 +3063,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				}
 			} else if (functionName.equals(FunctionID.GET_INTERIOR_VEHICLE_DATA.toString())) {
 				final GetInteriorVehicleDataResponse msg = new GetInteriorVehicleDataResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					_mainUIHandler.post(new Runnable() {
 						@Override
@@ -3034,6 +3079,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			} else if (functionName.equals(FunctionID.GET_SYSTEM_CAPABILITY.toString())) {
 				// GetSystemCapabilityResponse
 				final GetSystemCapabilityResponse msg = new GetSystemCapabilityResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					_mainUIHandler.post(new Runnable() {
 						@Override
@@ -3048,6 +3094,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				}
 			} else if (functionName.equals(FunctionID.BUTTON_PRESS.toString())) {
 				final ButtonPressResponse msg = new ButtonPressResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					_mainUIHandler.post(new Runnable() {
 						@Override
@@ -3062,6 +3109,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				}
 			} else if (functionName.equals(FunctionID.SEND_HAPTIC_DATA.toString())) {
 				final SendHapticDataResponse msg = new SendHapticDataResponse(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3104,6 +3152,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				_hmiLevel = msg.getHmiLevel();
 				_audioStreamingState = msg.getAudioStreamingState();
 
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3123,6 +3172,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// OnCommand
 				
 				final OnCommand msg = new OnCommand(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3148,6 +3198,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					sdlSession.getLockScreenMan().setDriverDistStatus(drDist == DriverDistractionState.DD_ON);
 				}
 				
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3174,7 +3225,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// If url is null, then send notification to the app, otherwise, send to URL
 				if (msg.getUrl() == null) {
 					updateBroadcastIntent(sendIntent, "COMMENT1", "URL is a null value (received)");
-					sendBroadcastIntent(sendIntent);					
+					sendBroadcastIntent(sendIntent);
+					msg.format(rpcSpecVersion, true);
 					if (_callbackToUIThread) {
 						// Run in UI thread
 						_mainUIHandler.post(new Runnable() {
@@ -3210,6 +3262,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				//OnPermissionsChange
 				
 				final OnPermissionsChange msg = new OnPermissionsChange(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3227,6 +3280,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// OnTBTClientState
 				
 				final OnTBTClientState msg = new OnTBTClientState(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3244,6 +3298,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// OnButtonPress
 				
 				final OnButtonPress msg = new OnButtonPress(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3261,6 +3316,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// OnButtonEvent
 				
 				final OnButtonEvent msg = new OnButtonEvent(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3278,6 +3334,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// OnLanguageChange
 				
 				final OnLanguageChange msg = new OnLanguageChange(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3295,6 +3352,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				// OnLanguageChange
 				
 				final OnHashChange msg = new OnHashChange(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3320,7 +3378,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					// OnSystemRequest
 					
 					final OnSystemRequest msg = new OnSystemRequest(hash);
-					
+					msg.format(rpcSpecVersion,true);
 					if ((msg.getUrl() != null) &&
 							(((msg.getRequestType() == RequestType.PROPRIETARY) && (msg.getFileType() == FileType.JSON)) 
 									|| ((msg.getRequestType() == RequestType.HTTP) && (msg.getFileType() == FileType.BINARY)))){
@@ -3340,6 +3398,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					    lockScreenIconRequest = msg;
 					}
 					
+					msg.format(rpcSpecVersion, true);
 					if (_callbackToUIThread) {
 						// Run in UI thread
 						_mainUIHandler.post(new Runnable() {
@@ -3356,6 +3415,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			} else if (functionName.equals(FunctionID.ON_AUDIO_PASS_THRU.toString())) {
 				// OnAudioPassThru
 				final OnAudioPassThru msg = new OnAudioPassThru(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -3372,6 +3432,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			} else if (functionName.equals(FunctionID.ON_VEHICLE_DATA.toString())) {
 				// OnVehicleData
                 final OnVehicleData msg = new OnVehicleData(hash);
+                msg.format(rpcSpecVersion, true);
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {
@@ -3395,6 +3456,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				}
 				
 				final OnAppInterfaceUnregistered msg = new OnAppInterfaceUnregistered(hash);
+				msg.format(rpcSpecVersion,true);
 								
 				Intent sendIntent = createBroadcastIntent();
 				updateBroadcastIntent(sendIntent, "RPC_NAME", FunctionID.ON_APP_INTERFACE_UNREGISTERED.toString());
@@ -3424,6 +3486,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			} 
 			else if (functionName.equals(FunctionID.ON_KEYBOARD_INPUT.toString())) {
 				final OnKeyboardInput msg = new OnKeyboardInput(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3440,6 +3503,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}
 			else if (functionName.equals(FunctionID.ON_TOUCH_EVENT.toString())) {
 				final OnTouchEvent msg = new OnTouchEvent(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3456,6 +3520,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}
 			else if (functionName.equals(FunctionID.ON_WAY_POINT_CHANGE.toString())) {
 				final OnWayPointChange msg = new OnWayPointChange(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3472,6 +3537,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}
 			else if (functionName.equals(FunctionID.ON_INTERIOR_VEHICLE_DATA.toString())) {
 				final OnInteriorVehicleData msg = new OnInteriorVehicleData(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3488,6 +3554,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			}
 			else if (functionName.equals(FunctionID.ON_RC_STATUS.toString())) {
 				final OnRCStatus msg = new OnRCStatus(hash);
+				msg.format(rpcSpecVersion, true);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -1651,7 +1651,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		try
 		{
 			//sReturn = msg.serializeJSON(getWiProVersion()).toString(2);
-			sReturn = msg.serializeJSON(new com.smartdevicelink.util.Version(getWiProVersion()+".0.0"),
+			sReturn = msg.serializeJSON(new com.smartdevicelink.util.Version(getWiProVersion(),0,0),
 					rpcSpecVersion ).toString(2);
 		}
 		catch (final Exception e) 
@@ -1805,7 +1805,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			try {
 			SdlTrace.logRPCEvent(InterfaceActivityDirection.Transmit, request, SDL_LIB_TRACE_KEY);
 						
-			byte[] msgBytes = JsonRPCMarshaller.marshall(request, new com.smartdevicelink.util.Version(_wiproVersion+".0.0"), rpcSpecVersion);
+			byte[] msgBytes = JsonRPCMarshaller.marshall(request, new com.smartdevicelink.util.Version(_wiproVersion,0,0), rpcSpecVersion);
 	
 			ProtocolMessage pm = new ProtocolMessage();
 			pm.setData(msgBytes);
@@ -2013,6 +2013,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	
 	private void handleRPCMessage(Hashtable<String, Object> hash) {
 		RPCMessage rpcMsg = new RPCMessage(hash);
+		//Call format to ensure the RPC is ready to be handled regardless of RPC spec version
+		rpcMsg.format(rpcSpecVersion);
+
 		String functionName = rpcMsg.getFunctionName();
 		String messageType = rpcMsg.getMessageType();
 		

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -241,6 +241,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	private final CopyOnWriteArrayList<IPutFileResponseListener> _putFileListenerList = new CopyOnWriteArrayList<IPutFileResponseListener>();
 
 	protected byte _wiproVersion = 1;
+	protected com.smartdevicelink.util.Version rpcSpecVersion;
 	
 	protected SparseArray<OnRPCResponseListener> rpcResponseListeners = null;
 	protected SparseArray<CopyOnWriteArrayList<OnRPCNotificationListener>> rpcNotificationListeners = null;
@@ -1649,7 +1650,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		String sReturn;
 		try
 		{
-			sReturn = msg.serializeJSON(getWiProVersion()).toString(2);
+			//sReturn = msg.serializeJSON(getWiProVersion()).toString(2);
+			sReturn = msg.serializeJSON(new com.smartdevicelink.util.Version(getWiProVersion()+".0.0"),
+					rpcSpecVersion ).toString(2);
 		}
 		catch (final Exception e) 
 		{
@@ -1802,7 +1805,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			try {
 			SdlTrace.logRPCEvent(InterfaceActivityDirection.Transmit, request, SDL_LIB_TRACE_KEY);
 						
-			byte[] msgBytes = JsonRPCMarshaller.marshall(request, _wiproVersion);
+			byte[] msgBytes = JsonRPCMarshaller.marshall(request, new com.smartdevicelink.util.Version(_wiproVersion+".0.0"), rpcSpecVersion);
 	
 			ProtocolMessage pm = new ProtocolMessage();
 			pm.setData(msgBytes);
@@ -2048,6 +2051,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					_sdlLanguage = msg.getLanguage();
 					_hmiDisplayLanguage = msg.getHmiDisplayLanguage();
 					_sdlMsgVersion = msg.getSdlMsgVersion();
+					rpcSpecVersion = new com.smartdevicelink.util.Version(_sdlMsgVersion.getMajorVersion(),_sdlMsgVersion.getMinorVersion(), _sdlMsgVersion.getPatchVersion());
 					_vehicleType = msg.getVehicleType();
 					_systemSoftwareVersion = msg.getSystemSoftwareVersion();
 					_proxyVersionInfo = msg.getProxyVersionInfo();
@@ -2196,6 +2200,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				_sdlLanguage = msg.getLanguage();
 				_hmiDisplayLanguage = msg.getHmiDisplayLanguage();
 				_sdlMsgVersion = msg.getSdlMsgVersion();
+				rpcSpecVersion = new com.smartdevicelink.util.Version(_sdlMsgVersion.getMajorVersion(),_sdlMsgVersion.getMinorVersion(), _sdlMsgVersion.getPatchVersion());
 				_vehicleType = msg.getVehicleType();
 				_systemSoftwareVersion = msg.getSystemSoftwareVersion();
 				_proxyVersionInfo = msg.getProxyVersionInfo();

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnHMIStatus.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnHMIStatus.java
@@ -104,6 +104,18 @@ public class OnHMIStatus extends RPCNotification {
         setAudioStreamingState(audioStreamingState);
         setSystemContext(systemContext);
     }
+
+    @Override
+    public void format(com.smartdevicelink.util.Version rpcVersion, boolean formatParams){
+        if(rpcVersion.getMajor() < 5){
+            if(getVideoStreamingState() == null){
+                setVideoStreamingState(VideoStreamingState.STREAMABLE);
+            }
+        }
+
+        super.format(rpcVersion,formatParams);
+    }
+
     /**
      * <p>Get HMILevel in effect for the application</p>
      * @return {@linkplain HMILevel} the current HMI Level in effect for the application
@@ -137,11 +149,7 @@ public class OnHMIStatus extends RPCNotification {
      * @return {@linkplain VideoStreamingState} Returns current state of video streaming for the application
      */
     public VideoStreamingState getVideoStreamingState() {
-        VideoStreamingState videoStreamingState =  (VideoStreamingState) getObject(VideoStreamingState.class, KEY_VIDEO_STREAMING_STATE);
-        if (videoStreamingState == null){
-            videoStreamingState = VideoStreamingState.STREAMABLE;
-        }
-        return videoStreamingState;
+        return (VideoStreamingState) getObject(VideoStreamingState.class, KEY_VIDEO_STREAMING_STATE);
     }
     /**
      * <p>Set the video streaming state</p>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
@@ -77,6 +77,17 @@ public class RegisterAppInterfaceResponse extends RPCResponse {
 		setSuccess(success);
 		setResultCode(resultCode);
 	}
+
+	@Override
+	public void format(com.smartdevicelink.util.Version rpcVersion, boolean formatParams){
+		//Add in 5.0.0 of the rpc spec
+		if(getIconResumed() == null){
+			setIconResumed(Boolean.FALSE);
+		}
+
+		super.format(rpcVersion,formatParams);
+	}
+
     @SuppressWarnings("unchecked")
     public SdlMsgVersion getSdlMsgVersion() {
 		return (SdlMsgVersion) getObject(SdlMsgVersion.class, KEY_SDL_MSG_VERSION);

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SdlMsgVersion.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SdlMsgVersion.java
@@ -74,7 +74,17 @@ public class SdlMsgVersion extends RPCStruct {
         this();
         setMajorVersion(majorVersion);
         setMinorVersion(minorVersion);
+
     }
+
+    @Override
+    public void format(com.smartdevicelink.util.Version rpcVersion, boolean formatParams) {
+        if(getPatchVersion() == null){
+            setPatchVersion(0);
+        }
+        super.format(rpcVersion,formatParams);
+    }
+
     public Integer getMajorVersion() {
         return getInteger( KEY_MAJOR_VERSION );
     }

--- a/sdl_android/src/main/java/com/smartdevicelink/streaming/AbstractPacketizer.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/streaming/AbstractPacketizer.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import com.smartdevicelink.SdlConnection.SdlSession;
 import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.proxy.RPCRequest;
+import com.smartdevicelink.util.Version;
 
 abstract public class AbstractPacketizer {
 
@@ -19,7 +20,7 @@ abstract public class AbstractPacketizer {
 	protected byte[] buffer;
 	protected boolean upts = false;
 	protected RPCRequest _request = null;
-	protected byte _wiproVersion = 1;
+	protected Version _wiproVersion = new Version("1.0.0");
 
 	//protected long ts = 0, intervalBetweenReports = 5000, delta = 0;
 	protected long intervalBetweenReports = 5000, delta = 0;
@@ -38,13 +39,30 @@ abstract public class AbstractPacketizer {
 		}
 	}
 
+	@Deprecated
 	public AbstractPacketizer(IStreamListener streamListener, InputStream is, RPCRequest request, SessionType sType, byte rpcSessionID, byte wiproVersion, SdlSession session) throws IOException, IllegalArgumentException {
 		this._streamListener = streamListener;
 		this.is = is;
 		_rpcSessionID = rpcSessionID;
 		_serviceType = sType;
 		_request = request;
-		_wiproVersion = wiproVersion;
+		_wiproVersion = new Version(wiproVersion+".0.0");
+		this._session = session;
+		if (this._session != null) {
+			bufferSize = this._session.getMtu();
+			buffer = new byte[bufferSize];
+		}else{
+			throw new IllegalArgumentException("Session variable is null");
+		}
+	}
+
+	public AbstractPacketizer(IStreamListener streamListener, InputStream is, RPCRequest request, SessionType sType, byte rpcSessionID, Version protocolVersion, SdlSession session) throws IOException, IllegalArgumentException {
+		this._streamListener = streamListener;
+		this.is = is;
+		_rpcSessionID = rpcSessionID;
+		_serviceType = sType;
+		_request = request;
+		_wiproVersion = protocolVersion;
 		this._session = session;
 		if (this._session != null) {
 			bufferSize = this._session.getMtu();

--- a/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamRPCPacketizer.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamRPCPacketizer.java
@@ -22,6 +22,7 @@ import com.smartdevicelink.proxy.rpc.PutFileResponse;
 import com.smartdevicelink.proxy.rpc.StreamRPCResponse;
 import com.smartdevicelink.proxy.rpc.enums.Result;
 import com.smartdevicelink.proxy.rpc.listeners.OnPutFileUpdateListener;
+import com.smartdevicelink.util.Version;
 
 public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileResponseListener, Runnable{
 
@@ -36,10 +37,31 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
     private Object mPauseLock;
     private boolean mPaused;
     private boolean isRPCProtected = false;
-	private OnPutFileUpdateListener callBack; 
+	private OnPutFileUpdateListener callBack;
+
+	private Version rpcSpecVersion;
 
 	public StreamRPCPacketizer(SdlProxyBase<IProxyListenerBase> proxy, IStreamListener streamListener, InputStream is, RPCRequest request, SessionType sType, byte rpcSessionID, byte wiproVersion, long lLength, SdlSession session) throws IOException {
 		super(streamListener, is, request, sType, rpcSessionID, wiproVersion, session);
+		lFileSize = lLength;
+		iInitialCorrID = request.getCorrelationID();
+        mPauseLock = new Object();
+        mPaused = false;
+        isRPCProtected = request.isPayloadProtected();
+		if (proxy != null)
+		{
+			_proxy = proxy;
+			_proxyListener = _proxy.getProxyListener();
+			_proxy.addPutFileResponseListener(this);
+		}
+		if(_request.getFunctionName().equalsIgnoreCase(FunctionID.PUT_FILE.toString())){
+			callBack = ((PutFile)_request).getOnPutFileUpdateListener();
+		}
+	}
+
+	public StreamRPCPacketizer(SdlProxyBase<IProxyListenerBase> proxy, IStreamListener streamListener, InputStream is, RPCRequest request, SessionType sType, byte rpcSessionID, Version wiproVersion, Version rpcSpecVersion, long lLength, SdlSession session) throws IOException {
+		super(streamListener, is, request, sType, rpcSessionID, wiproVersion, session);
+		this.rpcSpecVersion = rpcSpecVersion;
 		lFileSize = lLength;
 		iInitialCorrID = request.getCorrelationID();
         mPauseLock = new Object();
@@ -201,7 +223,7 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 					if (msg.getOffset() != 0)
 			        	msg.setLength((Long)null); //only need to send length when offset 0
 
-					msgBytes = JsonRPCMarshaller.marshall(msg, _wiproVersion);					
+					msgBytes = JsonRPCMarshaller.marshall(msg, _wiproVersion,rpcSpecVersion);
 					pm = new ProtocolMessage();
 					pm.setData(msgBytes);
 

--- a/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamRPCPacketizer.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamRPCPacketizer.java
@@ -64,11 +64,10 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 		this.rpcSpecVersion = rpcSpecVersion;
 		lFileSize = lLength;
 		iInitialCorrID = request.getCorrelationID();
-        mPauseLock = new Object();
-        mPaused = false;
-        isRPCProtected = request.isPayloadProtected();
-		if (proxy != null)
-		{
+		mPauseLock = new Object();
+		mPaused = false;
+		isRPCProtected = request.isPayloadProtected();
+		if (proxy != null) {
 			_proxy = proxy;
 			_proxyListener = _proxy.getProxyListener();
 			_proxy.addPutFileResponseListener(this);

--- a/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamRPCPacketizer.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/streaming/StreamRPCPacketizer.java
@@ -223,7 +223,8 @@ public class StreamRPCPacketizer extends AbstractPacketizer implements IPutFileR
 					if (msg.getOffset() != 0)
 			        	msg.setLength((Long)null); //only need to send length when offset 0
 
-					msgBytes = JsonRPCMarshaller.marshall(msg, _wiproVersion,rpcSpecVersion);
+					msg.format(rpcSpecVersion,true);
+					msgBytes = JsonRPCMarshaller.marshall(msg, (byte)_wiproVersion.getMajor());
 					pm = new ProtocolMessage();
 					pm.setData(msgBytes);
 

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1978,7 +1978,7 @@ public class SdlRouterService extends Service{
 	private byte[] createForceUnregisterApp(byte sessionId,byte version){
 		UnregisterAppInterface request = new UnregisterAppInterface();
 		request.setCorrelationID(UNREGISTER_APP_INTERFACE_CORRELATION_ID);
-		byte[] msgBytes = JsonRPCMarshaller.marshall(request, new Version(version+".0.0"), null);
+		byte[] msgBytes = JsonRPCMarshaller.marshall(request, new Version(version,0,0), null);
 		ProtocolMessage pm = new ProtocolMessage();
 		pm.setData(msgBytes);
 		pm.setSessionID(sessionId);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -78,6 +78,7 @@ import com.smartdevicelink.transport.utl.ByteArrayMessageSpliter;
 import com.smartdevicelink.util.AndroidTools;
 import com.smartdevicelink.util.BitConverter;
 import com.smartdevicelink.util.SdlAppInfo;
+import com.smartdevicelink.util.Version;
 
 import static com.smartdevicelink.transport.TransportConstants.FOREGROUND_EXTRA;
 import static com.smartdevicelink.transport.TransportConstants.SDL_NOTIFICATION_CHANNEL_ID;
@@ -1977,7 +1978,7 @@ public class SdlRouterService extends Service{
 	private byte[] createForceUnregisterApp(byte sessionId,byte version){
 		UnregisterAppInterface request = new UnregisterAppInterface();
 		request.setCorrelationID(UNREGISTER_APP_INTERFACE_CORRELATION_ID);
-		byte[] msgBytes = JsonRPCMarshaller.marshall(request, version);
+		byte[] msgBytes = JsonRPCMarshaller.marshall(request, new Version(version+".0.0"), null);
 		ProtocolMessage pm = new ProtocolMessage();
 		pm.setData(msgBytes);
 		pm.setSessionID(sessionId);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1978,7 +1978,8 @@ public class SdlRouterService extends Service{
 	private byte[] createForceUnregisterApp(byte sessionId,byte version){
 		UnregisterAppInterface request = new UnregisterAppInterface();
 		request.setCorrelationID(UNREGISTER_APP_INTERFACE_CORRELATION_ID);
-		byte[] msgBytes = JsonRPCMarshaller.marshall(request, new Version(version,0,0), null);
+		request.format(null,true);
+		byte[] msgBytes = JsonRPCMarshaller.marshall(request, version);
 		ProtocolMessage pm = new ProtocolMessage();
 		pm.setData(msgBytes);
 		pm.setSessionID(sessionId);

--- a/sdl_android/src/main/java/com/smartdevicelink/util/Version.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/util/Version.java
@@ -11,6 +11,12 @@ public class Version {
         patch = 0;
     }
 
+    public Version(int major, int minor, int patch){
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+
     public Version(String versionString){
         String[] versions = versionString.split("\\.");
         if(versions.length!=3){


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.


### Summary
RPC Struct now has a format method that can be used to properly format RPCs based on the rpc spec version

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)