### PR TITLE
Fix potential NPE for transportType during write

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -114,6 +114,7 @@ import com.smartdevicelink.transport.utl.ByteArrayMessageSpliter;
 import com.smartdevicelink.transport.utl.TransportRecord;
 import com.smartdevicelink.util.AndroidTools;
 import com.smartdevicelink.util.BitConverter;
+import com.smartdevicelink.util.DebugTool;
 import com.smartdevicelink.util.SdlAppInfo;
 
 import static com.smartdevicelink.transport.TransportConstants.FOREGROUND_EXTRA;
@@ -504,6 +505,12 @@ public class SdlRouterService extends Service{
 												transportType = TransportType.USB;
 											} else if(service.tcpTransport != null && service.tcpTransport.isConnected()){
 												transportType = TransportType.TCP;
+											}else{
+												// This means no transport is connected. Likely the
+												// router service has already disconnected and this
+												// is now just executing.
+												DebugTool.logError("Can't send packet, no transport specified and none are connected.");
+												return;
 											}
 											//Log.d(TAG, "Transport type was null, so router set it to " + transportType.name());
 											if(transportType != null){


### PR DESCRIPTION
Fixes #945 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Send a packet to router service to send while no transport is connected.

### Summary
- If no transport type is supplied and no transport is currently connected. The write task runnable will simply return instead of trying to write the packet while not supplying a transport type. 

### Changelog

##### Bug Fixes
* There is likely a race condition where the packet write runnable can be mid or starting execution as the router service is disconnecting or already disconnected.



### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
