### PR TITLE
issue #928 patch for adding Vehicle Type support

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -33,6 +33,7 @@ import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
 import com.smartdevicelink.proxy.rpc.SetAppIcon;
 import com.smartdevicelink.proxy.rpc.TTSChunk;
 import com.smartdevicelink.proxy.rpc.TemplateColorScheme;
+import com.smartdevicelink.proxy.rpc.VehicleType;
 import com.smartdevicelink.proxy.rpc.enums.AppHMIType;
 import com.smartdevicelink.proxy.rpc.enums.Language;
 import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
@@ -744,6 +745,16 @@ public class SdlManager{
 			}
 		}
 	}
+
+	public VehicleType getVehicleType() {
+        VehicleType vt = new VehicleType();
+        try {
+            vt = proxy.getVehicleType();
+        }catch (SdlException e){
+            handleSdlException(e);
+        }
+        return vt;
+    }
 
 	protected void setProxy(SdlProxyBase proxy){
 		this.proxy = proxy;

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -7378,6 +7378,23 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		return _iconResumed;
 	}
 
+	/**
+	 * Get VehileType Info
+	 * @return VehicleType
+	 * @throws SdlException
+	 */
+	public VehicleType getVehicleType() throws SdlException{
+		// Test if proxy has been disposed
+		if (_proxyDisposed) {
+			throw new SdlException("This object has been disposed, it is no long capable of executing methods.", SdlExceptionCause.SDL_PROXY_DISPOSED);
+		}
+
+		// Test SDL availability
+		if (!_appInterfaceRegisterd) {
+			throw new SdlException("SDL is not connected. Unable to determine if app icon was resumed.", SdlExceptionCause.SDL_UNAVAILABLE);
+		}
+		return _vehicleType;
+	}
 
 	/**
 	 * VideoStreamingManager houses all the elements needed to create a scoped, streaming manager for video projection. It is only a private, instance


### PR DESCRIPTION
Fixes #928 Patch to provide VehicleType information

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes for SDLManager.

### Testing Plan
NA

### Summary
Added API in SDLManager to retrieve VehicleType information from Proxy Base.

### Changelog
##### Breaking Changes
* [NA]

##### Enhancements
* Method in Proxy Base to retrieve Vehicle Type
* Method in SDL Manager to retrieve Vehicle Type

##### Bug Fixes
* #928 

### Tasks Remaining:
- [ ] Unit tests

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
