### PR TITLE
Handle onError in TextAndGraphicManager

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
@@ -24,6 +24,7 @@ import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.HMILevel;
 import com.smartdevicelink.proxy.rpc.enums.ImageType;
 import com.smartdevicelink.proxy.rpc.enums.MetadataType;
+import com.smartdevicelink.proxy.rpc.enums.Result;
 import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 import com.smartdevicelink.proxy.rpc.enums.TextFieldName;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCNotificationListener;
@@ -253,13 +254,22 @@ class TextAndGraphicManager extends BaseSubManager {
 		inProgressUpdate.setOnRPCResponseListener(new OnRPCResponseListener() {
 			@Override
 			public void onResponse(int correlationId, RPCResponse response) {
-				if (response.getSuccess()){
+				handleResponse(response.getSuccess());
+			}
+
+			@Override
+			public void onError(int correlationId, Result resultCode, String info) {
+				handleResponse(false);
+			}
+
+			private void handleResponse(boolean success){
+				if (success){
 					updateCurrentScreenDataState(inProgressUpdate);
 				}
 
 				inProgressUpdate = null;
 				if (inProgressListener != null){
-					inProgressListener.onComplete(true);
+					inProgressListener.onComplete(success);
 					inProgressListener = null;
 				}
 


### PR DESCRIPTION
Fixes #948 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
Currently, in the `TextAndGraphicManager` if the head unit responded with an error for the sending a `Show` request, the `inProgressUpdate` will not be set to `null`. We only set it to `null` when a successful response comes back as shown in the following line:

https://github.com/smartdevicelink/sdl_android/blob/490be41b20ec4bb4a81837e73eb6ea9bfcea7a8a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java#L255

However, if the `inProgressUpdate` is not set to `null`, all subsequent `TextAndGraphicManager` updates will hit this if:
https://github.com/smartdevicelink/sdl_android/blob/490be41b20ec4bb4a81837e73eb6ea9bfcea7a8a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java#L187

That will make all updates not go through.

### Changelog
- Handled `onError` in `sendShow` method.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
