### PR TITLE
fix: Router service doesn't support HashID for V5 protocol

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlPacketFactory.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlPacketFactory.java
@@ -1,7 +1,9 @@
 package com.smartdevicelink.protocol;
 
+import com.smartdevicelink.protocol.enums.ControlFrameTags;
 import com.smartdevicelink.protocol.enums.FrameDataControlFrameType;
 import com.smartdevicelink.protocol.enums.SessionType;
+import com.smartdevicelink.util.BitConverter;
 
 public class SdlPacketFactory {
 
@@ -51,6 +53,21 @@ public class SdlPacketFactory {
 		return new SdlPacket(version,false,SdlPacket.FRAME_TYPE_CONTROL,
 				serviceType.getValue(),SdlPacket.FRAME_INFO_END_SERVICE,sessionID,
 				payload.length,messageID,payload);
+	}
+
+	public static SdlPacket createEndSession(SessionType serviceType, byte sessionID, int messageID, byte version, int hashID) {
+		if (version < 5) {
+			byte[] payload = BitConverter.intToByteArray(hashID);
+			return new SdlPacket(version, false, SdlPacket.FRAME_TYPE_CONTROL,
+					serviceType.getValue(), SdlPacket.FRAME_INFO_END_SERVICE, sessionID,
+					payload.length, messageID, payload);
+		} else {
+			SdlPacket endSession = new SdlPacket(version, false, SdlPacket.FRAME_TYPE_CONTROL,
+					serviceType.getValue(), SdlPacket.FRAME_INFO_END_SERVICE, sessionID,
+					0, messageID, null);
+			endSession.putTag(ControlFrameTags.RPC.EndService.HASH_ID, hashID);
+			return endSession;
+		}
 	}
 
 	public static SdlPacket createSingleSendData(SessionType serviceType, byte sessionID,

--- a/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/protocol/SdlProtocol.java
@@ -511,14 +511,7 @@ public class SdlProtocol {
     }
 
     public void endSession(byte sessionID, int hashId) {
-        SdlPacket header;
-        if(protocolVersion.getMajor() < 5){
-            header = SdlPacketFactory.createEndSession(SessionType.RPC, sessionID, hashId, (byte)protocolVersion.getMajor(), BitConverter.intToByteArray(hashId));
-        }else{
-            header = SdlPacketFactory.createEndSession(SessionType.RPC, sessionID, hashId, (byte)protocolVersion.getMajor(), new byte[0]);
-            header.putTag(ControlFrameTags.RPC.EndService.HASH_ID, hashId);
-        }
-
+        SdlPacket header = SdlPacketFactory.createEndSession(SessionType.RPC, sessionID, hashId, (byte)protocolVersion.getMajor(), hashId);
         handlePacketToSend(header);
 
     } // end-method

--- a/sdl_android/src/main/java/com/smartdevicelink/protocol/WiProProtocol.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/protocol/WiProProtocol.java
@@ -157,12 +157,7 @@ public class WiProProtocol extends AbstractProtocol {
 	public void EndProtocolSession(SessionType sessionType, byte sessionID, int hashId) {
 		SdlPacket header;
 		if (sessionType.equals(SessionType.RPC)) { // check for RPC session
-			if(_version < 5){
-				header = SdlPacketFactory.createEndSession(sessionType, sessionID, hashID, getMajorVersionByte(), BitConverter.intToByteArray(hashID));
-			}else{
-				header = SdlPacketFactory.createEndSession(sessionType, sessionID, hashID, getMajorVersionByte(), new byte[0]);
-				header.putTag(ControlFrameTags.RPC.EndService.HASH_ID, hashID);
-			}
+			header = SdlPacketFactory.createEndSession(sessionType, sessionID, hashID, getMajorVersionByte(), hashID);
 		}else{ //Any other service type we don't include the hash id
 			header = SdlPacketFactory.createEndSession(sessionType, sessionID, hashID, getMajorVersionByte(), new byte[0]);
 		}

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -1985,14 +1985,7 @@ public class SdlRouterService extends Service{
 							}
 
 							//TODO stop other services on that transport for the session with no app
-							SdlPacket endService;
-							if (packet.getVersion() < 5) {
-								endService = SdlPacketFactory.createEndSession(SessionType.RPC, (byte)session, 0, (byte)packet.getVersion(), BitConverter.intToByteArray(hashId));
-							} else {
-								endService = SdlPacketFactory.createEndSession(SessionType.RPC, (byte)session, 0, (byte)packet.getVersion(), new byte[0]);
-								endService.putTag(ControlFrameTags.RPC.EndService.HASH_ID, hashId);
-							}
-							byte[] stopService = endService.constructPacket();
+							byte[] stopService = SdlPacketFactory.createEndSession(SessionType.RPC, (byte)session, 0, (byte)packet.getVersion(), hashId).constructPacket();
 							manuallyWriteBytes(packet.getTransportRecord().getType(), stopService,0,stopService.length);
 						}else{
 	    					Log.w(TAG, "No where to send a packet from what appears to be a non primary transport");
@@ -2145,14 +2138,7 @@ public class SdlRouterService extends Service{
 					this.cleanedSessionMap.put(session,hashId);
 				}
 			}
-			SdlPacket packet;
-			if (version < 5) {
-				packet = SdlPacketFactory.createEndSession(SessionType.RPC, (byte)session, 0, (byte)version, BitConverter.intToByteArray(hashId));
-			} else {
-				packet = SdlPacketFactory.createEndSession(SessionType.RPC, (byte)session, 0, (byte)version, new byte[0]);
-				packet.putTag(ControlFrameTags.RPC.EndService.HASH_ID, hashId);
-			}
-			byte[] stopService = packet.constructPacket();
+			byte[] stopService = SdlPacketFactory.createEndSession(SessionType.RPC, (byte)session, 0, (byte)version, hashId).constructPacket();
 			manuallyWriteBytes(primaryTransport,stopService,0,stopService.length);
 		}
 		
@@ -2178,14 +2164,7 @@ public class SdlRouterService extends Service{
 								hashId = this.sessionHashIdMap.get(sessionId);
 							}
 						}
-						SdlPacket packet;
-						if (version < 5) {
-							packet = SdlPacketFactory.createEndSession(SessionType.RPC, (byte) sessionId, 0, version, BitConverter.intToByteArray(hashId));
-						} else {
-							packet = SdlPacketFactory.createEndSession(SessionType.RPC, (byte) sessionId, 0, version, new byte[0]);
-							packet.putTag(ControlFrameTags.RPC.EndService.HASH_ID, hashId);
-						}
-						stopService = packet.constructPacket();
+						stopService = SdlPacketFactory.createEndSession(SessionType.RPC, (byte) sessionId, 0, version, hashId).constructPacket();
 
 						manuallyWriteBytes(transportTypes.get(0),stopService, 0, stopService.length);
 						synchronized (SESSION_LOCK) {


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_android/issues/943

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- Repeat the repro steps mentioned in https://github.com/smartdevicelink/sdl_android/issues/943
- Run the newly added unit tests.

### Summary
This PR updates SdlRouterService to generate an End Session frame with BSON document for protocol version >= 5.

### Changelog
##### Breaking Changes
* None

##### Enhancements
* None

##### Bug Fixes
* fix: Router service doesn't support HashID for V5 protocol

### Tasks Remaining:
- None

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)