### PR TITLE
[WIP] Feature/multiplexing only add on transport changed

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
@@ -993,7 +993,7 @@ public class SdlProtocol {
     }
 
     private void sendTransportNotification (){
-        boolean isMediaSupported = false;
+        boolean isHighBandwidthAvailable = false;
         List<TransportType> connectedPrimaryTransports = new ArrayList<>();
         List<TransportType> connectedSecondaryTransports = new ArrayList<>();
 
@@ -1008,23 +1008,14 @@ public class SdlProtocol {
                 }
             }
 
-            // Check if there is at least on transport that supports media
+            // Check if there is at least on transport that supports audio & video
             if ( (audio.contains(PRIMARY_TRANSPORT_ID) && video.contains(PRIMARY_TRANSPORT_ID) && !connectedPrimaryTransports.isEmpty())
                     || (audio.contains(SECONDARY_TRANSPORT_ID) && video.contains(SECONDARY_TRANSPORT_ID) && !connectedSecondaryTransports.isEmpty()) ){
-                isMediaSupported = true;
+                isHighBandwidthAvailable = true;
             }
 
 
-            // send notifactin
-            Log.i("Bilalo89", "connectedTransports: " + connectedTransports);
-            Log.i("Bilalo89", "supportedSecondaryTransports: " + supportedSecondaryTransports);
-            Log.i("Bilalo89", "audio: " + audio);
-            Log.i("Bilalo89", "video: " + video);
-
-
-            Log.i("Bilalo89", "connectedPrimaryTransports: " + connectedPrimaryTransports);
-            Log.i("Bilalo89", "connectedSecondaryTransports: " + connectedSecondaryTransports);
-            Log.i("Bilalo89", "isMediaSupported: " + isMediaSupported);
+            // Send notification
         }
 
     }

--- a/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
@@ -1014,8 +1014,8 @@ public class SdlProtocol {
                 isHighBandwidthAvailable = true;
             }
 
-
             // Send notification
+            transportConfig.getTransportListener().onTransportChanged(isHighBandwidthAvailable, connectedTransports);
         }
 
     }

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTransportConfig.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTransportConfig.java
@@ -1,6 +1,7 @@
 package com.smartdevicelink.transport;
 
 import com.smartdevicelink.transport.enums.TransportType;
+import com.smartdevicelink.transport.utl.TransportRecord;
 
 import android.content.ComponentName;
 import android.content.Context;
@@ -41,9 +42,9 @@ public class MultiplexTransportConfig extends BaseTransportConfig{
 
 	List<TransportType> primaryTransports, secondaryTransports;
 	boolean requiresHighBandwidth = false;
+	private ITransportListener transportListener;
 
 
-	
 	public MultiplexTransportConfig(Context context, String appId) {
 		this.context = context;
 		this.appId = appId;
@@ -138,5 +139,23 @@ public class MultiplexTransportConfig extends BaseTransportConfig{
 		return this.secondaryTransports;
 	}
 
+	/**
+	 * Set a callback interface that will be triggered when a transport connects or disconnects
+	 * @param listener ITransportListener represents the callback interface
+	 */
+	public void setOnTransportChangedListener(ITransportListener listener){
+		transportListener = listener;
+	}
 
+	/**
+	 * Get the callback interface that will be triggered when a transport connects or disconnects
+	 * @return ITransportListener represents the callback interface
+	 */
+	public ITransportListener getTransportListener() {
+		return transportListener;
+	}
+
+	public interface ITransportListener {
+		void onTransportChanged(boolean isHighBandwidthAvailable, List<TransportRecord> connectedTransports);
+	}
 }


### PR DESCRIPTION
This PR is **[not ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Summary
This PR adds `setOnTransportChangedListener` to `MultiplexTransportConfig` to let developers set a listener to receive updates when a new transport connects/disconnects. It also informs the developer if the current connected transports support audio/video. So developers can start video streaming when the correct transport is connected.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)