### PR TITLE
Expose RAI response and move SdlManager.Builder

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -276,204 +276,6 @@ public class SdlManager{
 		}
 	}
 
-	// BUILDER
-	public static class Builder {
-		SdlManager sdlManager;
-
-		/**
-		 * Builder for the SdlManager. Parameters in the constructor are required.
-		 * @param context the current context
-		 * @param appId the app's ID
-		 * @param appName the app's name
-		 * @param listener a SdlManagerListener object
-		 */
-		public Builder(@NonNull Context context, @NonNull final String appId, @NonNull final String appName, @NonNull final SdlManagerListener listener){
-			sdlManager = new SdlManager();
-			setContext(context);
-			setAppId(appId);
-			setAppName(appName);
-			setManagerListener(listener);
-		}
-
-		/**
-		 * Sets the App ID
-		 * @param appId
-		 */
-		public Builder setAppId(@NonNull final String appId){
-			sdlManager.appId = appId;
-			return this;
-		}
-
-		/**
-		 * Sets the Application Name
-		 * @param appName
-		 */
-		public Builder setAppName(@NonNull final String appName){
-			sdlManager.appName = appName;
-			return this;
-		}
-
-		/**
-		 * Sets the Short Application Name
-		 * @param shortAppName
-		 */
-		public Builder setShortAppName(final String shortAppName) {
-			sdlManager.shortAppName = shortAppName;
-			return this;
-		}
-
-		/**
-		 * Sets the Language of the App
-		 * @param hmiLanguage
-		 */
-		public Builder setLanguage(final Language hmiLanguage){
-			sdlManager.hmiLanguage = hmiLanguage;
-			return this;
-		}
-
-		/**
-		 * Sets the TemplateColorScheme for daytime
-		 * @param dayColorScheme
-		 */
-		public Builder setDayColorScheme(final TemplateColorScheme dayColorScheme){
-			sdlManager.dayColorScheme = dayColorScheme;
-			return this;
-		}
-
-		/**
-		 * Sets the TemplateColorScheme for nighttime
-		 * @param nightColorScheme
-		 */
-		public Builder setNightColorScheme(final TemplateColorScheme nightColorScheme){
-			sdlManager.nightColorScheme = nightColorScheme;
-			return this;
-		}
-
-		/**
-		 * Sets the LockScreenConfig for the session. <br>
-		 * <strong>Note: If not set, the default configuration will be used.</strong>
-		 * @param lockScreenConfig - configuration options
-		 */
-		public Builder setLockScreenConfig (final LockScreenConfig lockScreenConfig){
-			sdlManager.lockScreenConfig = lockScreenConfig;
-			return this;
-		}
-
-        /**
-         * Sets the icon for the app on HU <br>
-         * @param sdlArtwork
-         */
-        public Builder setAppIcon(final SdlArtwork sdlArtwork){
-			sdlManager.appIcon = sdlArtwork;
-            return this;
-        }
-
-		/**
-		 * Sets the vector of AppHMIType <br>
-		 * <strong>Note: This should be an ordered list from most -> least relevant</strong>
-		 * @param hmiTypes
-		 */
-		public Builder setAppTypes(final Vector<AppHMIType> hmiTypes){
-
-			sdlManager.hmiTypes = hmiTypes;
-
-			if (hmiTypes != null) {
-				sdlManager.isMediaApp = hmiTypes.contains(AppHMIType.MEDIA);
-			}
-
-			return this;
-		}
-
-		/**
-		 * Sets the vector of vrSynonyms
-		 * @param vrSynonyms
-		 */
-		public Builder setVrSynonyms(final Vector<String> vrSynonyms) {
-			sdlManager.vrSynonyms = vrSynonyms;
-			return this;
-		}
-
-		/**
-		 * Sets the TTS Name
-		 * @param ttsChunks
-		 */
-		public Builder setTtsName(final Vector<TTSChunk> ttsChunks) {
-			sdlManager.ttsChunks = ttsChunks;
-			return this;
-		}
-
-		/**
-		 * This Object type may change with the transport refactor
-		 * Sets the BaseTransportConfig
-		 * @param transport
-		 */
-		public Builder setTransportType(BaseTransportConfig transport){
-			sdlManager.transport = transport;
-			return this;
-		}
-
-		/**
-		 * Sets the Context
-		 * @param context
-		 */
-		public Builder setContext(Context context){
-			sdlManager.context = context;
-			return this;
-		}
-
-		/**
-		 * Sets the Security library
-		 * @param secList The list of security class(es)
-		 */
-		public Builder setSdlSecurity(List<Class<? extends SdlSecurityBase>> secList) {
-			sdlManager.sdlSecList = secList;
-			return this;
-		}
-
-		/**
-		 * Set the SdlManager Listener
-		 * @param listener the listener
-		 */
-		public Builder setManagerListener(@NonNull final SdlManagerListener listener){
-			sdlManager.managerListener = listener;
-			return this;
-		}
-
-		public SdlManager build() {
-
-			if (sdlManager.appName == null) {
-				throw new IllegalArgumentException("You must specify an app name by calling setAppName");
-			}
-
-			if (sdlManager.appId == null) {
-				throw new IllegalArgumentException("You must specify an app ID by calling setAppId");
-			}
-
-			if (sdlManager.managerListener == null) {
-				throw new IllegalArgumentException("You must set a SdlManagerListener object");
-			}
-
-			if (sdlManager.hmiTypes == null) {
-				Vector<AppHMIType> hmiTypesDefault = new Vector<>();
-				hmiTypesDefault.add(AppHMIType.DEFAULT);
-				sdlManager.hmiTypes = hmiTypesDefault;
-				sdlManager.isMediaApp = false;
-			}
-
-			if (sdlManager.lockScreenConfig == null){
-				// if lock screen params are not set, use default
-				sdlManager.lockScreenConfig = new LockScreenConfig();
-			}
-
-			if (sdlManager.hmiLanguage == null){
-				sdlManager.hmiLanguage = Language.EN_US;
-			}
-
-			sdlManager.transitionToState(BaseSubManager.SETTING_UP);
-
-			return sdlManager;
-		}
-	}
 
 	private void checkSdlManagerState(){
 		if (getState() != BaseSubManager.READY && getState() != BaseSubManager.LIMITED){
@@ -924,4 +726,204 @@ public class SdlManager{
 		}
 
 	};
+
+
+	// BUILDER
+	public static class Builder {
+		SdlManager sdlManager;
+
+		/**
+		 * Builder for the SdlManager. Parameters in the constructor are required.
+		 * @param context the current context
+		 * @param appId the app's ID
+		 * @param appName the app's name
+		 * @param listener a SdlManagerListener object
+		 */
+		public Builder(@NonNull Context context, @NonNull final String appId, @NonNull final String appName, @NonNull final SdlManagerListener listener){
+			sdlManager = new SdlManager();
+			setContext(context);
+			setAppId(appId);
+			setAppName(appName);
+			setManagerListener(listener);
+		}
+
+		/**
+		 * Sets the App ID
+		 * @param appId
+		 */
+		public Builder setAppId(@NonNull final String appId){
+			sdlManager.appId = appId;
+			return this;
+		}
+
+		/**
+		 * Sets the Application Name
+		 * @param appName
+		 */
+		public Builder setAppName(@NonNull final String appName){
+			sdlManager.appName = appName;
+			return this;
+		}
+
+		/**
+		 * Sets the Short Application Name
+		 * @param shortAppName
+		 */
+		public Builder setShortAppName(final String shortAppName) {
+			sdlManager.shortAppName = shortAppName;
+			return this;
+		}
+
+		/**
+		 * Sets the Language of the App
+		 * @param hmiLanguage
+		 */
+		public Builder setLanguage(final Language hmiLanguage){
+			sdlManager.hmiLanguage = hmiLanguage;
+			return this;
+		}
+
+		/**
+		 * Sets the TemplateColorScheme for daytime
+		 * @param dayColorScheme
+		 */
+		public Builder setDayColorScheme(final TemplateColorScheme dayColorScheme){
+			sdlManager.dayColorScheme = dayColorScheme;
+			return this;
+		}
+
+		/**
+		 * Sets the TemplateColorScheme for nighttime
+		 * @param nightColorScheme
+		 */
+		public Builder setNightColorScheme(final TemplateColorScheme nightColorScheme){
+			sdlManager.nightColorScheme = nightColorScheme;
+			return this;
+		}
+
+		/**
+		 * Sets the LockScreenConfig for the session. <br>
+		 * <strong>Note: If not set, the default configuration will be used.</strong>
+		 * @param lockScreenConfig - configuration options
+		 */
+		public Builder setLockScreenConfig (final LockScreenConfig lockScreenConfig){
+			sdlManager.lockScreenConfig = lockScreenConfig;
+			return this;
+		}
+
+		/**
+		 * Sets the icon for the app on HU <br>
+		 * @param sdlArtwork
+		 */
+		public Builder setAppIcon(final SdlArtwork sdlArtwork){
+			sdlManager.appIcon = sdlArtwork;
+			return this;
+		}
+
+		/**
+		 * Sets the vector of AppHMIType <br>
+		 * <strong>Note: This should be an ordered list from most -> least relevant</strong>
+		 * @param hmiTypes
+		 */
+		public Builder setAppTypes(final Vector<AppHMIType> hmiTypes){
+
+			sdlManager.hmiTypes = hmiTypes;
+
+			if (hmiTypes != null) {
+				sdlManager.isMediaApp = hmiTypes.contains(AppHMIType.MEDIA);
+			}
+
+			return this;
+		}
+
+		/**
+		 * Sets the vector of vrSynonyms
+		 * @param vrSynonyms
+		 */
+		public Builder setVrSynonyms(final Vector<String> vrSynonyms) {
+			sdlManager.vrSynonyms = vrSynonyms;
+			return this;
+		}
+
+		/**
+		 * Sets the TTS Name
+		 * @param ttsChunks
+		 */
+		public Builder setTtsName(final Vector<TTSChunk> ttsChunks) {
+			sdlManager.ttsChunks = ttsChunks;
+			return this;
+		}
+
+		/**
+		 * This Object type may change with the transport refactor
+		 * Sets the BaseTransportConfig
+		 * @param transport
+		 */
+		public Builder setTransportType(BaseTransportConfig transport){
+			sdlManager.transport = transport;
+			return this;
+		}
+
+		/**
+		 * Sets the Context
+		 * @param context
+		 */
+		public Builder setContext(Context context){
+			sdlManager.context = context;
+			return this;
+		}
+
+		/**
+		 * Sets the Security library
+		 * @param secList The list of security class(es)
+		 */
+		public Builder setSdlSecurity(List<Class<? extends SdlSecurityBase>> secList) {
+			sdlManager.sdlSecList = secList;
+			return this;
+		}
+
+		/**
+		 * Set the SdlManager Listener
+		 * @param listener the listener
+		 */
+		public Builder setManagerListener(@NonNull final SdlManagerListener listener){
+			sdlManager.managerListener = listener;
+			return this;
+		}
+
+		public SdlManager build() {
+
+			if (sdlManager.appName == null) {
+				throw new IllegalArgumentException("You must specify an app name by calling setAppName");
+			}
+
+			if (sdlManager.appId == null) {
+				throw new IllegalArgumentException("You must specify an app ID by calling setAppId");
+			}
+
+			if (sdlManager.managerListener == null) {
+				throw new IllegalArgumentException("You must set a SdlManagerListener object");
+			}
+
+			if (sdlManager.hmiTypes == null) {
+				Vector<AppHMIType> hmiTypesDefault = new Vector<>();
+				hmiTypesDefault.add(AppHMIType.DEFAULT);
+				sdlManager.hmiTypes = hmiTypesDefault;
+				sdlManager.isMediaApp = false;
+			}
+
+			if (sdlManager.lockScreenConfig == null){
+				// if lock screen params are not set, use default
+				sdlManager.lockScreenConfig = new LockScreenConfig();
+			}
+
+			if (sdlManager.hmiLanguage == null){
+				sdlManager.hmiLanguage = Language.EN_US;
+			}
+
+			sdlManager.transitionToState(BaseSubManager.SETTING_UP);
+
+			return sdlManager;
+		}
+	}
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -29,6 +29,7 @@ import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.interfaces.ISdlServiceListener;
 import com.smartdevicelink.proxy.interfaces.IVideoStreamListener;
 import com.smartdevicelink.proxy.interfaces.OnSystemCapabilityListener;
+import com.smartdevicelink.proxy.rpc.RegisterAppInterfaceResponse;
 import com.smartdevicelink.proxy.rpc.SdlMsgVersion;
 import com.smartdevicelink.proxy.rpc.SetAppIcon;
 import com.smartdevicelink.proxy.rpc.TTSChunk;
@@ -372,6 +373,21 @@ public class SdlManager{
 	 */
 	public SystemCapabilityManager getSystemCapabilityManager(){
 		return proxy.getSystemCapabilityManager();
+	}
+
+	/**
+	 * Method to retrieve the RegisterAppInterface Response message that was sent back from the
+	 * module. It contains various attributes about the connected module and can be used to adapt
+	 * to different module types and their supported features.
+	 *
+	 * @return RegisterAppInterfaceResponse received from the module or null if the app has not yet
+	 * registered with the module.
+	 */
+	public RegisterAppInterfaceResponse getRegisterAppInterfaceResponse(){
+		if(proxy != null){
+			return proxy.getRegisterAppInterfaceResponse();
+		}
+		return null;
 	}
 
 	// PROTECTED GETTERS

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -244,6 +244,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	protected List<Class<? extends SdlSecurityBase>> _secList = null;
 	protected SystemCapabilityManager _systemCapabilityManager;
 	protected Boolean _iconResumed = false;
+	protected RegisterAppInterfaceResponse raiResponse = null;
 	
 	private final CopyOnWriteArrayList<IPutFileResponseListener> _putFileListenerList = new CopyOnWriteArrayList<IPutFileResponseListener>();
 
@@ -2169,6 +2170,8 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	private void processRaiResponse(RegisterAppInterfaceResponse rai)
 	{
 		if (rai == null) return;
+
+		this.raiResponse = rai;
 		
 		VehicleType vt = rai.getVehicleType();
 		if (vt == null) return;
@@ -7376,6 +7379,18 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			throw new SdlException("SDL is not connected. Unable to determine if app icon was resumed.", SdlExceptionCause.SDL_UNAVAILABLE);
 		}
 		return _iconResumed;
+	}
+
+	/**
+	 * Method to retrieve the RegisterAppInterface Response message that was sent back from the
+	 * module. It contains various attributes about the connected module and can be used to adapt
+	 * to different module types and their supported features.
+	 *
+	 * @return RegisterAppInterfaceResponse received from the module or null if the app has not yet
+	 * registered with the module.
+	 */
+	public RegisterAppInterfaceResponse getRegisterAppInterfaceResponse(){
+		return this.raiResponse;
 	}
 
 


### PR DESCRIPTION
Fixes #928 

This PR is **ready** for review.

### Risk
This PR makes ** minor** API changes.

### Testing Plan
 - Connect with Core
- Use new method to retrieve register app interface

### Summary
- Moved the `SdlManager.Builder` class to end of file
- Added public method to retrieve the RegisterAppInterface Response in it's entirety.

### Changelog
##### Enhancements
* Developers should have access to all information that comes back through the RAI response similar to the iOS library.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
