### PR TITLE
Fix issue-884: sdl.router.startservice broadcast was sent twice unexpectedly

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -143,7 +143,6 @@ public class AndroidTools {
 
 		if (apps == null) {
 			apps = context.getPackageManager().queryBroadcastReceivers(intent, 0);
-			context.sendBroadcast(intent);
 		}
 
 		if (apps != null && apps.size()>0) {
@@ -155,6 +154,9 @@ public class AndroidTools {
 					//In case there is missing info in the app reference we want to keep moving
 				}
 			}
+		} else {
+			// fallback to implicit broadcast if we cannot resolve apps info.
+			context.sendBroadcast(intent);
 		}
 	}
 


### PR DESCRIPTION
Fix issue-884: sdl.router.startservice broadcast was sent twice unexpectedly

Fixes #884 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
N/A

### Summary
sendExplicitBroadcast unexpectedly sent broadcast twice if the given apps param was null.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* #884 

### Tasks Remaining:
- N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)