### PR TITLE
Start ScreenManager’s submanagers in start() method

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/ScreenManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/ScreenManager.java
@@ -64,14 +64,14 @@ public class ScreenManager extends BaseSubManager {
 	@Override
 	public void start(CompletionListener listener) {
 		super.start(listener);
+		this.softButtonManager.start(subManagerListener);
+		this.textAndGraphicManager.start(subManagerListener);
 	}
 
 	private void initialize(){
 		if (fileManager.get() != null) {
 			this.softButtonManager = new SoftButtonManager(internalInterface, fileManager.get());
 			this.textAndGraphicManager = new TextAndGraphicManager(internalInterface, fileManager.get(), softButtonManager);
-			this.softButtonManager.start(subManagerListener);
-			this.textAndGraphicManager.start(subManagerListener);
 		}
 	}
 


### PR DESCRIPTION
Fixes #937 

This PR is **not ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Use `ScreenManager` and make sure that it can set texts/graphics/softbuttons correctly.

### Summary
This PR moves `ScreenManager`'s submanagers starting logic from `initialize()` to `ScreenManager.start()` to prevent potential issues in starting `SdlManager` as described in #937 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
