### PR TITLE
Add support for Template Images in ScreenManager

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
@@ -29,7 +29,7 @@ public class SdlArtwork extends SdlFile {
      * Set whether this SdlArtwork is a template image whose coloring should be decided by the HMI
      * @param isTemplate boolean that tells whether this SdlArtwork is a template image
      */
-    public void setIsTemplate(@NonNull Boolean isTemplate){
+    public void setIsTemplate(boolean isTemplate){
         this.isTemplate = isTemplate;
     }
 
@@ -37,7 +37,7 @@ public class SdlArtwork extends SdlFile {
      * Get whether this SdlArtwork is a template image whose coloring should be decided by the HMI
      * @return boolean that tells whether this SdlArtwork is a template image
      */
-    public Boolean getIsTemplate(){
+    public boolean getIsTemplate(){
         return isTemplate;
     }
 

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
@@ -29,7 +29,7 @@ public class SdlArtwork extends SdlFile {
      * Set whether this SdlArtwork is a template image whose coloring should be decided by the HMI
      * @param isTemplate boolean that tells whether this SdlArtwork is a template image
      */
-    public void setIsTemplate(boolean isTemplate){
+    public void setTemplateImage(boolean isTemplate){
         this.isTemplate = isTemplate;
     }
 
@@ -37,7 +37,7 @@ public class SdlArtwork extends SdlFile {
      * Get whether this SdlArtwork is a template image whose coloring should be decided by the HMI
      * @return boolean that tells whether this SdlArtwork is a template image
      */
-    public boolean getIsTemplate(){
+    public boolean isTemplateImage(){
         return isTemplate;
     }
 

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
@@ -9,6 +9,8 @@ import com.smartdevicelink.proxy.rpc.enums.FileType;
  * A class that extends SdlFile, representing artwork (JPEG, PNG, or BMP) to be uploaded to core
  */
 public class SdlArtwork extends SdlFile {
+    private boolean isTemplate;
+
     public SdlArtwork(){}
 
     public SdlArtwork(@NonNull String fileName, @NonNull FileType fileType, int id, boolean persistentFile) {
@@ -21,6 +23,22 @@ public class SdlArtwork extends SdlFile {
 
     public SdlArtwork(@NonNull String fileName, @NonNull FileType fileType, byte[] data, boolean persistentFile) {
         super(fileName, fileType, data, persistentFile);
+    }
+
+    /**
+     * Set whether this SdlArtwork is a template image whose coloring should be decided by the HMI
+     * @param isTemplate boolean that tells whether this SdlArtwork is a template image
+     */
+    public void setIsTemplate(@NonNull Boolean isTemplate){
+        this.isTemplate = isTemplate;
+    }
+
+    /**
+     * Get whether this SdlArtwork is a template image whose coloring should be decided by the HMI
+     * @return boolean that tells whether this SdlArtwork is a template image
+     */
+    public Boolean getIsTemplate(){
+        return isTemplate;
     }
 
     @Override

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -54,7 +54,9 @@ public class SoftButtonState {
 
         // Set the SoftButton's image
         if (artwork != null) {
-            softButton.setImage(new Image(artwork.getName(), ImageType.DYNAMIC));
+            Image image = new Image(artwork.getName(), ImageType.DYNAMIC);
+            image.setIsTemplate(artwork.getIsTemplate());
+            softButton.setImage(image);
         }
 
         // Set the SoftButton's text

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -55,7 +55,7 @@ public class SoftButtonState {
         // Set the SoftButton's image
         if (artwork != null) {
             Image image = new Image(artwork.getName(), ImageType.DYNAMIC);
-            image.setIsTemplate(artwork.getIsTemplate());
+            image.setIsTemplate(artwork.isTemplateImage());
             softButton.setImage(image);
         }
 

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
@@ -315,13 +315,13 @@ class TextAndGraphicManager extends BaseSubManager {
 
 		if (shouldUpdatePrimaryImage()){
 			Image primaryImage = new Image(primaryGraphic.getName(), ImageType.DYNAMIC);
-			primaryImage.setIsTemplate(primaryGraphic.getIsTemplate());
+			primaryImage.setIsTemplate(primaryGraphic.isTemplateImage());
 			show.setGraphic(primaryImage);
 		}
 
 		if (shouldUpdateSecondaryImage()){
 			Image secondaryImage = new Image(secondaryGraphic.getName(), ImageType.DYNAMIC);
-			secondaryImage.setIsTemplate(secondaryGraphic.getIsTemplate());
+			secondaryImage.setIsTemplate(secondaryGraphic.isTemplateImage());
 			show.setSecondaryGraphic(secondaryImage);
 		}
 

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
@@ -314,16 +314,14 @@ class TextAndGraphicManager extends BaseSubManager {
 	private Show assembleShowImages(Show show){
 
 		if (shouldUpdatePrimaryImage()){
-			Image primaryImage = new Image();
-			primaryImage.setImageType(ImageType.DYNAMIC);
-			primaryImage.setValue(primaryGraphic.getName());
+			Image primaryImage = new Image(primaryGraphic.getName(), ImageType.DYNAMIC);
+			primaryImage.setIsTemplate(primaryGraphic.getIsTemplate());
 			show.setGraphic(primaryImage);
 		}
 
 		if (shouldUpdateSecondaryImage()){
-			Image secondaryImage = new Image();
-			secondaryImage.setImageType(ImageType.DYNAMIC);
-			secondaryImage.setValue(secondaryGraphic.getName());
+			Image secondaryImage = new Image(secondaryGraphic.getName(), ImageType.DYNAMIC);
+			secondaryImage.setIsTemplate(secondaryGraphic.getIsTemplate());
 			show.setSecondaryGraphic(secondaryImage);
 		}
 


### PR DESCRIPTION
Fixes #916 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
This PR adds a public method in `SdlArtwork` to set the `isTemplate` value. It also modifies `ScreenManager` to load the `isTemplate` value from `SdlArtwork` and set it in the corresponding `com.smartdevicelink.proxy.rpc.Image` instance before using the image.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)