### PR TITLE
Fix NPE in AudioStreamManager

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/audio/AudioStreamManager.java
@@ -353,7 +353,9 @@ public class AudioStreamManager extends BaseSubManager {
         AudioDecoderListener decoderListener = new AudioDecoderListener() {
             @Override
             public void onAudioDataAvailable(SampleBuffer buffer) {
-                sdlAudioStream.sendAudio(buffer.getByteBuffer(), buffer.getPresentationTimeUs());
+                if (sdlAudioStream != null) {
+                    sdlAudioStream.sendAudio(buffer.getByteBuffer(), buffer.getPresentationTimeUs());
+                }
             }
 
             @Override


### PR DESCRIPTION
Fixes #963 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run a test navigation app that uses audio streaming on Core and Generic HMI and make sure it doesn't crash.

### Summary
When the audio service is ended, `sdlAudioStream` gets set to `null`. However, the `sdlAudioStream` may still be used to send data in `onAudioDataAvailable` which causes an NPE.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
