### PR TITLE
Fix: make sure `MultiplexTcpTransport` creates a TCP socket over Wi-Fi network

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTcpTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTcpTransport.java
@@ -32,6 +32,7 @@
 
 package com.smartdevicelink.transport;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -39,6 +40,7 @@ import android.util.Log;
 
 import com.smartdevicelink.protocol.SdlPacket;
 import com.smartdevicelink.transport.enums.TransportType;
+import com.smartdevicelink.transport.utl.WiFiSocketFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,14 +67,16 @@ public class MultiplexTcpTransport extends MultiplexBaseTransport {
 	private OutputStream mOutputStream = null;
 	private MultiplexTcpTransport.TcpTransportThread mThread = null;
 	private WriterThread writerThread;
+	private Context mContext;
 
 
-	public MultiplexTcpTransport(int port, String ipAddress, boolean autoReconnect, Handler handler) {
+	public MultiplexTcpTransport(int port, String ipAddress, boolean autoReconnect, Handler handler, Context context) {
 		super(handler, TransportType.TCP);
 		this.ipAddress = ipAddress;
 		this.port = port;
         connectedDeviceAddress = ipAddress + ":" + port;
 		this.autoReconnect = autoReconnect;
+		mContext = context;
 		setState(STATE_NONE);
 	}
 
@@ -214,7 +218,7 @@ public class MultiplexTcpTransport extends MultiplexBaseTransport {
 						}
 
 						logInfo(String.format("TCPTransport.connect: Socket is closed. Trying to connect to %s", getAddress()));
-						mSocket = new Socket();
+						mSocket = WiFiSocketFactory.createSocket(mContext);
 						mSocket.connect(new InetSocketAddress(ipAddress, port));
 						mOutputStream = mSocket.getOutputStream();
 						mInputStream = mSocket.getInputStream();

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -650,7 +650,7 @@ public class SdlRouterService extends Service{
 							}//else { TCP transport does not exists.}
 
 							//TCP transport either doesn't exist or is not connected. Start one up.
-							service.tcpTransport = new MultiplexTcpTransport(port, ipAddress, true, service.tcpHandler);
+							service.tcpTransport = new MultiplexTcpTransport(port, ipAddress, true, service.tcpHandler, service);
 							service.tcpTransport.start();
 
 		                }

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/utl/WiFiSocketFactory.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/utl/WiFiSocketFactory.java
@@ -1,0 +1,56 @@
+package com.smartdevicelink.transport.utl;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.os.Build;
+
+import java.io.IOException;
+import java.net.Socket;
+
+import javax.net.SocketFactory;
+
+import static com.smartdevicelink.util.NativeLogTool.logInfo;
+
+public class WiFiSocketFactory {
+    /**
+     * Creates a TCP socket which is bound to Wi-Fi network (for Android 5+)
+     *
+     * On Android 5 and later, this method returns a Socket which is always bound to a Wi-Fi
+     * network. If the phone is not connected to a Wi-Fi network, this method throws an IOException.
+     * Prior to Android 5, this method simply creates a Socket equivalent to "new Socket();".
+     *
+     * @return a Socket instance bound to Wi-Fi network.
+     */
+    public static Socket createSocket(Context context) throws IOException {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            SocketFactory factory = retrieveSocketFactory(context);
+            if (factory == null) {
+                logInfo("Cannot find Wi-Fi network, aborting socket creation.");
+                throw new IOException("The phone is not connected to Wi-Fi network");
+            }
+            return factory.createSocket();
+        } else {
+            return new Socket();
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private static SocketFactory retrieveSocketFactory(Context context) {
+        ConnectivityManager connMan = (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        // requires ACCESS_NETWORK_STATE permission
+        Network[] allNetworks = connMan.getAllNetworks();
+
+        for (Network network : allNetworks) {
+            // requires ACCESS_NETWORK_STATE permission
+            NetworkCapabilities capabilities = connMan.getNetworkCapabilities(network);
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+                return network.getSocketFactory();
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_android/issues/899

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.
This PR only affects `MultiplexTcpTransport` class.

### Testing Plan
Repeat the steps mentioned in my comment https://github.com/smartdevicelink/sdl_android/issues/899#issuecomment-428445159 and make sure that the library establishes a TCP connection to Core.

### Summary
This PR updates `MultiplexTcpTransport` to make sure it creates a `Socket` instance which is bound to Wi-Fi network.

### Changelog
##### Breaking Changes
* None.

##### Enhancements
* None.

##### Bug Fixes
* fixes `MultiplexTcpTransport` opening a TCP socket via mobile network when the head unit has no Internet connectivity over Wi-Fi network and the phone is associated with cellular network.

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)