### PR TITLE
Fix javadocs rpc version

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/AddSubMenu.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/AddSubMenu.java
@@ -56,7 +56,7 @@ import java.util.Hashtable;
  * 			<td>Image to be be shown along with the submenu item</td>
  *                 <td>N</td>
  * 			<td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *  </table>
  *  <b>Response</b>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/DisplayCapabilities.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/DisplayCapabilities.java
@@ -37,7 +37,7 @@ import static com.smartdevicelink.proxy.constants.Names.displayType;
  * 			<td>String</td>
  * 			<td>The name of the display
  *			</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>textField</td>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/GetVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/GetVehicleData.java
@@ -176,7 +176,7 @@ import static com.smartdevicelink.proxy.rpc.CreateInteractionChoiceSet.KEY_CHOIC
  * 			<td>The estimated percentage of remaining oil life of the engine</td>
  *                 <td>N</td>
  *                 <td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>accPedalPosition</td>
@@ -200,7 +200,7 @@ import static com.smartdevicelink.proxy.rpc.CreateInteractionChoiceSet.KEY_CHOIC
  * 			<td>@see TurnSignal</td>
  * 			<td>N</td>
  * 			<td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *  </table>
  *  

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnHMIStatus.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnHMIStatus.java
@@ -57,7 +57,7 @@ import java.util.Hashtable;
  * <td>videoStreamingState</td>
  * <td>{@linkplain VideoStreamingState}</td>
  * <td>If it is NOT_STREAMABLE, the app must stop streaming video to SDL Core(stop service).</td>
- * <td>SmartDeviceLink 4.6</td>
+ * <td>SmartDeviceLink 5.0</td>
  * </tr>
  * <tr>
  * <td>systemContext</td>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnSystemRequest.java
@@ -44,7 +44,7 @@ import java.util.List;
  * 			<td>This parameter is filled for supporting OEM proprietary data exchanges.</td>
  *                 <td>N</td>
  *                 <td>Max Length: 255</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>url</td>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/OnVehicleData.java
@@ -230,7 +230,7 @@ import static com.smartdevicelink.proxy.constants.Names.timeout;
  * 			<td>The estimated percentage of remaining oil life of the engine</td>
  *                 <td>N</td>
  * 			<td>minvalue:0; maxvalue:100</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>accPedalPosition</td>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RGBColor.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RGBColor.java
@@ -19,24 +19,24 @@ import java.util.Hashtable;
  * 			<td>Integer</td>
  * 			<td>Y</td>
  * 			<td><ul><li>minvalue="0"</li><li>maxvalue="255"</li></ul></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>green</td>
  * 			<td>Integer</td>
  * 			<td>Y</td>
  * 			<td><ul><li>minvalue="0"</li><li>maxvalue="255"</li></ul></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>blue</td>
  * 			<td>Integer</td>
  * 			<td>Y</td>
  * 			<td><ul><li>minvalue="0"</li><li>maxvalue="255"</li></ul></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * </table>
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public class RGBColor extends RPCStruct{
     public static final String KEY_RED = "red";

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/RegisterAppInterface.java
@@ -189,7 +189,7 @@ import java.util.List;
  * 			<td>ID used to validate app with policy table entries</td>
  *                 <td>N</td>
  *                 <td>Maxlength: 100</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>hmiCapabilities</td>
@@ -224,7 +224,7 @@ import java.util.List;
  * 			<td>The color scheme that is used for day.</td>
  *                 <td>N</td>
  *                 <td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *
  * 		<tr>
@@ -233,7 +233,7 @@ import java.util.List;
  * 			<td>The color scheme that is used for night.</td>
  *                 <td>N</td>
  *                 <td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *  </table>
  *  <p></p>
@@ -619,7 +619,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *
 	 * @return String - a String value representing the unique ID, which an app
 	 *         will be given when approved
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public String getFullAppID() {
 		return getString(KEY_FULL_APP_ID);
@@ -633,7 +633,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *            given when approved
 	 *            <p></p>
 	 *            <b>Notes: </b>Maxlength = 100
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public void setFullAppID(String fullAppID) {
 		if (fullAppID != null) {
@@ -666,7 +666,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *
 	 * @return TemplateColorScheme - a TemplateColorScheme object representing the colors that are used
 	 * for day color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
     public TemplateColorScheme getDayColorScheme(){
 		return (TemplateColorScheme) getObject(TemplateColorScheme.class, KEY_DAY_COLOR_SCHEME);
@@ -677,7 +677,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *
 	 * @param templateColorScheme a TemplateColorScheme object representing the colors that will be
 	 * used for day color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
     public void setDayColorScheme(TemplateColorScheme templateColorScheme){
 		setParameters(KEY_DAY_COLOR_SCHEME, templateColorScheme);
@@ -688,7 +688,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *
 	 * @return TemplateColorScheme - a TemplateColorScheme object representing the colors that are used
 	 * for night color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public TemplateColorScheme getNightColorScheme(){
 		return (TemplateColorScheme) getObject(TemplateColorScheme.class, KEY_NIGHT_COLOR_SCHEME);
@@ -699,7 +699,7 @@ public class RegisterAppInterface extends RPCRequest {
 	 *
 	 * @param templateColorScheme a TemplateColorScheme object representing the colors that will be
 	 * used for night color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public void setNightColorScheme(TemplateColorScheme templateColorScheme){
 		setParameters(KEY_NIGHT_COLOR_SCHEME, templateColorScheme);

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SetDisplayLayout.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SetDisplayLayout.java
@@ -36,7 +36,7 @@ import java.util.Hashtable;
  * 			<td>The color scheme that is used for day.</td>
  *                 <td>N</td>
  *                 <td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *
  * 		<tr>
@@ -45,7 +45,7 @@ import java.util.Hashtable;
  * 			<td>The color scheme that is used for night.</td>
  *                 <td>N</td>
  *                 <td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *
  *  </table>
@@ -119,7 +119,7 @@ public class SetDisplayLayout extends RPCRequest {
 	 *
 	 * @return TemplateColorScheme - a TemplateColorScheme object representing the colors that are used
 	 * for day color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public TemplateColorScheme getDayColorScheme(){
 		return (TemplateColorScheme) getObject(TemplateColorScheme.class, KEY_DAY_COLOR_SCHEME);
@@ -130,7 +130,7 @@ public class SetDisplayLayout extends RPCRequest {
 	 *
 	 * @param templateColorScheme a TemplateColorScheme object representing the colors that will be
 	 * used for day color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public void setDayColorScheme(TemplateColorScheme templateColorScheme){
 		setParameters(KEY_DAY_COLOR_SCHEME, templateColorScheme);
@@ -141,7 +141,7 @@ public class SetDisplayLayout extends RPCRequest {
 	 *
 	 * @return TemplateColorScheme - a TemplateColorScheme object representing the colors that are used
 	 * for night color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public TemplateColorScheme getNightColorScheme(){
 		return (TemplateColorScheme) getObject(TemplateColorScheme.class, KEY_NIGHT_COLOR_SCHEME);
@@ -152,7 +152,7 @@ public class SetDisplayLayout extends RPCRequest {
 	 *
 	 * @param templateColorScheme a TemplateColorScheme object representing the colors that will be
 	 * used for night color scheme
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	public void setNightColorScheme(TemplateColorScheme templateColorScheme){
 		setParameters(KEY_NIGHT_COLOR_SCHEME, templateColorScheme);

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SetMediaClockTimer.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SetMediaClockTimer.java
@@ -60,7 +60,7 @@ import java.util.Hashtable;
  * 			<td></td>
  *                 <td>N</td>
  * 			<td></td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *
  *  </table>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SingleTireStatus.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SingleTireStatus.java
@@ -32,13 +32,13 @@ import java.util.Hashtable;
  * 			<td>The status of TPMS according to the particular tire.
  * 					See {@linkplain com.smartdevicelink.proxy.rpc.enums.TPMS}
  * 			</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>pressure</td>
  * 			<td>Float</td>
  * 			<td>The pressure value of the particular tire in kilo pascal.</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  *  </table>
  * @since SmartDeviceLink 2.0

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SubscribeVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SubscribeVehicleData.java
@@ -168,7 +168,7 @@ import java.util.Hashtable;
  * 			<td>The estimated percentage of remaining oil life of the engine</td>
  *                 <td>N</td>
  *                 <td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6 </td>
+ * 			<td>SmartDeviceLink 5.0 </td>
  * 		</tr>
  * 		<tr>
  * 			<td>accPedalPosition</td>
@@ -232,7 +232,7 @@ import java.util.Hashtable;
  * 			<td>@see TurnSignal</td>
  *				<td>N</td>
  *				<td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6 </td>
+ * 			<td>SmartDeviceLink 5.0 </td>
  * 		</tr>
  *  </table>
  *  

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SystemRequest.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SystemRequest.java
@@ -35,7 +35,7 @@ import java.util.List;
  * 			<td>This parameter is filled for supporting OEM proprietary data exchanges.</td>
  *                 <td>N</td>
  *                 <td>Max Length: 255</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>fileName</td>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/TemplateColorScheme.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/TemplateColorScheme.java
@@ -19,24 +19,24 @@ import java.util.Hashtable;
  * 			<td>RGBColor</td>
  * 			<td>The primary "accent" color</td>
  * 			<td>N</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>secondaryColor</td>
  * 			<td>RGBColor</td>
  * 			<td>The secondary "accent" color</td>
  * 			<td>N</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * 		<tr>
  * 			<td>backgroundColor</td>
  * 			<td>RGBColor</td>
  * 			<td>The color of the background</td>
  * 			<td>N</td>
- * 			<td>SmartDeviceLink 4.6</td>
+ * 			<td>SmartDeviceLink 5.0</td>
  * 		</tr>
  * </table>
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public class TemplateColorScheme extends RPCStruct {
 

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
@@ -163,7 +163,7 @@ import com.smartdevicelink.proxy.RPCRequest;
  * 			<td>The estimated percentage of remaining oil life of the engine</td>
  *                 <td>N</td>
  *                 <td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6 </td>
+ * 			<td>SmartDeviceLink 5.0 </td>
  * 		</tr>
  * 		<tr>
  * 			<td>accPedalPosition</td>
@@ -227,7 +227,7 @@ import com.smartdevicelink.proxy.RPCRequest;
  * 			<td>@see TurnSignal</td>
  *				<td>N</td>
  *				<td>Subscribable</td>
- * 			<td>SmartDeviceLink 4.6 </td>
+ * 			<td>SmartDeviceLink 5.0 </td>
  * 		</tr>
  *  </table>
  * <p><b> Response</b></p>

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/VideoStreamingCapability.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/VideoStreamingCapability.java
@@ -26,10 +26,22 @@ public class VideoStreamingCapability extends RPCStruct {
 		return (ImageResolution) getObject(ImageResolution.class, KEY_PREFERRED_RESOLUTION);
 	}
 
+	/**
+	 * Set the max bitrate supported by this module.
+	 *
+	 * <b>NOTE: </b> Unit is in kbps.
+	 * @param maxBitrate in kbps
+	 */
 	public void setMaxBitrate(Integer maxBitrate){
 		setValue(KEY_MAX_BITRATE, maxBitrate);
 	}
 
+	/**
+	 * Retrieves the max bitrate supported by this module.
+	 *
+	 * <b>NOTE: </b> Unit is in kbps.
+	 * @return max bitrate in kbps
+	 */
 	public Integer getMaxBitrate(){
 		return getInteger(KEY_MAX_BITRATE);
 	}

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/AudioStreamingIndicator.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/AudioStreamingIndicator.java
@@ -3,32 +3,32 @@ package com.smartdevicelink.proxy.rpc.enums;
 /**
  * Identifies the playback status of a media app
  *
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public enum AudioStreamingIndicator {
 	/**
 	 * Default playback indicator.
 	 *
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	PLAY_PAUSE,
 
 	/**
 	 * Indicates that a button press of the Play/Pause button would start the playback.
 	 *
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	PLAY,
 	/**
 	 * Indicates that a button press of the Play/Pause button would pause the current playback.
 	 *
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	PAUSE,
 	/**
 	 * Indicates that a button press of the Play/Pause button would stop the current playback.
 	 *
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	STOP,
 	;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/ImageFieldName.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/ImageFieldName.java
@@ -69,7 +69,7 @@ public enum ImageFieldName {
 	/**
 	 * The secondary graphic image field
 	 *
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	secondaryGraphic,
 	;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/RequestType.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/RequestType.java
@@ -69,7 +69,7 @@ public enum RequestType {
      */
     FOTA,
     /**
-     * @since SmartDeviceLink 4.6
+     * @since SmartDeviceLink 5.0
      */
     OEM_SPECIFIC,
 	;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/TPMS.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/TPMS.java
@@ -3,7 +3,7 @@ package com.smartdevicelink.proxy.rpc.enums;
 /**
  * Enums for Tire Pressure Monitoring Systems
  *
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public enum TPMS {
 

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/TurnSignal.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/TurnSignal.java
@@ -3,7 +3,7 @@ package com.smartdevicelink.proxy.rpc.enums;
 /**
  * Enumeration that describes the status of the turn light indicator.
  *
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public enum TurnSignal {
 

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/VideoStreamingState.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/VideoStreamingState.java
@@ -2,15 +2,15 @@ package com.smartdevicelink.proxy.rpc.enums;
 
 /**
  * Enumeration that describes possible states of video streaming.
- * @since SmartDeviceLink 4.6
+ * @since SmartDeviceLink 5.0
  */
 public enum VideoStreamingState {
 	/**
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	STREAMABLE,
 	/**
-	 * @since SmartDeviceLink 4.6
+	 * @since SmartDeviceLink 5.0
 	 */
 	NOT_STREAMABLE;
     public static VideoStreamingState valueForString(String value) {

--- a/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -126,8 +126,8 @@ public class AndroidTools {
 	 * Sends the provided intent to the specified destinations making it an explicit intent, rather
 	 * than an implicit intent. A direct replacement of sendBroadcast(Intent). As of Android 8.0
 	 * (API 26+) implicit broadcasts are no longer sent to broadcast receivers that are declared via
-	 * the AndroidManifest. Ihe method will also send the broadcast implicitly if no list of apps is
-	 * provided for backwards comparability.
+	 * the AndroidManifest. If no apps are found to receive the intent, this method will send the
+	 * broadcast implicitly if no list of apps is provided.
 	 *
 	 * @param intent - the intent to send explicitly
 	 * @param apps - the list of apps that this broadcast will be sent to. If null is passed in


### PR DESCRIPTION


This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan

Only documentation was updated

### Summary

- JavaDocs updated to reflect 5.0 spec version instead of 4.6
- Also fix a few minor missing or misleading doc entries

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)