### PR TITLE
usb enhacements

### DIFF
--- a/hello_sdl_android/src/main/AndroidManifest.xml
+++ b/hello_sdl_android/src/main/AndroidManifest.xml
@@ -29,8 +29,7 @@
         </activity>
 
         <activity android:name="com.smartdevicelink.transport.USBAccessoryAttachmentActivity"
-                  android:launchMode="singleTop"
-                  android:process="com.smartdevicelink.router">
+                  android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED" />
             </intent-filter>

--- a/hello_sdl_android/src/main/AndroidManifest.xml
+++ b/hello_sdl_android/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
         </activity>
 
         <activity android:name="com.smartdevicelink.transport.USBAccessoryAttachmentActivity"
-                  android:launchMode="singleTop">
+                  android:launchMode="singleTop"
+                  android:process="com.smartdevicelink.router">
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED" />
             </intent-filter>

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexUsbTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexUsbTransport.java
@@ -100,7 +100,9 @@ public class MultiplexUsbTransport extends MultiplexBaseTransport{
         setState(STATE_CONNECTING);
         FileDescriptor fileDescriptor = parcelFileDescriptor.getFileDescriptor();
         readerThread = new ReaderThread(fileDescriptor);
+        readerThread.setDaemon(true);
         writerThread = new WriterThread(fileDescriptor);
+        writerThread.setDaemon(true);
 
         readerThread.start();
         writerThread.start();

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexUsbTransport.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexUsbTransport.java
@@ -199,7 +199,7 @@ public class MultiplexUsbTransport extends MultiplexBaseTransport{
         @Override
         public void run() {             //FIXME probably check to see what the BT does
             super.run();
-            final int READ_BUFFER_SIZE = 4096;
+            final int READ_BUFFER_SIZE = 16384;
             byte[] buffer = new byte[READ_BUFFER_SIZE];
             int bytesRead;
             boolean stateProgress;

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -3383,6 +3383,7 @@ public class SdlRouterService extends Service{
 
 		public PacketWriteTaskMaster(){
 			this.setName("PacketWriteTaskMaster");
+			this.setDaemon(true);
 		}
 		protected void setTransportType(TransportType transportType){
 			this.transportType = transportType;

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1403,7 +1403,8 @@ public class SdlRouterService extends Service{
 		PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, intent, 0);
 		builder.setContentIntent(pendingIntent);
 
-        if(chronometerLength > 0) {
+        if(chronometerLength > 0 && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        	//The countdown method is only available in SDKs >= 24
         	builder.setWhen(chronometerLength + System.currentTimeMillis());
         	builder.setUsesChronometer(true);
         	builder.setChronometerCountDown(true);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
@@ -98,7 +98,6 @@ public class USBAccessoryAttachmentActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        checkUsbAccessoryIntent("Create");
     }
 
     @Override
@@ -107,7 +106,16 @@ public class USBAccessoryAttachmentActivity extends Activity {
         checkUsbAccessoryIntent("Resume");
     }
 
-    private void checkUsbAccessoryIntent(String sourceAction) {
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        this.setIntent(intent);
+    }
+
+    private synchronized void checkUsbAccessoryIntent(String sourceAction) {
+        if(usbAccessory != null){
+            return;
+        }
         final Intent intent = getIntent();
         String action = intent.getAction();
         Log.d(TAG, sourceAction + " with action: " + action);

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
@@ -126,8 +126,16 @@ public class USBAccessoryAttachmentActivity extends Activity {
 
             wakeUpRouterService(getApplicationContext());
 
+        }else{
+            finish();
         }
+    }
 
+    @Override
+    protected void onDestroy() {
+        usbAccessory = null;
+        permissionGranted = null;
+        super.onDestroy();
     }
 
     @SuppressWarnings("deprecation")

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
@@ -107,7 +107,7 @@ public class UsbTransferProvider {
             throw new IllegalStateException("Supplied params are not correct. Context == null? "+ (context==null) + " ComponentName == null? " + (service == null) + " Usb Accessory == null? " + usbAccessory);
         }
         usbPfd = getFileDescriptor(usbAccessory, context);
-        if(usbPfd != null){
+        if(usbPfd != null && usbPfd.getFileDescriptor() != null && usbPfd.getFileDescriptor().valid()){
             this.context = context;
             this.routerService = service;
             this.callback = callback;

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
@@ -40,6 +40,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.hardware.usb.UsbAccessory;
 import android.hardware.usb.UsbManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
@@ -51,6 +52,8 @@ import android.os.RemoteException;
 import android.util.Log;
 
 import com.smartdevicelink.util.AndroidTools;
+
+import java.io.IOException;
 import java.lang.ref.WeakReference;
 
 @TargetApi(12)
@@ -188,11 +191,19 @@ public class UsbTransferProvider {
     }
 
     private void finish(){
+       try {
+            usbPfd.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        usbPfd = null;
+        unBindFromService();
+        routerServiceMessenger =null;
+        context = null;
+        System.gc();
         if(callback != null){
             callback.onUsbTransferUpdate(true);
         }
-        unBindFromService();
-        routerServiceMessenger =null;
     }
 
     static class ClientHandler extends Handler {

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
@@ -103,12 +103,13 @@ public class UsbTransferProvider {
         if(context == null || service == null || usbAccessory == null){
             throw new IllegalStateException("Supplied params are not correct. Context == null? "+ (context==null) + " ComponentName == null? " + (service == null) + " Usb Accessory == null? " + usbAccessory);
         }
-        this.context = context;
-        this.routerService = service;
-        this.callback = callback;
-        this.clientMessenger = new Messenger(new ClientHandler(this));
         usbPfd = getFileDescriptor(usbAccessory);
         if(usbPfd != null){
+            this.context = context;
+            this.routerService = service;
+            this.callback = callback;
+            this.clientMessenger = new Messenger(new ClientHandler(this));
+
             usbInfoBundle = new Bundle();
             usbInfoBundle.putString(MultiplexUsbTransport.MANUFACTURER, usbAccessory.getManufacturer());
             usbInfoBundle.putString(MultiplexUsbTransport.MODEL, usbAccessory.getModel());
@@ -119,6 +120,7 @@ public class UsbTransferProvider {
             checkIsConnected();
         }else{
             Log.e(TAG, "Unable to open accessory");
+            clientMessenger = null;
             if(callback != null){
                 callback.onUsbTransferUpdate(false);
             }

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
@@ -117,6 +117,11 @@ public class UsbTransferProvider {
             usbInfoBundle.putString(MultiplexUsbTransport.SERIAL, usbAccessory.getSerial());
             usbInfoBundle.putString(MultiplexUsbTransport.DESCRIPTION, usbAccessory.getDescription());
             checkIsConnected();
+        }else{
+            Log.e(TAG, "Unable to open accessory");
+            if(callback != null){
+                callback.onUsbTransferUpdate(false);
+            }
         }
 
     }

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/UsbTransferProvider.java
@@ -103,7 +103,7 @@ public class UsbTransferProvider {
         if(context == null || service == null || usbAccessory == null){
             throw new IllegalStateException("Supplied params are not correct. Context == null? "+ (context==null) + " ComponentName == null? " + (service == null) + " Usb Accessory == null? " + usbAccessory);
         }
-        usbPfd = getFileDescriptor(usbAccessory);
+        usbPfd = getFileDescriptor(usbAccessory, context);
         if(usbPfd != null){
             this.context = context;
             this.routerService = service;
@@ -129,7 +129,7 @@ public class UsbTransferProvider {
     }
 
     @SuppressLint("NewApi")
-    private ParcelFileDescriptor getFileDescriptor(UsbAccessory accessory) {
+    private ParcelFileDescriptor getFileDescriptor(UsbAccessory accessory, Context context) {
         try {
             UsbManager manager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
 

--- a/sdl_android/src/main/res/values/sdl.xml
+++ b/sdl_android/src/main/res/values/sdl.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="sdl_router_service_version_name" translatable="false">sdl_router_version</string>
 
-    <integer name="sdl_router_service_version_value">8</integer>
+    <integer name="sdl_router_service_version_value">9</integer>
 
     <string name="sdl_router_service_is_custom_name" translatable="false">sdl_custom_router</string>
 </resources>


### PR DESCRIPTION
(Attempting to) Fixes #924 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan

For the most effective testing a few items should be noted
1. Should be tested on a variety of devices and OS levels as this issue has different behavior between them
2. One app should be installed (included hello sdl app) that is chosen to accept the USB attachment intent. A second app should be installed that does not have the USB attachment activity in its manifest and it's SdlRouterService version upped past the hello sdl's version so that it can be guaranteed the second app is hosting the router service.



### Summary
- Made the USB read buffer the max AOA size
- Refactored some items for optimization
- ~Moved the sampel app's UsbAttatchementAcitity into the SdlRouterService process~
    - An easier fix was to close the ParcelFileDescriptor in the `UsbAttatchementAcitity` after it had been transferred to the router service.
- Fixed an issue where the router service's registered apps were not having their registered transports  properly tracked.
- Refactored transport disconnect to ensure transports were actually set to null after disconnection


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
