### PR TITLE
Add addOnRPCNotificationListener method to SdlManager

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
@@ -547,7 +547,7 @@ public class SdlManager{
 
 	/**
 	 * Add an OnRPCNotificationListener
-	 * @param listener listener that will be called when a notifications is received
+	 * @param listener listener that will be called when a notification is received
 	 */
 	public void addOnRPCNotificationListener(FunctionID notificationId, OnRPCNotificationListener listener){
 		proxy.addOnRPCNotificationListener(notificationId,listener);

--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
@@ -546,19 +546,19 @@ public class SdlManager{
 	}
 
 	/**
-	 * Add an OnRPCNotificationListener for HMI status notifications
-	 * @param listener listener that will be called when the HMI status changes
+	 * Add an OnRPCNotificationListener
+	 * @param listener listener that will be called when a notifications is received
 	 */
-	public void addOnHmiStatusListener(OnRPCNotificationListener listener){
-		proxy.addOnRPCNotificationListener(FunctionID.ON_HMI_STATUS,listener);
+	public void addOnRPCNotificationListener(FunctionID notificationId, OnRPCNotificationListener listener){
+		proxy.addOnRPCNotificationListener(notificationId,listener);
 	}
 
 	/**
-	 * Remove an OnRPCNotificationListener for HMI status notifications
-	 * @param listener listener that was previously added for the HMI status notifications
+	 * Remove an OnRPCNotificationListener
+	 * @param listener listener that was previously added
 	 */
-	public void removeOnHmiStatusListener(OnRPCNotificationListener listener){
-		proxy.removeOnRPCNotificationListener(FunctionID.ON_HMI_STATUS, listener);
+	public void removeOnRPCNotificationListener(FunctionID notificationId, OnRPCNotificationListener listener){
+		proxy.removeOnRPCNotificationListener(notificationId, listener);
 	}
 
 	// LIFECYCLE / OTHER


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR adds `addOnRPCNotificationListener` to `SdlManager` so developers can register to receive specific notifications. For example when the HMI level changes or when `OnVehicleData` update is received.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)