### PR TITLE
Feature/issue 782 - Fix broadcast issue in SdlProxyBase

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/api/SdlManager.java
@@ -609,7 +609,7 @@ public class SdlManager{
 	public void start(){
 		if (proxy == null) {
 			try {
-				proxy = new SdlProxyBase(proxyBridge, appName, shortAppName, isMediaApp, hmiLanguage,
+				proxy = new SdlProxyBase(proxyBridge, context, appName, shortAppName, isMediaApp, hmiLanguage,
 						hmiLanguage, hmiTypes, appId, transport, vrSynonyms, ttsChunks, dayColorScheme,
 						nightColorScheme) {
 				};

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -132,6 +132,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	private proxyListenerType _proxyListener = null;
 	
 	protected Service _appService = null;
+	private Context _appContext;
 	private String sPoliciesURL = ""; //for testing only
 
 	// Protected Correlation IDs
@@ -649,6 +650,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * Used by the SdlManager
 	 *
 	 * @param listener Type of listener for this proxy base.
+	 * @param context Application context.
 	 * @param appName Client application name.
 	 * @param shortAppName Client short application name.
 	 * @param isMediaApp Flag that indicates that client application if media application or not.
@@ -663,10 +665,11 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * @param ttsName TTS name.
 	 * @throws SdlException
 	 */
-	public SdlProxyBase(proxyListenerType listener, String appName,String shortAppName, Boolean isMediaApp, Language languageDesired, Language hmiDisplayLanguageDesired, Vector<AppHMIType> appType, String appID,
+	public SdlProxyBase(proxyListenerType listener, Context context, String appName,String shortAppName, Boolean isMediaApp, Language languageDesired, Language hmiDisplayLanguageDesired, Vector<AppHMIType> appType, String appID,
 						BaseTransportConfig transportConfig, Vector<String> vrSynonyms, Vector<TTSChunk> ttsName, TemplateColorScheme dayColorScheme, TemplateColorScheme nightColorScheme) throws SdlException {
 		performBaseCommon(listener, null, true, appName, ttsName, shortAppName, vrSynonyms, isMediaApp,
 				null, languageDesired, hmiDisplayLanguageDesired, appType, appID, null, dayColorScheme,nightColorScheme, false, false, null, null,  transportConfig);
+		_appContext = context;
 	}
 	
 	/**
@@ -1039,7 +1042,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	
 	private void sendBroadcastIntent(Intent sendIntent)
 	{
-		Service myService;
+		Service myService = null;
 		if (_proxyListener != null && _proxyListener instanceof Service)
 		{
 			myService = (Service) _proxyListener;				
@@ -1048,13 +1051,18 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		{
 			myService = _appService;
 		}
+		Context myContext;
+		if (myService != null){
+			myContext = myService.getApplicationContext();
+		} else if (_appContext != null){
+			myContext = _appContext;
+		}
 		else
 		{
 			return;
 		}
 		try
 		{
-			Context myContext = myService.getApplicationContext();
 			if (myContext != null) myContext.sendBroadcast(sendIntent);
 		}
 		catch(Exception ex)
@@ -2085,6 +2093,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		SdlSecurityBase sec;
 		Service svc = getService();
 		SdlSecurityBase.setAppService(svc);
+		SdlSecurityBase.setContext(_appContext);
 		
 		for (Class<? extends SdlSecurityBase> cls : _secList)
 		{

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2093,8 +2093,12 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		SdlSecurityBase sec;
 		Service svc = getService();
 		SdlSecurityBase.setAppService(svc);
-		SdlSecurityBase.setContext(_appContext);
-		
+		if (svc != null && svc.getApplicationContext() != null){
+			SdlSecurityBase.setContext(svc.getApplicationContext());
+		} else {
+			SdlSecurityBase.setContext(_appContext);
+		}
+
 		for (Class<? extends SdlSecurityBase> cls : _secList)
 		{
 			try

--- a/sdl_android/src/main/java/com/smartdevicelink/security/SdlSecurityBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/security/SdlSecurityBase.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import android.app.Service;
+import android.content.Context;
 
 import com.smartdevicelink.SdlConnection.SdlSession;
 import com.smartdevicelink.protocol.enums.SessionType;
@@ -16,6 +17,7 @@ public abstract class SdlSecurityBase {
 	protected boolean isInitSuccess = false;
 	protected byte sessionId = 0;
 	protected static Service appService = null;
+	protected static Context context;
 	protected List<SessionType> startServiceList = new ArrayList<SessionType>();	
 	
     public SdlSecurityBase() {
@@ -84,12 +86,22 @@ public abstract class SdlSecurityBase {
     	appId = val;
     }
 
+    @Deprecated
     public static Service getAppService() {
-    	return appService;
+        return appService;
     }
-    
+
+    @Deprecated
     public static void setAppService(Service val) {
-    	appService = val;
+        appService = val;
+    }
+
+    public static Context getContext() {
+        return context;
+    }
+
+    public static void setContext(Context val) {
+        context = val;
     }
     
     public List<String> getMakeList() {

--- a/sdl_android/src/main/java/com/smartdevicelink/security/SdlSecurityBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/security/SdlSecurityBase.java
@@ -94,6 +94,9 @@ public abstract class SdlSecurityBase {
     @Deprecated
     public static void setAppService(Service val) {
         appService = val;
+        if (val != null && val.getApplicationContext() != null){
+        	setContext(val.getApplicationContext());
+        }
     }
 
     public static Context getContext() {


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
Because `_proxyListener` is no longer an instance of `Service` after adding the managers layer, the method `sendBroadcastIntent` in `SdlProxyBase` is always returning without actually sending a broadcast:

https://github.com/smartdevicelink/sdl_android/blob/42ef06bb9a212371abf778a8f6d4f5ba255a98a0/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java#L896

Also the `getService()` method will always return `null` for the same reason:
https://github.com/smartdevicelink/sdl_android/blob/42ef06bb9a212371abf778a8f6d4f5ba255a98a0/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java#L867

### Changelog
* Pass context from`SdlManager` to `SdlProxyBase` to use it directly to send broadcast instead of getting the context from the service
* Deprecate `setAppService()` & `getAppService()` methods in `SdlSecurityBase`
* Add `setContext()` & `getContext()` methods to `SdlSecurityBase`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)