### PR TITLE
Fix the problem where VirtualDisplayEncoder sends unexpected buffer

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/encoder/VirtualDisplayEncoder.java
@@ -219,6 +219,9 @@ public class VirtualDisplayEncoder {
                         try {
                             ByteBuffer encodedData = codec.getOutputBuffer(index);
                             if (encodedData != null) {
+                                if ((info.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+                                    info.size = 0;
+                                }
                                 if (info.size != 0) {
                                     byte[] dataToWrite;// = new byte[info.size];
                                     int dataOffset = 0;


### PR DESCRIPTION
Fix the problem where VirtualDisplayEncoder sends unexpected buffer, which includes PTS value zero.

Fixes #921 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
n/a

### Summary
This fixes the case where VDE sends unexpected buffer at startup.

### Changelog
##### Breaking Changes
* n/a

##### Enhancements
* n/a

##### Bug Fixes
* #921

### Tasks Remaining:
- n/a


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)