### PR TITLE
Bug fix for timeout for notification

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -899,7 +899,7 @@ public class SdlRouterService extends Service{
 			}
 		}
 		if(intent != null ){
-			if(intent.getBooleanExtra(FOREGROUND_EXTRA, false)){
+			if(intent.getBooleanExtra(FOREGROUND_EXTRA, false) && !isTransportConnected){
 				String address = null;
 				if(intent.hasExtra(BluetoothDevice.EXTRA_DEVICE)){
 					BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
@@ -908,7 +908,8 @@ public class SdlRouterService extends Service{
 					}
 				}
 				int timeout = getNotificationTimeout(address);
-				enterForeground("Waiting for connection...", timeout, false);
+				int timeOutInSeconds = timeout/1000;
+				enterForeground("Waiting for connection...", timeOutInSeconds, false);
 				resetForegroundTimeOut(timeout);
 			}
 			if(intent.hasExtra(TransportConstants.PING_ROUTER_SERVICE_EXTRA)){
@@ -1020,7 +1021,7 @@ public class SdlRouterService extends Service{
 		}
 		// If this is a new device or hasn't connected through SDL we want to limit the exposure
 		// of the SDL service in the foreground
-		return FOREGROUND_TIMEOUT/1000;
+		return FOREGROUND_TIMEOUT;
 	}
 
 	public void resetForegroundTimeOut(long delay){


### PR DESCRIPTION
Fixes #867

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Tested with production units

### Summary
1. "Waiting for connection" notification shown even if App is connected. So, added check for transport connection before "waiting" notification is shown.
2. Time in milliseconds is passed as argument to Handler.postdelayed method, so that notification should be removed after 10 seconds.

### Changelog
##### Breaking Changes
* NA

##### Enhancements
1. Check for transport connection before "waiting" notification is shown
2. Time in milliseconds is passed as argument to Handler.postdelayed method

##### Bug Fixes
* NA

### Tasks Remaining:
- [X] code changes
- [X] Tests

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)