### PR TITLE
add best practices link and review info to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-[Things to note: Pull Requests **must** fix an issue. Discussion about the feature / bug takes place in the issue, discussion of the implementation takes place in the PR. Please also see the [Contributing Guide](https://github.com/smartdevicelink/sdl_android/blob/master/.github/CONTRIBUTING.md) for information on branch naming and the CLA.
+[Things to note: Pull Requests **must** fix an issue. Discussion about the feature / bug takes place in the issue, discussion of the implementation takes place in the PR. Please also see the [Contributing Guide](https://github.com/smartdevicelink/sdl_android/blob/master/.github/CONTRIBUTING.md) for information on branch naming and the CLA, and the [SmartDeviceLink GitHub Best Practices](https://d83tozu1c8tt6.cloudfront.net/media/resources/SDL_GitHub_BestPractices.pdf) document for more information on how to enter a pull request.  Once this PR is ready for review, please request one from @joeygrover.
 
 Delete the above section when you've read it.]
 


### PR DESCRIPTION
Fixes #913 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Added SDL GitHub Best Practices link and review request information to pull_request_template.md, per issue #913 .

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)