### PR TITLE
Issue 854 - Fix an issue in isEmulator

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/DeviceUtil.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/DeviceUtil.java
@@ -9,6 +9,7 @@ public class DeviceUtil {
                 || Build.MODEL.contains("google_sdk")
                 || Build.MODEL.contains("Emulator")
                 || Build.MODEL.contains("Android SDK built for")
+                || Build.MANUFACTURER.contains("Genymotion")
                 || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
                 || (Build.BRAND.startsWith("Android") && Build.DEVICE.startsWith("generic"))
                 || (Build.PRODUCT != null && Build.PRODUCT.startsWith("sdk_google_phone"))

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/DeviceUtil.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/DeviceUtil.java
@@ -8,7 +8,7 @@ public class DeviceUtil {
                 || Build.FINGERPRINT.startsWith("unknown")
                 || Build.MODEL.contains("google_sdk")
                 || Build.MODEL.contains("Emulator")
-                || Build.MODEL.contains("Android SDL built for")
+                || Build.MODEL.contains("Android SDK built for")
                 || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
                 || (Build.BRAND.startsWith("Android") && Build.DEVICE.startsWith("generic"))
                 || (Build.PRODUCT != null && Build.PRODUCT.startsWith("sdk_google_phone"))


### PR DESCRIPTION
Fixes #854 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
1. Create a new Android Emulator
2. Run `com.smartdevicelink.SdlConnection.SdlConnectionTest` on the emulator
3. All tests should pass

### Summary
Fixed an issue in `isEmulator()` method where it returns false on new emulators while it is supposed to return `true`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)