### PR TITLE
ScreenManager does not call completion listener if TextAndGraphicManager is not dirty

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
@@ -169,8 +169,8 @@ class TextAndGraphicManager extends BaseSubManager {
 			isDirty = false;
 			sdlUpdate(listener);
 		} else if (listener != null) {
-            listener.onComplete(true);
-        }
+			listener.onComplete(true);
+		}
 	}
 	
 	private synchronized void sdlUpdate(CompletionListener listener){

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
@@ -168,7 +168,9 @@ class TextAndGraphicManager extends BaseSubManager {
 		if (isDirty){
 			isDirty = false;
 			sdlUpdate(listener);
-		}
+		} else if (listener != null) {
+            listener.onComplete(true);
+        }
 	}
 	
 	private synchronized void sdlUpdate(CompletionListener listener){


### PR DESCRIPTION
Fixes #930 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Summary
When the app developer uses screen manager and updates soft buttons only. the completion handler will never be called. Fixed by immediately calling completion handler.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
