### PR TITLE
Add PLAY_PAUSE enum value

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/ButtonNameTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/ButtonNameTests.java
@@ -10,7 +10,7 @@ import com.smartdevicelink.proxy.rpc.enums.ButtonName;
 
 /**
  * This is a unit test class for the SmartDeviceLink library project class : 
- * {@link com.smartdevicelink.rpc.enums.ButtonName}
+ * {@link com.smartdevicelink.proxy.rpc.enums.ButtonName}
  */
 public class ButtonNameTests extends TestCase {
 
@@ -200,7 +200,6 @@ public class ButtonNameTests extends TestCase {
 		enumTestList.add(ButtonName.SHUFFLE);
 		enumTestList.add(ButtonName.REPEAT);
 		enumTestList.add(ButtonName.PLAY_PAUSE);
-		enumTestList.add(ButtonName.OKAY);
 
 		assertTrue("Enum value list does not match enum class list", 
 				enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/ButtonNameTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/enums/ButtonNameTests.java
@@ -199,6 +199,8 @@ public class ButtonNameTests extends TestCase {
 		enumTestList.add(ButtonName.SOURCE);
 		enumTestList.add(ButtonName.SHUFFLE);
 		enumTestList.add(ButtonName.REPEAT);
+		enumTestList.add(ButtonName.PLAY_PAUSE);
+		enumTestList.add(ButtonName.OKAY);
 
 		assertTrue("Enum value list does not match enum class list", 
 				enumValueList.containsAll(enumTestList) && enumTestList.containsAll(enumValueList));

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCRequest.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/RPCRequest.java
@@ -21,6 +21,10 @@ public class RPCRequest extends RPCMessage {
 		super(hash);
 	}
 
+	public RPCRequest(RPCRequest request){
+		super(request);
+		setCorrelationID(CorrelationIdGenerator.generateId());
+	}
 	public Integer getCorrelationID() {
 		//First we check to see if a correlation ID is set. If not, create one.
 		if(!function.containsKey(RPCMessage.KEY_CORRELATION_ID)){

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3302,7 +3302,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				
 				final OnButtonPress msg = new OnButtonPress(hash);
 				msg.format(rpcSpecVersion, true);
-				final List<OnButtonPress> extras = (List<OnButtonPress>)handleButtonNotificationFormatting(msg);
+				final OnButtonPress onButtonPressCompat = (OnButtonPress)handleButtonNotificationFormatting(msg);
 				if (_callbackToUIThread) {
 					// Run in UI thread
 					_mainUIHandler.post(new Runnable() {
@@ -3310,20 +3310,16 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 						public void run() {
 							_proxyListener.onOnButtonPress(msg);
 							onRPCNotificationReceived(msg);
-							if(extras != null){
-								for(OnButtonPress press: extras){
-									_proxyListener.onOnButtonPress(press);
-								}
+							if(onButtonPressCompat != null){
+								_proxyListener.onOnButtonPress(onButtonPressCompat);
 							}
 						}
 					});
 				} else {
 					_proxyListener.onOnButtonPress(msg);
 					onRPCNotificationReceived(msg);
-					if(extras != null){
-						for(OnButtonPress press: extras){
-							_proxyListener.onOnButtonPress(press);
-						}
+					if(onButtonPressCompat != null){
+						_proxyListener.onOnButtonPress(onButtonPressCompat);
 					}
 				}
 			} else if (functionName.equals(FunctionID.ON_BUTTON_EVENT.toString())) {
@@ -3331,7 +3327,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				
 				final OnButtonEvent msg = new OnButtonEvent(hash);
 				msg.format(rpcSpecVersion, true);
-				final List<OnButtonEvent> extras = (List<OnButtonEvent>)handleButtonNotificationFormatting(msg);
+				final OnButtonEvent onButtonEventCompat = (OnButtonEvent)handleButtonNotificationFormatting(msg);
 
 				if (_callbackToUIThread) {
 					// Run in UI thread
@@ -3340,20 +3336,16 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 						public void run() {
 							_proxyListener.onOnButtonEvent(msg);
 							onRPCNotificationReceived(msg);
-							if(extras != null){
-								for(OnButtonEvent event: extras){
-									_proxyListener.onOnButtonEvent(event);
-								}
+							if(onButtonEventCompat != null){
+								_proxyListener.onOnButtonEvent(onButtonEventCompat);
 							}
 						}
 					});
 				} else {
 					_proxyListener.onOnButtonEvent(msg);
 					onRPCNotificationReceived(msg);
-					if(extras != null){
-						for(OnButtonEvent event: extras){
-							_proxyListener.onOnButtonEvent(event);
-						}
+					if(onButtonEventCompat != null){
+						_proxyListener.onOnButtonEvent(onButtonEventCompat);
 					}
 				}
 			} else if (functionName.equals(FunctionID.ON_LANGUAGE_CHANGE.toString())) {
@@ -3614,7 +3606,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	 * OK button name. This should be removed during the next major release
 	 * @param notification
 	 */
-	private List<? extends RPCNotification> handleButtonNotificationFormatting(RPCNotification notification){
+	private RPCNotification handleButtonNotificationFormatting(RPCNotification notification){
 		if(FunctionID.ON_BUTTON_EVENT.toString().equals(notification.getFunctionName())
 				|| FunctionID.ON_BUTTON_PRESS.toString().equals(notification.getFunctionName())){
 
@@ -3623,25 +3615,13 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				if(ButtonName.PLAY_PAUSE.equals(buttonName)){
 					RPCNotification notification2 = new RPCNotification(notification);
 					notification2.setParameters(OnButtonEvent.KEY_BUTTON_NAME, ButtonName.OK);
-					return Collections.singletonList(notification2);
-				}else if(ButtonName.OK.equals(buttonName)){
-					RPCNotification notification2 = new RPCNotification(notification);
-					notification2.setParameters(OnButtonEvent.KEY_BUTTON_NAME, ButtonName.OKAY);
-					return Collections.singletonList(notification2);
+					return notification2;
 				}
 			}else{
 				if(ButtonName.OK.equals(buttonName)){
-					List<RPCNotification> retList = new ArrayList<>();
-
 					RPCNotification notification2 = new RPCNotification(notification);
-					notification2.setParameters(OnButtonEvent.KEY_BUTTON_NAME, ButtonName.OKAY);
-					retList.add(notification2);
-
-					RPCNotification notification3 = new RPCNotification(notification);
-					notification3.setParameters(OnButtonEvent.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
-					retList.add(notification3);
-
-					return retList;
+					notification2.setParameters(OnButtonEvent.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
+					return notification2;
 				}
 			}
 
@@ -3805,8 +3785,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			throw new SdlException("Invalid correlation ID. The correlation ID, " + request.getCorrelationID()
 					+ " , is a reserved correlation ID.", SdlExceptionCause.RESERVED_CORRELATION_ID);
 		}
-		
-		// Throw exception if RPCRequest is sent when SDL is unavailable 
+		// Throw exception if RPCRequest is sent when SDL is unavailable
 		if (!_appInterfaceRegisterd && !request.getFunctionName().equals(FunctionID.REGISTER_APP_INTERFACE.toString())) {
 			
 			SdlTrace.logProxyEvent("Application attempted to send an RPCRequest (non-registerAppInterface), before the interface was registerd.", SDL_LIB_TRACE_KEY);
@@ -3833,8 +3812,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 			if(rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
 
-				if (ButtonName.PLAY_PAUSE.equals(buttonName)
-						|| ButtonName.OKAY.equals(buttonName)) {
+				if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
 					request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
 				}
 			} else { //Newer than version 5.0.0

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCResponse;
 import com.smartdevicelink.proxy.Version;
+import com.smartdevicelink.proxy.rpc.enums.ButtonName;
 import com.smartdevicelink.proxy.rpc.enums.HmiZoneCapabilities;
 import com.smartdevicelink.proxy.rpc.enums.Language;
 import com.smartdevicelink.proxy.rpc.enums.PrerecordedSpeech;
@@ -84,6 +85,25 @@ public class RegisterAppInterfaceResponse extends RPCResponse {
 		if(getIconResumed() == null){
 			setIconResumed(Boolean.FALSE);
 		}
+
+		List<ButtonCapabilities> capabilities = getButtonCapabilities();
+		if(capabilities != null){
+			List<ButtonCapabilities> additions = new ArrayList<>();
+			for(ButtonCapabilities capability : capabilities){
+				if(ButtonName.OK.equals(capability.getName())){
+					//Regardless of version this needs to be added
+					additions.add(new ButtonCapabilities(ButtonName.OKAY, capability.getShortPressAvailable(), capability.getLongPressAvailable(), capability.getUpDownAvailable()));
+
+					if(rpcVersion == null || rpcVersion.getMajor() < 5){
+						//If version is < 5, the play pause button must also be added
+						additions.add(new ButtonCapabilities(ButtonName.PLAY_PAUSE, capability.getShortPressAvailable(), capability.getLongPressAvailable(), capability.getUpDownAvailable()));
+					}
+				}
+			}
+			capabilities.addAll(additions);
+			setButtonCapabilities(capabilities);
+		}
+
 
 		super.format(rpcVersion,formatParams);
 	}

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterfaceResponse.java
@@ -91,9 +91,6 @@ public class RegisterAppInterfaceResponse extends RPCResponse {
 			List<ButtonCapabilities> additions = new ArrayList<>();
 			for(ButtonCapabilities capability : capabilities){
 				if(ButtonName.OK.equals(capability.getName())){
-					//Regardless of version this needs to be added
-					additions.add(new ButtonCapabilities(ButtonName.OKAY, capability.getShortPressAvailable(), capability.getLongPressAvailable(), capability.getUpDownAvailable()));
-
 					if(rpcVersion == null || rpcVersion.getMajor() < 5){
 						//If version is < 5, the play pause button must also be added
 						additions.add(new ButtonCapabilities(ButtonName.PLAY_PAUSE, capability.getShortPressAvailable(), capability.getLongPressAvailable(), capability.getUpDownAvailable()));

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/ButtonName.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/ButtonName.java
@@ -23,20 +23,22 @@ package com.smartdevicelink.proxy.rpc.enums;
  */
 public enum ButtonName{
 	/**
-	 * <br><b>THIS ENUM VALUE HAS BEEN DEPRECATED AND SHOULD NO LONGER BE USED!</b>
+	 * <br><b>THIS ENUM VALUE WILL CHANGE IN FUNCITONALITY DURING THE NEXT MAJOR RELEASE!</b>
 	 * <br><br>
 	 * This ButtonName value originally was used for both the OK button and PLAY_PAUSE button. As of
-	 * SmartDeviceLink 5.0.0, the functionality was broken out into the OKAY and PLAY_PAUSE buttons.
+	 * SmartDeviceLink 5.0.0, the functionality was broken out into the OK and PLAY_PAUSE buttons.
+	 * <br><br> For this version of the library OK will be received for both OK and PLAY_PAUSE to
+	 * mitigate a potential break in functionliaty. If the desire is only for the OK functionality,
+	 * this button should still be used. If the desired functionality was actually for the play/pause
+	 * toggle, then the new PLAY_PAUSE should be used.
 	 * <br><br>
-	 * <s>Represents the button usually labeled "OK". A typical use of this button
-	 * is for the user to press it to make a selection or toggle between play and pause.</s>
+	 * Represents the button usually labeled "OK". A typical use of this button
+	 * is for the user to press it to make a selection (and until a major library version release,
+	 * play pause toggle).
 	 *
 	 * @since SmartDeviceLink 1.0
-	 * @deprecated SmartDeviceLink 5.0. See #OKAY
-	 * @see #OKAY
 	 * @see #PLAY_PAUSE
 	 */
-	@Deprecated
 	OK,
 	/**
 	 * Represents the seek-left button. A typical use of this button is for the
@@ -152,21 +154,10 @@ public enum ButtonName{
 	 * <br><br><b>NOTE:</b> This functionality used to be represented by the OK button.
 	 *
 	 * @since SmartDeviceLink 5.0
-	 * @see #OKAY
 	 * @see #OK
 	 */
 	PLAY_PAUSE,
-	/**
-	 * Represents the button usually labeled "OKAY" or "OK". A typical use of this button
-	 * is for the user to press it to make a selection.
-	 *
-	 * <br><br><b>NOTE:</b> This functionality used to be represented by the OK button.
-	 *
-	 * @since SmartDeviceLink 5.0
-	 * @see #PLAY_PAUSE
-	 * @see #OK
-	 */
-	OKAY,
+
 	;
 
     public static ButtonName valueForString(String value) {

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/ButtonName.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/ButtonName.java
@@ -23,11 +23,20 @@ package com.smartdevicelink.proxy.rpc.enums;
  */
 public enum ButtonName{
 	/**
-	 * Represents the button usually labeled "OK". A typical use of this button
-	 * is for the user to press it to make a selection.
-	 * 
+	 * <br><b>THIS ENUM VALUE HAS BEEN DEPRECATED AND SHOULD NO LONGER BE USED!</b>
+	 * <br><br>
+	 * This ButtonName value originally was used for both the OK button and PLAY_PAUSE button. As of
+	 * SmartDeviceLink 5.0.0, the functionality was broken out into the OKAY and PLAY_PAUSE buttons.
+	 * <br><br>
+	 * <s>Represents the button usually labeled "OK". A typical use of this button
+	 * is for the user to press it to make a selection or toggle between play and pause.</s>
+	 *
 	 * @since SmartDeviceLink 1.0
+	 * @deprecated SmartDeviceLink 5.0. See #OKAY
+	 * @see #OKAY
+	 * @see #PLAY_PAUSE
 	 */
+	@Deprecated
 	OK,
 	/**
 	 * Represents the seek-left button. A typical use of this button is for the
@@ -136,6 +145,28 @@ public enum ButtonName{
 	SOURCE,
 	SHUFFLE,
 	REPEAT,
+	/**
+	 * Represents the play/pause button. A typical use of this button
+	 * is for the user to press it to toggle between media playing and pausing.
+	 *
+	 * <br><br><b>NOTE:</b> This functionality used to be represented by the OK button.
+	 *
+	 * @since SmartDeviceLink 5.0
+	 * @see #OKAY
+	 * @see #OK
+	 */
+	PLAY_PAUSE,
+	/**
+	 * Represents the button usually labeled "OKAY" or "OK". A typical use of this button
+	 * is for the user to press it to make a selection.
+	 *
+	 * <br><br><b>NOTE:</b> This functionality used to be represented by the OK button.
+	 *
+	 * @since SmartDeviceLink 5.0
+	 * @see #PLAY_PAUSE
+	 * @see #OK
+	 */
+	OKAY,
 	;
 
     public static ButtonName valueForString(String value) {


### PR DESCRIPTION
Fixes #229 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
- Updated unit tests.
- Test with develop branch of Core
- Test with older systems using new enums

### Summary
Added the PLAY_PLAUSE enum value. There was also javadoc added to clarify the situation until the next major release.  Essentially both OK and PLAY_PAUSE will receive the events when one comes in from core for this release. In the next major release this will be sorted out with less confusion.

 Developer API |Version & Direction | Core
---------------|----------------------|------------
Received               |<~~~~~~~| Sent
Drop           |< 5                   | PLAY_PAUSE
PP & OK        |>= 5                  | PLAY_PAUSE
OK & PP  |< 5                   | OK
OK & PP      |>= 5                  | OK
Sent               |~~~~~~>|  Received
OK             |< 5                   | OK
OK             |>= 5                  | OK & PLAY_PAUSE
PLAY_PAUSE     |< 5                   | OK
PLAY_PAUSE     |>= 5                  | PLAY_PAUSE

### Changelog

##### Enhancements
* Added the `PLAY_PAUSE` enum value

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)