### PR TITLE
Fix null issue in getService()

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -1057,6 +1057,9 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		{
 			myService = _appService;
 		}
+		else if(_appContext != null && _appContext instanceof Service){
+			myService = (Service)_appContext;
+		}
 		if (myService != null)
 		{
 			try

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -1048,31 +1048,19 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	
 	private Service getService()
 	{
-		Service myService = null;		
-		if (_proxyListener != null && _proxyListener instanceof Service)
-		{
-			myService = (Service) _proxyListener;				
-		}
-		else if (_appService != null)
-		{
-			myService = _appService;
-		}
-		else if(_appContext != null && _appContext instanceof Service){
-			myService = (Service)_appContext;
-		}
-		if (myService != null)
-		{
-			try
-			{
-				return myService;
+		try {
+			Service myService = null;
+			if (_proxyListener != null && _proxyListener instanceof Service) {
+				myService = (Service) _proxyListener;
+			} else if (_appService != null) {
+				myService = _appService;
+			} else if (_appContext != null && _appContext instanceof Service) {
+				myService = (Service) _appContext;
 			}
-			catch(Exception ex)
-			{
-				return null;
-			}
-			
+			return myService;
+		} catch (Exception ex){
+			return null;
 		}
-		return null;
 	}
 	
 	private void sendBroadcastIntent(Intent sendIntent)


### PR DESCRIPTION
Fixes #908

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
This PR fixes an issue in `SdlProxyBase.getService()`. It was always returning null if the new managers' layer is used.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)