### PR TITLE
Fixed the screen manager not being able to clear images

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/ScreenManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/ScreenManagerTests.java
@@ -81,9 +81,21 @@ public class ScreenManagerTests extends AndroidTestCase2 {
 		assertEquals(screenManager.getPrimaryGraphic(), testArtwork);
 	}
 
+	public void testSetPrimaryGraphicWithBlankImage() {
+		screenManager.setPrimaryGraphic(null);
+		assertNotNull(screenManager.getPrimaryGraphic());
+		assertEquals(screenManager.getPrimaryGraphic().getName(), "blankArtwork");
+	}
+
 	public void testSetSecondaryGraphic() {
 		screenManager.setSecondaryGraphic(testArtwork);
 		assertEquals(screenManager.getSecondaryGraphic(), testArtwork);
+	}
+
+	public void testSetSecondaryGraphicWithBlankImage() {
+		screenManager.setSecondaryGraphic(null);
+		assertNotNull(screenManager.getSecondaryGraphic());
+		assertEquals(screenManager.getSecondaryGraphic().getName(), "blankArtwork");
 	}
 
 	public void testAlignment() {

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/TextAndGraphicManagerTests.java
@@ -113,6 +113,7 @@ public class TextAndGraphicManagerTests extends AndroidTestCase2 {
 		assertEquals(textAndGraphicManager.currentHMILevel, HMILevel.HMI_NONE);
 		assertFalse(textAndGraphicManager.isDirty);
 		assertEquals(textAndGraphicManager.getState(), BaseSubManager.SETTING_UP);
+		assertNotNull(textAndGraphicManager.getBlankArtwork());
 	}
 
 	public void testGetMainLines(){
@@ -533,7 +534,7 @@ public class TextAndGraphicManagerTests extends AndroidTestCase2 {
 		assertNull(textAndGraphicManager.getTextField2Type());
 		assertNull(textAndGraphicManager.getTextField3Type());
 		assertNull(textAndGraphicManager.getTextField4Type());
-		assertNull(textAndGraphicManager.getBlankArtwork());
+		assertNotNull(textAndGraphicManager.getBlankArtwork());
 		assertNull(textAndGraphicManager.currentScreenData);
 		assertNull(textAndGraphicManager.inProgressUpdate);
 		assertNull(textAndGraphicManager.queuedImageUpdate);

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
@@ -662,7 +662,7 @@ class TextAndGraphicManager extends BaseSubManager {
 
 	SdlArtwork getBlankArtwork(){
 
-		if (blankArtwork != null){
+		if (blankArtwork == null){
 			blankArtwork = new SdlArtwork();
 			blankArtwork.setType(FileType.GRAPHIC_PNG);
 			blankArtwork.setName("blankArtwork");


### PR DESCRIPTION
Fixes #942 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Test cases added to the `ScreenManagerTests` and `TextAndGraphicManagerTests` classes.

### Summary
The blank artwork object was never created due to a bug where the blank artwork could only be created if it was already not `null`. 

### Changelog
##### Bug Fixes
* Developers can now successfully clear a primary or secondary graphic when using the screen manager. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)