### PR TITLE
Fix for issue #958: some apps do not get START_ROUTER_SERVICE_ACTION broadcast

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/utl/AndroidToolsTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/utl/AndroidToolsTests.java
@@ -28,5 +28,29 @@ public class AndroidToolsTests extends AndroidTestCase2 {
 		}
 		
 	}
+	public void testSendExplicitBroadcast() {
+		Intent pingIntent = new Intent();
+		pingIntent.setAction(TransportConstants.START_ROUTER_SERVICE_ACTION);
+		pingIntent.putExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_EXTRA, true);
+		pingIntent.putExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_APP_PACKAGE, getContext().getPackageName());
+		pingIntent.putExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_CMP_NAME, new ComponentName(getContext().getPackageName(), getClass().toString()));
+		pingIntent.putExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_PING, true);
+		Intent param = new Intent(pingIntent);
+		AndroidTools.sendExplicitBroadcast(getContext(), pingIntent, null);
+		if (pingIntent.getAction() == param.getAction() &&
+				pingIntent.getClass() == param.getClass() &&
+				pingIntent.getBooleanExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_EXTRA, false) == param.getBooleanExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_EXTRA, true) &&
+				pingIntent.getStringExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_APP_PACKAGE) == param.getStringExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_APP_PACKAGE) &&
+				pingIntent.getBooleanExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_PING, false) == param.getBooleanExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_PING, true) &&
+				pingIntent.getComponent() == null && param.getComponent() == null){
+			ComponentName comp1 = (ComponentName)pingIntent.getParcelableExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_CMP_NAME);
+			ComponentName comp2 = (ComponentName)param.getParcelableExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_CMP_NAME);
+			if (comp1.compareTo(comp2) != 0) {
+				Assert.fail("ComponentName has been changed");
+			}
+		} else {
+			Assert.fail("Given intent has been changed");
+		}
+	}
 
 }

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/utl/AndroidToolsTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/utl/AndroidToolsTests.java
@@ -2,8 +2,10 @@ package com.smartdevicelink.test.utl;
 
 import junit.framework.Assert;
 import android.content.ComponentName;
+import android.content.Intent;
 
 import com.smartdevicelink.AndroidTestCase2;
+import com.smartdevicelink.transport.TransportConstants;
 import com.smartdevicelink.util.AndroidTools;
 
 public class AndroidToolsTests extends AndroidTestCase2 {

--- a/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/util/AndroidTools.java
@@ -129,13 +129,14 @@ public class AndroidTools {
 	 * the AndroidManifest. If no apps are found to receive the intent, this method will send the
 	 * broadcast implicitly if no list of apps is provided.
 	 *
-	 * @param intent - the intent to send explicitly
+	 * @param intent - the intent used for populating target apps when apps is null.
+	 *                 this intent is copied and used also for sending broadcast.
 	 * @param apps - the list of apps that this broadcast will be sent to. If null is passed in
 	 *                the intent will be sent to all apps that match the provided intent via a query
 	 *                to the package manager; it will also be sent implicitly to mimic
 	 *                sendBroadcast()'s original functionality.
 	 */
-	public static void sendExplicitBroadcast(Context context, Intent intent, List<ResolveInfo> apps) {
+	public static void sendExplicitBroadcast(final Context context, final Intent intent, List<ResolveInfo> apps) {
 
 		if(context == null || intent == null){
 			return;
@@ -148,8 +149,9 @@ public class AndroidTools {
 		if (apps != null && apps.size()>0) {
 			for(ResolveInfo app: apps){
 				try {
-					intent.setClassName(app.activityInfo.applicationInfo.packageName, app.activityInfo.name);
-					context.sendBroadcast(intent);
+					Intent broadcastIntent = new Intent(intent);
+					broadcastIntent.setClassName(app.activityInfo.applicationInfo.packageName, app.activityInfo.name);
+					context.sendBroadcast(broadcastIntent);
 				}catch(Exception e){
 					//In case there is missing info in the app reference we want to keep moving
 				}


### PR DESCRIPTION
Fix the case where sendExplicitBroadcast modifies the given intent unexpectedly. That caused pingIntent used in RouterService got modified, and then broadcast sent to different target.

Fixes #958 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
This PR includes unit test added to AndroidToolsTests.

### Summary
Fix for issue #958: some apps do not get START_ROUTER_SERVICE_ACTION broadcast.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* N/A

##### Bug Fixes
* This fixes the #958: some apps do not get START_ROUTER_SERVICE_ACTION broadcast, because the intent was unexpectedly modified after sendExplicitBroadcast call.

### Tasks Remaining:
- N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
