### PR TITLE
Remove ScreenManager setDisplayLayout

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/ScreenManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/ScreenManager.java
@@ -322,12 +322,6 @@ public class ScreenManager extends BaseSubManager {
 		return softButtonManager.getSoftButtonObjectById(buttonId);
 	}
 
-	public void setDisplayLayout(PredefinedLayout layout){
-		SetDisplayLayout setDisplayLayoutRequest = new SetDisplayLayout();
-		setDisplayLayoutRequest.setDisplayLayout(layout.toString());
-		internalInterface.sendRPCRequest(setDisplayLayoutRequest);
-	}
-
 	/**
 	 * Begin a multiple updates transaction. The updates will be applied when commit() is called<br>
 	 * Note: if we don't use beginTransaction & commit, every update will be sent individually.


### PR DESCRIPTION
### Summary
This PR removes the `setDisplayLayout` method from `ScreenManager` to align with iOS and allow the developer to attach a listener to the RPC request.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)