### PR TITLE
[WIP] VideoStreamingManager state fixes

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -184,7 +184,9 @@ public class SdlManager{
 
 
 		if(getAppTypes().contains(AppHMIType.NAVIGATION) || getAppTypes().contains(AppHMIType.PROJECTION)){
-			this.videoStreamingManager = new VideoStreamingManager(_internalInterface);
+			if (videoStreamingManager == null) {
+				this.videoStreamingManager = new VideoStreamingManager(_internalInterface);
+			}
 			this.videoStreamingManager.start(subManagerListener);
 		}
 
@@ -641,6 +643,9 @@ public class SdlManager{
 						@Override
 						public void onTransportEvent(List<TransportRecord> connectedTransports, boolean audioStreamTransportAvail, boolean videoStreamTransportAvail) {
 
+							if (videoStreamingManager == null){
+								videoStreamingManager = new VideoStreamingManager(_internalInterface);
+							}
 							//Pass to submanagers that need it
 							if(videoStreamingManager != null){
 								videoStreamingManager.handleTransportUpdated(connectedTransports, audioStreamTransportAvail, videoStreamTransportAvail);

--- a/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
@@ -1036,6 +1036,8 @@ public class SdlProtocol {
                     hashID = BitConverter.intFromByteArray(packet.payload, 0);
                 }
             }
+
+            notifyDevTransportListener();
         }
 
         iSdlProtocol.onProtocolSessionStarted(serviceType, (byte) packet.getSessionId(), (byte)protocolVersion.getMajor(), "", hashID, packet.isEncrypted());


### PR DESCRIPTION
Minor fixes for https://github.com/smartdevicelink/sdl_android/pull/879 to make sure that `videoStreamingManager` is initialized before we call `videoStreamingManager.handleTransportUpdated()`