### PR TITLE
Add null check before accessing packetWriteMap

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -3151,9 +3151,11 @@ public class SdlRouterService extends Service{
 					PacketWriteTaskBlockingQueue queue = queues.get(transportType);
 					if (queue != null) {
 						queue.add(new PacketWriteTask(bytes, 0, bytes.length, this.priorityForBuffingMessage,transportType));
-						PacketWriteTaskMaster packetWriteTaskMaster = packetWriteTaskMasterMap.get(transportType);
-						if (packetWriteTaskMaster != null) {
-							packetWriteTaskMaster.alert();
+						if(packetWriteTaskMasterMap != null) {
+							PacketWriteTaskMaster packetWriteTaskMaster = packetWriteTaskMasterMap.get(transportType);
+							if (packetWriteTaskMaster != null) {
+								packetWriteTaskMaster.alert();
+							}
 						}
 					}
 					buffer.close();


### PR DESCRIPTION

Fixes #951

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.


### Summary
- Added a null check before accessing offending variable

### Changelog

##### Bug Fixes
* Prevent NPE during a router service shutdown


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
