### PR TITLE
Hotfix 4.7.2

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-[Delete any non-applicable sections, but we may ask for more information.]
+[Delete any non-applicable sections, but we may ask for more information. Please reference the [SmartDeviceLink GitHub Best Practices](https://d83tozu1c8tt6.cloudfront.net/media/resources/SDL_GitHub_BestPractices.pdf) for further instructions on how to enter an issue.]
 
 ### Bug Report
 [Summary]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-[Things to note: Pull Requests **must** fix an issue. Discussion about the feature / bug takes place in the issue, discussion of the implementation takes place in the PR. Please also see the [Contributing Guide](https://github.com/smartdevicelink/sdl_android/blob/master/.github/CONTRIBUTING.md) for information on branch naming and the CLA.
+[Things to note: Pull Requests **must** fix an issue. Discussion about the feature / bug takes place in the issue, discussion of the implementation takes place in the PR. Please also see the [Contributing Guide](https://github.com/smartdevicelink/sdl_android/blob/master/.github/CONTRIBUTING.md) for information on branch naming and the CLA, and the [SmartDeviceLink GitHub Best Practices](https://d83tozu1c8tt6.cloudfront.net/media/resources/SDL_GitHub_BestPractices.pdf) document for more information on how to enter a pull request.  Once this PR is ready for review, please request one from @joeygrover.
 
 Delete the above section when you've read it.]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,82 +1,9 @@
-# 4.7.0 Release Notes
+# 4.7.2 Release Notes
 
-## Summary
+## Hot Fix
 
-- Manager APIs - The manager APIs will closely align with the iOS SDL Library managers, with a few exceptions to match the native platform. 
-- Transport layer overhaul - The protocol layer and transport layer have been overhauled to properly match the stack in which they should exist. This also sets up three additional features
-    - AOA multiplexing - SDL apps can now use the multiplexing transport with the AOA/USB transport. Multiple apps can then register on a single AOA connection to SDL Core.
-    - Primary/Secondary transports - apps can now carry their session over multiple transports with the first transport being primary, and a later connected one being a secondary. This means apps can register over bluetooth, then connect over WiFi when necessary (video/audio streaming).
-    - All apps should be using `MultiplexingConfig` at this point unless debugging with TCP.
-- Color Scheme for templates - App developers now have the ability to set color themes for the templates they use
-- New Remote Control modules
-- Additional vehicle data added
-- `SdlProxyALM` has been deprecated - The `SdlProxyALM` will still function for this release but it has now moved into maintenance mode and no new features will be added. The manager APIs should be used from this point forward.
-
-
-## New Features
-
-- [Add enum for `predefinedlayout`](https://github.com/smartdevicelink/sdl_android/pull/851)
-- [Feature/Listen for responses and capability changes in ISdl](https://github.com/smartdevicelink/sdl_android/pull/828)
-- [Add ability for RPCs to be versioned/formatted](https://github.com/smartdevicelink/sdl_android/pull/839)
-- [[SDL 0159] Static SDL Icon Names Enum](https://github.com/smartdevicelink/sdl_android/issues/740)
-
-#### Transport
-
-- [[SDL 0141] Supporting simultaneous multiple transports](https://github.com/smartdevicelink/sdl_android/issues/714)
-- [[SDL 0194] Android Transport Layer Overhaul](https://github.com/smartdevicelink/sdl_android/issues/841)
-
-#### Manager API
-
-- [[SDL 0171] Android Manager APIs](https://github.com/smartdevicelink/sdl_android/issues/782)
-- [[SDL 0113] SDLAudioStreamManager](https://github.com/smartdevicelink/sdl_android/issues/654)
-
-#### RPC Updates
-
-- [Add PLAY_PAUSE to ButtonName enum](https://github.com/smartdevicelink/sdl_android/issues/228)
-- [[SDL 0014] Adding Audio File Playback to TTSChunk](https://github.com/smartdevicelink/sdl_android/issues/419)
-- [[SDL 0037] Expand Mobile `PutFile` RPC](https://github.com/smartdevicelink/sdl_android/issues/452)
-- [[SDL 0041] Provide AppIcon resumption across app registration requests](https://github.com/smartdevicelink/sdl_android/issues/453)
-- [[SDL 0062] Template images](https://github.com/smartdevicelink/sdl_android/issues/533)
-- [[SDL 0064] Choice-VR optional](https://github.com/smartdevicelink/sdl_android/issues/739)
-- [[SDL 0063] Display name parameter](https://github.com/smartdevicelink/sdl_android/issues/534)
-- [[SDL 0163] Make spaceAvailable field non-mandatory ](https://github.com/smartdevicelink/sdl_android/issues/860)
-- [[SDL 0083] Expandable Design for Proprietary Data Exchange](https://github.com/smartdevicelink/sdl_android/issues/594)
-- [[SDL 0085] SubMenu Icon](https://github.com/smartdevicelink/sdl_android/issues/603)
-- [[SDL 0109] SetAudioStreamingIndicator RPC](https://github.com/smartdevicelink/sdl_android/issues/710)
-- [[SDL 0147] Template Improvements: Color Scheme](https://github.com/smartdevicelink/sdl_android/issues/715)
-- [[SDL 0150] Enhancing onHMIStatus with a New Parameter for Video Streaming State](https://github.com/smartdevicelink/sdl_android/issues/734)
-- [[SDL 0151] ImageFieldName for SecondaryImage](https://github.com/smartdevicelink/sdl_android/issues/724)
-- [[SDL 0153] Support for Short and Full UUID App ID](https://github.com/smartdevicelink/sdl_android/issues/738)
-
-#### Remote Control
-
-- [[SDL 0099] New modules LIGHT, AUDIO, HMI_SETTINGS and parameter SIS Data](https://github.com/smartdevicelink/sdl_android/issues/624)
-- [[SDL 0105] New Seat module](https://github.com/smartdevicelink/sdl_android/issues/651)
-- [[SDL 0106] OnRCStatus notification](https://github.com/smartdevicelink/sdl_android/issues/657)
-- [[SDL 0160] Radio Parameter Update](https://github.com/smartdevicelink/sdl_android/issues/741)
-- [[SDL 0165] Lights modules -  More Names and Status Values](https://github.com/smartdevicelink/sdl_android/issues/751)
-- [[SDL 0172] Update OnRCStatus with a new allowed parameter](https://github.com/smartdevicelink/sdl_android/issues/783)
-- [[SDL 0182] Audio Source AM/FM/XM/DAB](https://github.com/smartdevicelink/sdl_android/issues/809)
-
-#### Vehicle Data
-
-- [[SDL 0072] FuelRange](https://github.com/smartdevicelink/sdl_android/issues/552)
-- [[SDL 0082] EngineOilLife](https://github.com/smartdevicelink/sdl_android/issues/593)
-- [[SDL 0097] Tire pressure additions](https://github.com/smartdevicelink/sdl_android/issues/613)
-- [[SDL 0102] ElectronicParkBrakeStatus](https://github.com/smartdevicelink/sdl_android/issues/632)
-- [[SDL 0107] TurnSignal](https://github.com/smartdevicelink/sdl_android/issues/650)
-- [[SDL 0175] Updating DOP value range for GPS notification](https://github.com/smartdevicelink/sdl_android/issues/803)
-
-
-## Bug Fixes
-
-- [SystemCapabilityManager false positive issue](https://github.com/smartdevicelink/sdl_android/issues/844)
-- [Optimize video streaming for still graphics](https://github.com/smartdevicelink/sdl_android/issues/806)
-- [sdl.router.startservice broadcast is sent twice unexpectedly](https://github.com/smartdevicelink/sdl_android/issues/884)
-- [maxBitrate in VIDEO_STREAMING capability is read in wrong unit](https://github.com/smartdevicelink/sdl_android/issues/882)
-
-
-## Documentation
-
-- [Add third_party file](https://github.com/smartdevicelink/sdl_android/issues/865)
-
+- Fix legacy router service [issue #925](https://github.com/smartdevicelink/sdl_android/issues/925)
+    - Addressed issue in `TransportBroker` that caused previous router service's connection messages to be dropped. 
+    - Add logic to check router service version and perform appropriate logic.
+    - Added check if packet doesn't include a transport record
+    - Fixed a parcel issue in the `SdlPacket` class 

--- a/sdl_android/build.gradle
+++ b/sdl_android/build.gradle
@@ -5,8 +5,8 @@ android {
     defaultConfig {
         minSdkVersion 8
         targetSdkVersion 26
-        versionCode 9
-        versionName "4.7.1"
+        versionCode 10
+        versionName "4.7.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         resValue "string", "SDL_LIB_VERSION", '\"' + versionName + '\"'
     }

--- a/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 
 import com.livio.BSON.BsonEncoder;
 import com.smartdevicelink.protocol.enums.FrameType;
-import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.transport.utl.TransportRecord;
 
 import android.os.Parcel;
@@ -13,6 +12,7 @@ import android.os.Parcelable;
 
 public class SdlPacket implements Parcelable{
 
+	private static final int EXTRA_PARCEL_DATA_LENGTH 			= 24;
 	
 	public static final int HEADER_SIZE 						= 12;
 	public static final int HEADER_SIZE_V1 						= 8;//Backwards
@@ -62,7 +62,7 @@ public class SdlPacket implements Parcelable{
 	//Most others
 	public static final int FRAME_INFO_RESERVED 				= 0x00;
 
-	
+
 	int version;
 	boolean encryption;
 	int frameType;
@@ -340,7 +340,7 @@ public class SdlPacket implements Parcelable{
 
 		this.priorityCoefficient = p.readInt();
 
-		if(p.dataAvail() > 0) {
+		if(p.dataAvail() > EXTRA_PARCEL_DATA_LENGTH) {
 			messagingVersion = p.readInt();
 			if(messagingVersion >= 2) {
 				if (p.readInt() == 1) { //We should have a transport type attached

--- a/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlPacket.java
@@ -8,10 +8,23 @@ import com.smartdevicelink.protocol.enums.FrameType;
 import com.smartdevicelink.transport.utl.TransportRecord;
 
 import android.os.Parcel;
+import android.os.ParcelFormatException;
 import android.os.Parcelable;
 
+/**
+ * This class is only intended to be parcelable from the transport broker to the SDL Router Service.
+ * Any other binder transactions must include an additional int flag into their bundle or the parsing
+ * of this object will fail.
+ */
 public class SdlPacket implements Parcelable{
 
+	/**
+	 * This is the amount of bytes added to the bundle from the router service for a specific int
+	 * flag; this data will always and must be included. This flag is the
+	 * TransportConstants.BYTES_TO_SEND_FLAGS.
+	 *
+	 *	@see com.smartdevicelink.transport.TransportConstants#BYTES_TO_SEND_FLAGS
+	 */
 	private static final int EXTRA_PARCEL_DATA_LENGTH 			= 24;
 	
 	public static final int HEADER_SIZE 						= 12;
@@ -340,12 +353,16 @@ public class SdlPacket implements Parcelable{
 
 		this.priorityCoefficient = p.readInt();
 
-		if(p.dataAvail() > EXTRA_PARCEL_DATA_LENGTH) {
-			messagingVersion = p.readInt();
-			if(messagingVersion >= 2) {
-				if (p.readInt() == 1) { //We should have a transport type attached
-					this.transportRecord = p.readParcelable(TransportRecord.class.getClassLoader());
+		if(p.dataAvail() > EXTRA_PARCEL_DATA_LENGTH) {	//See note on constant for why not 0
+			try {
+				messagingVersion = p.readInt();
+				if (messagingVersion >= 2) {
+					if (p.readInt() == 1) { //We should have a transport type attached
+						this.transportRecord = p.readParcelable(TransportRecord.class.getClassLoader());
+					}
 				}
+			}catch (ParcelFormatException e){
+
 			}
 		}
 	}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -2037,10 +2037,16 @@ public class SdlRouterService extends Service{
 	    			if(packetSize < ByteArrayMessageSpliter.MAX_BINDER_SIZE){ //This is a small enough packet just send on through
 	    				//Log.w(TAG, " Packet size is just right " + packetSize  + " is smaller than " + ByteArrayMessageSpliter.MAX_BINDER_SIZE + " = " + (packetSize<ByteArrayMessageSpliter.MAX_BINDER_SIZE));
 		    			message.what = TransportConstants.ROUTER_RECEIVED_PACKET;
-		    			packet.setMessagingVersion(app.routerMessagingVersion);
+
+						// !!!! ADD ADDITIONAL ITEMS TO BUNDLE HERE !!!
+
+						packet.setMessagingVersion(app.routerMessagingVersion);
 		    			bundle.putParcelable(FORMED_PACKET_EXTRA_NAME, packet);
-	    				bundle.putInt(TransportConstants.BYTES_TO_SEND_FLAGS, TransportConstants.BYTES_TO_SEND_FLAG_NONE);
-		    			message.setData(bundle);
+						/* !!!!!! DO NOT ADD ANY ADDITIONAL ITEMS TO THE BUNDLE AFTER PACKET. ONLY BYTES_TO_SEND_FLAG !!!!!!!*/
+						bundle.putInt(TransportConstants.BYTES_TO_SEND_FLAGS, TransportConstants.BYTES_TO_SEND_FLAG_NONE);
+						/* !!!!!! DO NOT ADD ANY ADDITIONAL ITEMS TO THE BUNDLE AFTER PACKET. ONLY BYTES_TO_SEND_FLAG !!!!!!!*/
+
+	    				message.setData(bundle);
 		    			return sendPacketMessageToClient(app,message, version);
 	    			}else{
 	    				//Log.w(TAG, "Packet too big for IPC buffer. Breaking apart and then sending to client.");
@@ -2051,9 +2057,14 @@ public class SdlRouterService extends Service{
 	    													packet.getServiceType(),packet.getFrameInfo(), session,
 	    													(int)packet.getDataSize(),packet.getMessageId(),null);
 	    				message.what = TransportConstants.ROUTER_RECEIVED_PACKET;
-		    			bundle.putParcelable(FORMED_PACKET_EXTRA_NAME, copyPacket);
-		    			bundle.putInt(TransportConstants.BYTES_TO_SEND_FLAGS, TransportConstants.BYTES_TO_SEND_FLAG_SDL_PACKET_INCLUDED);
-		    			message.setData(bundle);
+						// !!!! ADD ADDITIONAL ITEMS TO BUNDLE HERE !!!
+
+						bundle.putParcelable(FORMED_PACKET_EXTRA_NAME, copyPacket);
+						/* !!!!!! DO NOT ADD ANY ADDITIONAL ITEMS TO THE BUNDLE AFTER PACKET. ONLY BYTES_TO_SEND_FLAG !!!!!!!*/
+						bundle.putInt(TransportConstants.BYTES_TO_SEND_FLAGS, TransportConstants.BYTES_TO_SEND_FLAG_SDL_PACKET_INCLUDED);
+						/* !!!!!! DO NOT ADD ANY ADDITIONAL ITEMS TO THE BUNDLE AFTER PACKET. ONLY BYTES_TO_SEND_FLAG !!!!!!!*/
+
+						message.setData(bundle);
 		    			//Log.d(TAG, "First packet before sending: " + message.getData().toString());
 		    			if(!sendPacketMessageToClient(app, message, version)){
 		    				Log.w(TAG, "Error sending first message of split packet to client " + app.appId);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
@@ -59,6 +59,7 @@ import com.smartdevicelink.transport.utl.TransportRecord;
 import java.lang.ref.WeakReference;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -73,6 +74,9 @@ public class TransportBroker {
      */
     private static final int MAX_MESSAGING_VERSION = 2;
     private static final int MIN_MESSAGING_VERSION = 1;
+
+    /** Version of the router service that supports the new additional transports (USB and TCP) */
+    private static final int RS_MULTI_TRANSPORT_SUPPORT = 8;
 
     private final String WHERE_TO_REPLY_PREFIX = "com.sdl.android.";
     private String appId = null;
@@ -217,20 +221,16 @@ public class TransportBroker {
                             // yay! we have been registered. Now what?
                             broker.registeredWithRouterService = true;
                             if (bundle != null) {
-                                if (bundle.containsKey(TransportConstants.HARDWARE_CONNECTED)) {
-                                    if (bundle.containsKey(TransportConstants.CONNECTED_DEVICE_STRING_EXTRA_NAME)) {
-                                        //Keep track if we actually get this
-                                    }
-                                    //broker.onHardwareConnected(TransportType.valueOf(bundle.getString(TransportConstants.HARDWARE_CONNECTED)));
-                                }
 
-                                if (bundle.containsKey(TransportConstants.CURRENT_HARDWARE_CONNECTED)) {
-                                    ArrayList<TransportRecord> transports = bundle.getParcelableArrayList(TransportConstants.CURRENT_HARDWARE_CONNECTED);
-                                    broker.onHardwareConnected(transports);
-                                }
                                 if (bundle.containsKey(TransportConstants.ROUTER_SERVICE_VERSION)) {
                                     broker.routerServiceVersion = bundle.getInt(TransportConstants.ROUTER_SERVICE_VERSION);
                                 }
+
+                                if (bundle.containsKey(TransportConstants.HARDWARE_CONNECTED) || bundle.containsKey(TransportConstants.CURRENT_HARDWARE_CONNECTED)) {
+                                    //A connection is already available
+                                    handleConnectionEvent(bundle, broker);
+                                }
+
                             }
                             break;
                         case TransportConstants.REGISTRATION_RESPONSE_DENIED_LEGACY_MODE_ENABLED:
@@ -330,12 +330,8 @@ public class TransportBroker {
                     }
 
                     if (bundle.containsKey(TransportConstants.HARDWARE_CONNECTED) || bundle.containsKey(TransportConstants.CURRENT_HARDWARE_CONNECTED)) {
-                        //broker.onHardwareConnected(TransportType.valueOf(bundle.getString(TransportConstants.HARDWARE_CONNECTED)));
-
-                        if (bundle.containsKey(TransportConstants.CURRENT_HARDWARE_CONNECTED)) {
-                            ArrayList<TransportRecord> transports = bundle.getParcelableArrayList(TransportConstants.CURRENT_HARDWARE_CONNECTED);
-                            broker.onHardwareConnected(transports);
-                        }
+                        //This is a connection event
+                        handleConnectionEvent(bundle,broker);
                         break;
                     }
                     break;
@@ -344,6 +340,45 @@ public class TransportBroker {
             }
 
         }
+
+        /**
+         * Handle a potential connection event. This will adapt legacy router service implementaions
+         * into the new multiple transport scheme.
+         * @param bundle the received bundle from the router service
+         * @param broker reference to the transport broker that this handler exists
+         * @return if a connection event was triggered in the supplied broker
+         */
+        private boolean handleConnectionEvent(Bundle bundle, TransportBroker broker){
+            if (broker.routerServiceVersion < RS_MULTI_TRANSPORT_SUPPORT) {
+                //Previous versions of the router service only supports a single
+                //transport, so this will be the only extra received
+                if (bundle.containsKey(TransportConstants.HARDWARE_CONNECTED)) {
+                    String transportName = "";
+                    if (bundle.containsKey(TransportConstants.CONNECTED_DEVICE_STRING_EXTRA_NAME)) {
+                        //Keep track if we actually get this
+                        transportName = bundle.getString(TransportConstants.CONNECTED_DEVICE_STRING_EXTRA_NAME);
+                    }
+                    TransportType transportType = TransportType.valueOf(bundle.getString(TransportConstants.HARDWARE_CONNECTED));
+                    if(transportType == null){
+                        transportType = TransportType.BLUETOOTH;
+                    }
+                    TransportRecord record = new TransportRecord(transportType,transportName);
+
+                    broker.onHardwareConnected(Collections.singletonList(record));
+                    return true;
+                }
+            } else{
+                //Router service supports multiple transport
+
+                if (bundle.containsKey(TransportConstants.CURRENT_HARDWARE_CONNECTED)) {
+                    ArrayList<TransportRecord> transports = bundle.getParcelableArrayList(TransportConstants.CURRENT_HARDWARE_CONNECTED);
+                    broker.onHardwareConnected(transports);
+                    return true;
+                }
+            }
+            return false;
+        }
+
     }
 
 

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
@@ -266,10 +266,18 @@ public class TransportBroker {
                     int flags = bundle.getInt(TransportConstants.BYTES_TO_SEND_FLAGS, TransportConstants.BYTES_TO_SEND_FLAG_NONE);
 
                     if (bundle.containsKey(TransportConstants.FORMED_PACKET_EXTRA_NAME)) {
-                        Parcelable packet = bundle.getParcelable(TransportConstants.FORMED_PACKET_EXTRA_NAME);
+                        SdlPacket packet = bundle.getParcelable(TransportConstants.FORMED_PACKET_EXTRA_NAME);
 
                         if (flags == TransportConstants.BYTES_TO_SEND_FLAG_NONE) {
                             if (packet != null) { //Log.i(TAG, "received packet to process "+  packet.toString());
+
+                                if(packet.getTransportRecord() == null){
+                                    // If the transport record is null, one must be added
+                                    // This is likely due to an older router service being used
+                                    // in which only a bluetooth transport is available
+                                    packet.setTransportRecord(new TransportRecord(TransportType.BLUETOOTH,""));
+                                }
+
                                 broker.onPacketReceived(packet);
                             } else {
                                 Log.w(TAG, "Received null packet from router service, not passing along");


### PR DESCRIPTION
Fixes #925

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Create an app  (App A) with library version 4.6.3 or lower
- Create second app (App B) with library version 4.7.0 or newer, but do not include router service
- Ensure that App B connects to App A


### Summary

Hotfix is to enable apps to connect to legacy router services. While the scenario should never happen, some OEMs have implemented companion apps that will take a while to implement new versions of the library therefore the library should be able to handle that situation.

- Addressed issue in TransportBroker that caused previous router service's connection messages to be dropped. Add logic to check router service version and perform appropriate logic.
- Added check if packet doesn't include a transport record
- Fixed a parcel issue in the `SdlPacket` class

### Changelog

##### Bug Fixes
* #925

##### Tasks

[x] Find out why Android attaches 24 bytes the parcel object after being sent over the binder

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)