### PR TITLE
Fix false positive in SCM capability supported

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
@@ -131,6 +131,12 @@ public class SystemCapabilityManagerTests extends AndroidTestCase {
 
 	}
 
+	public void testFalsePositive(){
+		SystemCapabilityManager systemCapabilityManager = createSampleManager();
+		systemCapabilityManager.setCapability(SystemCapabilityType.AUDIO_PASSTHROUGH, null);
+		assertFalse(systemCapabilityManager.isCapabilitySupported(SystemCapabilityType.AUDIO_PASSTHROUGH));
+	}
+
 	private class InternalSDLInterface implements ISdl{
 		@Override
 		public void start(){}

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -57,7 +57,8 @@ public class SystemCapabilityManager {
 	 * @return if that capability is supported with the current, connected module
 	 */
 	public boolean isCapabilitySupported(SystemCapabilityType type){
-		if(cachedSystemCapabilities.containsKey(type)){
+		if(cachedSystemCapabilities.get(type) != null){
+			//The capability exists in the map and is not null
 			return true;
 		}else if(cachedSystemCapabilities.containsKey(SystemCapabilityType.HMI)){
 			HMICapabilities hmiCapabilities = ((HMICapabilities)cachedSystemCapabilities.get(SystemCapabilityType.HMI));


### PR DESCRIPTION
Fixes #844

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Added a new unit test to check for false positivie

### Summary
Changed the `isCapabilitySupported` method from checking if the mapping exists to checking if the value returned by they key is not null (`cachedSystemCapabilities.get(type) != null`). 

### Changelog

##### Bug Fixes
* Returns `false` if the value doesn't exists or is null in the `cachedSystemCapabilities` mapping.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)