### PR TITLE
Fix issue-882: maxBitrate in VIDEO_STREAMING capability is misread

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/streaming/video/VideoStreamingParameters.java
@@ -133,7 +133,7 @@ public class VideoStreamingParameters {
      * @see VideoStreamingCapability
      */
     public void update(VideoStreamingCapability capability){
-        if(capability.getMaxBitrate()!=null){ this.bitrate = capability.getMaxBitrate(); }
+        if(capability.getMaxBitrate()!=null){ this.bitrate = capability.getMaxBitrate() * 1000; } // NOTE: the unit of maxBitrate in getSystemCapability is kbps.
         ImageResolution resolution = capability.getPreferredResolution();
         if(resolution!=null){
             if(resolution.getResolutionHeight()!=null && resolution.getResolutionHeight() > 0){ this.resolution.setResolutionHeight(resolution.getResolutionHeight()); }


### PR DESCRIPTION
Fix issue-882: maxBitrate in VIDEO_STREAMING capability is misread

Fixes #882 
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
N/A

### Summary
Fix the VideoStreamingParamters to handle maxBitrate correctly.

### Changelog
##### Breaking Changes
N/A

##### Enhancements
N/A

##### Bug Fixes
#882 

### Tasks Remaining:
None

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)