### PR TITLE
Fix issue with legacy USB connections

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -90,6 +90,7 @@ import com.smartdevicelink.trace.enums.InterfaceActivityDirection;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
 import com.smartdevicelink.transport.SiphonServer;
+import com.smartdevicelink.transport.USBTransportConfig;
 import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.util.CorrelationIdGenerator;
 import com.smartdevicelink.util.DebugTool;
@@ -111,6 +112,8 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Vector;
@@ -1471,6 +1474,24 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		_systemCapabilityManager = new SystemCapabilityManager(_internalInterface);
 		// Setup SdlConnection
 		synchronized(CONNECTION_REFERENCE_LOCK) {
+
+			//Handle legacy USB connections
+			if(_transportConfig != null
+					&& TransportType.USB.equals(_transportConfig.getTransportType())){
+				//A USB transport config was provided
+				USBTransportConfig usbTransportConfig = (USBTransportConfig)_transportConfig;
+				if(usbTransportConfig.getUsbAccessory() == null){
+					DebugTool.logInfo("Legacy USB transport config was used, but received null for accessory. Attempting to connect with router service");
+					//The accessory was null which means it came from a router service
+					MultiplexTransportConfig multiplexTransportConfig = new MultiplexTransportConfig(usbTransportConfig.getUSBContext(),_appID);
+					multiplexTransportConfig.setRequiresHighBandwidth(true);
+					multiplexTransportConfig.setSecurityLevel(MultiplexTransportConfig.FLAG_MULTI_SECURITY_OFF);
+					multiplexTransportConfig.setPrimaryTransports(Collections.singletonList(TransportType.USB));
+					multiplexTransportConfig.setSecondaryTransports(new ArrayList<TransportType>());
+					_transportConfig = multiplexTransportConfig;
+				}
+			}
+
 			if(_transportConfig.getTransportType().equals(TransportType.MULTIPLEX)){
 				this.sdlSession = new SdlSession2(_interfaceBroker,(MultiplexTransportConfig)_transportConfig);
 			}else{

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTransportConfig.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTransportConfig.java
@@ -157,6 +157,13 @@ public class MultiplexTransportConfig extends BaseTransportConfig{
 	 * Set whether or not this app requires the use of a transport that supports high bandwidth
 	 * services. Common use is when an app uses the video/audio streaming services and there is no
 	 * other integration that could be useful to the user.
+	 * <br><br> <b>For example:</b>
+	 * <br><b>1. </b>If an app intends to perform audio or video streaming and does not wish
+	 * to appear on the module when that isn't possible, a value of true should be sent.
+	 * <br><b>2. </b>If the same app wishes to appear on the module even when those services aren't available
+	 * a value of true should be sent. In this case, the app could display a message prompting the
+	 * user to "Please connect USB or Wifi" or it could have a separate integration like giving turn
+	 * by turn directions in place of streaming the full navigation map.
 	 * @param requiresHighBandwidth whether the app should be treated as requiring a high
 	 *                                 bandwidth transport.
 	 */
@@ -242,13 +249,13 @@ public class MultiplexTransportConfig extends BaseTransportConfig{
 		 * @param connectedTransports the currently connected transports
 		 * @param audioStreamTransportAvail true if there is either an audio streaming supported
 		 *                                        transport currently connected or a transport is
-		 *                                        available to connect with. false if there is no
+		 *                                        available to connect with. False if there is no
 		 *                                        transport connected to support audio streaming and
 		 *                                        no possibility in the foreseeable future.
-		 * @param videoStreamTransportAvail true if there is either an audio streaming supported
+		 * @param videoStreamTransportAvail true if there is either a video streaming supported
 		 *                                        transport currently connected or a transport is
-		 *                                        available to connect with. false if there is no
-		 *                                        transport connected to support audio streaming and
+		 *                                        available to connect with. False if there is no
+		 *                                        transport connected to support video streaming and
 		 *                                        no possibility in the foreseeable future.
 		 */
 		void onTransportEvent(List<TransportRecord> connectedTransports, boolean audioStreamTransportAvail,boolean videoStreamTransportAvail);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -102,11 +102,12 @@ public class RouterServiceValidator {
 	}
 
 	public RouterServiceValidator(@NonNull MultiplexTransportConfig config){
-		inDebugMode = inDebugMode();
 		this.context = config.context;
 		this.service = config.service;
 		setSecurityLevel(config.securityLevel);
+		inDebugMode = inDebugMode();
 	}
+	
 	/**
 	 * Main function to call to ensure we are connecting to a validated router service
 	 * @return whether or not the currently running router service can be trusted.

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -23,6 +23,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
 import android.content.pm.ServiceInfo;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.smartdevicelink.util.AndroidTools;
@@ -98,6 +99,13 @@ public class RouterServiceValidator {
 		this.context = context;
 		inDebugMode = inDebugMode();
 		this.service = service;
+	}
+
+	public RouterServiceValidator(@NonNull MultiplexTransportConfig config){
+		inDebugMode = inDebugMode();
+		this.context = config.context;
+		this.service = config.service;
+		setSecurityLevel(config.securityLevel);
 	}
 	/**
 	 * Main function to call to ensure we are connecting to a validated router service

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -44,11 +44,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.hardware.usb.UsbManager;
 import android.os.Build;
+import android.os.Parcelable;
 import android.util.Log;
 
 import com.smartdevicelink.R;
 import com.smartdevicelink.transport.RouterServiceValidator.TrustedListCallback;
+import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.util.AndroidTools;
 import com.smartdevicelink.util.SdlAppInfo;
 import com.smartdevicelink.util.ServiceFinder;
@@ -164,6 +167,12 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 								//List obtained. Let's start our service
 								queuedService = componentName;
 								finalIntent.setAction("com.sdl.noaction"); //Replace what's there so we do go into some unintended loop
+								String  transportType = finalIntent.getStringExtra(TransportConstants.START_ROUTER_SERVICE_TRANSPORT_CONNECTED);
+								if(transportType!= null ){
+									if(TransportType.USB.toString().equals(transportType)){
+										finalIntent.putExtra(UsbManager.EXTRA_ACCESSORY, (Parcelable)null);
+									}
+								}
 								onSdlEnabled(finalContext, finalIntent);
 							}
 							

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1593,6 +1593,11 @@ public class SdlRouterService extends Service{
 		startService.putExtra(TransportConstants.FORCE_TRANSPORT_CONNECTED, true);
 		startService.putExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_APP_PACKAGE, getBaseContext().getPackageName());
 		startService.putExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_CMP_NAME, new ComponentName(this, this.getClass()));
+
+		if(record!= null && record.getType() != null){
+			startService.putExtra(TransportConstants.START_ROUTER_SERVICE_TRANSPORT_CONNECTED, record.getType().toString());
+		}
+
 		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
 			startService.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
 		}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/TransportConstants.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/TransportConstants.java
@@ -27,6 +27,7 @@ public class TransportConstants {
 	public static final String START_ROUTER_SERVICE_SDL_ENABLED_EXTRA		= "sdl_enabled";
 	public static final String START_ROUTER_SERVICE_SDL_ENABLED_APP_PACKAGE = "package_name";
 	public static final String START_ROUTER_SERVICE_SDL_ENABLED_CMP_NAME    = "component_name";
+	public static final String START_ROUTER_SERVICE_TRANSPORT_CONNECTED   	= "transport_connected"; //Extra for the transport that just connected
 	public static final String START_ROUTER_SERVICE_SDL_ENABLED_PING		= "ping";
 	@Deprecated
 	public static final String FORCE_TRANSPORT_CONNECTED					= "force_connect"; //This is legacy, do not refactor this. 

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
@@ -82,7 +82,7 @@ public class TransportManager {
             config.service = SdlBroadcastReceiver.consumeQueuedRouterService();
         }
 
-        RouterServiceValidator validator = new RouterServiceValidator(config.context,config.service);
+        RouterServiceValidator validator = new RouterServiceValidator(config);
         if(validator.validate()){
             transport = new TransportBrokerImpl(config.context, config.appId,config.service);
         }else{

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransportConfig.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBTransportConfig.java
@@ -5,28 +5,78 @@ import com.smartdevicelink.transport.enums.TransportType;
 import android.content.Context;
 import android.hardware.usb.UsbAccessory;
 
+/**
+ * <b>NOTE: </b> This should no longer be used. See the MultplexTransportConfig and guides to
+ * understand how to implement USB multiplexing. This class and method of USB connection will be
+ * removed in the next major release. If a router service is available to handle multiplexing of the
+ * usb transport it will be used, and this app will connect to whatever router service hosts the USB
+ * connection.
+ * @see MultiplexTransportConfig
+ */
 @Deprecated
 public class USBTransportConfig extends BaseTransportConfig {
 	
 	private Context mainActivity = null;
 	private UsbAccessory usbAccessory = null;
 	private Boolean queryUsbAcc = true;
-	
+
+	/**
+	 * <b>NOTE: </b> This should no longer be used. See the MultplexTransportConfig and guides to
+	 * understand how to implement USB multiplexing. This class and method of USB connection will be
+	 * removed in the next major release. If a router service is available to handle multiplexing of the
+	 *  usb transport it will be used, and this app will connect to whatever router service hosts the USB
+	 *  connection.
+	 * @param mainActivity context used to start USB transport
+	 * @see MultiplexTransportConfig
+	 */
 	public USBTransportConfig (Context mainActivity) {
 		this.mainActivity = mainActivity;
 	}
-	
+
+	/**
+	 * <b>NOTE: </b> This should no longer be used. See the MultplexTransportConfig and guides to
+	 * understand how to implement USB multiplexing. This class and method of USB connection will be
+	 * removed in the next major release. If a router service is available to handle multiplexing of the
+	 * usb transport it will be used, and this app will connect to whatever router service hosts the USB
+	 * connection.
+	 * @param mainActivity context used to start USB transport
+	 * @param usbAccessory the accessory that was given to this app
+	 * @see MultiplexTransportConfig
+	 */
 	public USBTransportConfig (Context mainActivity, UsbAccessory usbAccessory) {
 		this.mainActivity = mainActivity;
 		this.usbAccessory = usbAccessory;
 	}
-	
+
+	/**
+	 * <b>NOTE: </b> This should no longer be used. See the MultplexTransportConfig and guides to
+	 * understand how to implement USB multiplexing. This class and method of USB connection will be
+	 * removed in the next major release. If a router service is available to handle multiplexing of the
+	 * usb transport it will be used, and this app will connect to whatever router service hosts the USB
+	 * connection.
+	 * @param mainActivity context used to start USB transport
+	 * @param shareConnection enable other sessions on this app to use this USB connection
+	 * @param queryUsbAcc attempt to query the USB accessory if none is provided
+	 * @see MultiplexTransportConfig
+	 */
 	public USBTransportConfig (Context mainActivity, boolean shareConnection, boolean queryUsbAcc) {
 		this.mainActivity = mainActivity;
 		this.queryUsbAcc = queryUsbAcc;
 		super.shareConnection = shareConnection;
 	}
-	
+
+	/**
+	 * <b>NOTE: </b> This should no longer be used. See the MultplexTransportConfig and guides to
+	 * understand how to implement USB multiplexing. This class and method of USB connection will be
+	 * removed in the next major release. If a router service is available to handle multiplexing of the
+	 * usb transport it will be used, and this app will connect to whatever router service hosts the USB
+	 * connection.
+	 * @param mainActivity context used to start USB transport
+	 * @param usbAccessory the accessory that was given to this app
+	 * @param shareConnection enable other sessions on this app to use this USB connection
+	 * @param queryUsbAcc attempt to query the USB accessory if none is provided
+	 * @see MultiplexTransportConfig
+	 */
 	public USBTransportConfig (Context mainActivity, UsbAccessory usbAccessory, boolean shareConnection, boolean queryUsbAcc) {
 		this.mainActivity = mainActivity;
 		this.queryUsbAcc = queryUsbAcc;


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
1. Install app that uses legacy USB transport and does not have router service declared. Plug in USB, ensure app connects
2. Install second app that has router service declared. Plug in USB, ensure both apps connect.
3. Change second app's router service version to less than 8. Plug in USB, only the first app should show.

### Summary
Introduced a new scheme to handle the legacy bluetooth connection scenario. It will also ensure that if a router service is available to host a USB connection it is used and the originating app can handle the USB connection (through multiplexing) still. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)