### PR TITLE
Make SystemCapabilityManager query only for queryable capabilities

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -1,5 +1,7 @@
 package com.smartdevicelink.proxy;
 
+import android.util.Log;
+
 import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.interfaces.OnSystemCapabilityListener;
 import com.smartdevicelink.proxy.rpc.GetSystemCapability;
@@ -17,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class SystemCapabilityManager {
+	private static final String TAG = "SystemCapabilityManager";
 	private final HashMap<SystemCapabilityType, Object> cachedSystemCapabilities;
 	private final HashMap<SystemCapabilityType, CopyOnWriteArrayList<OnSystemCapabilityListener>> onSystemCapabilityListeners;
 	private final Object LISTENER_LOCK;
@@ -169,6 +172,10 @@ public class SystemCapabilityManager {
 	 * passes GetSystemCapabilityType request to  `callback` to be sent by proxy
 	 */
 	private void retrieveCapability(final SystemCapabilityType systemCapabilityType, final OnSystemCapabilityListener scListener){
+		if (!systemCapabilityType.getIsAsync()){
+			Log.e(TAG, "This systemCapabilityType cannot be queried for");
+			return;
+		}
 		final GetSystemCapability request = new GetSystemCapability();
 		request.setSystemCapabilityType(systemCapabilityType);
 		request.setOnRPCResponseListener(new OnRPCResponseListener() {

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -172,7 +172,9 @@ public class SystemCapabilityManager {
 	 */
 	private void retrieveCapability(final SystemCapabilityType systemCapabilityType, final OnSystemCapabilityListener scListener){
 		if (!systemCapabilityType.isQueryable()){
-			DebugTool.logError("This systemCapabilityType cannot be queried for");
+			String message = "This systemCapabilityType cannot be queried for";
+			DebugTool.logError(message);
+			scListener.onError(message);
 			return;
 		}
 		final GetSystemCapability request = new GetSystemCapability();

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -169,10 +169,11 @@ public class SystemCapabilityManager {
 
 	/**
 	 * @param systemCapabilityType Type of capability desired
-	 * passes GetSystemCapabilityType request to  `callback` to be sent by proxy
+	 * passes GetSystemCapabilityType request to `callback` to be sent by proxy.
+	 * this method will send RPC and call the listener's callback only if the systemCapabilityType is queryable
 	 */
 	private void retrieveCapability(final SystemCapabilityType systemCapabilityType, final OnSystemCapabilityListener scListener){
-		if (!systemCapabilityType.getIsAsync()){
+		if (!systemCapabilityType.isQueryable()){
 			Log.e(TAG, "This systemCapabilityType cannot be queried for");
 			return;
 		}

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -1,7 +1,5 @@
 package com.smartdevicelink.proxy;
 
-import android.util.Log;
-
 import com.smartdevicelink.proxy.interfaces.ISdl;
 import com.smartdevicelink.proxy.interfaces.OnSystemCapabilityListener;
 import com.smartdevicelink.proxy.rpc.GetSystemCapability;
@@ -12,6 +10,7 @@ import com.smartdevicelink.proxy.rpc.enums.Result;
 import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCResponseListener;
 import com.smartdevicelink.util.CorrelationIdGenerator;
+import com.smartdevicelink.util.DebugTool;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,7 +18,6 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class SystemCapabilityManager {
-	private static final String TAG = "SystemCapabilityManager";
 	private final HashMap<SystemCapabilityType, Object> cachedSystemCapabilities;
 	private final HashMap<SystemCapabilityType, CopyOnWriteArrayList<OnSystemCapabilityListener>> onSystemCapabilityListeners;
 	private final Object LISTENER_LOCK;
@@ -174,7 +172,7 @@ public class SystemCapabilityManager {
 	 */
 	private void retrieveCapability(final SystemCapabilityType systemCapabilityType, final OnSystemCapabilityListener scListener){
 		if (!systemCapabilityType.isQueryable()){
-			Log.e(TAG, "This systemCapabilityType cannot be queried for");
+			DebugTool.logError("This systemCapabilityType cannot be queried for");
 			return;
 		}
 		final GetSystemCapability request = new GetSystemCapability();

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
@@ -419,15 +419,15 @@ public enum SystemCapabilityType {
 
 	;
 
-    boolean IS_ASYNC;
+    boolean IS_QUERYABLE;
 
-    SystemCapabilityType (boolean isAsync){
-    	this.IS_ASYNC = isAsync;
-	}
+    SystemCapabilityType(boolean isQueryable) {
+        this.IS_QUERYABLE = isQueryable;
+    }
 
-	public boolean getIsAsync(){
-    	return IS_ASYNC;
-	}
+    public boolean isQueryable() {
+        return IS_QUERYABLE;
+    }
 
     public static SystemCapabilityType valueForString(String value) {
         try{

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/enums/SystemCapabilityType.java
@@ -135,7 +135,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    NAVIGATION,
+    NAVIGATION (true),
 
 	/**
 	 * <strong>Requires</strong> initial asynchronous call, then available synchronously after successful call. <br>
@@ -156,7 +156,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    PHONE_CALL,
+    PHONE_CALL (true),
 
 	/**
 	 * <strong>Requires</strong> initial asynchronous call, then available synchronously after successful call. <br>
@@ -177,7 +177,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    VIDEO_STREAMING,
+    VIDEO_STREAMING (true),
 
 	/**
 	 * <strong>Requires</strong> initial asynchronous call, then available synchronously after successful call. <br>
@@ -198,7 +198,7 @@ public enum SystemCapabilityType {
 	 * 	</table>
 	 *
 	 */
-    REMOTE_CONTROL,
+    REMOTE_CONTROL (true),
 
     /* These below are not part of the RPC spec. Only for Internal Proxy use */
 
@@ -221,7 +221,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    HMI,
+    HMI (false),
 
 	/**
 	 * Available Synchronously after Register App Interface response <br>
@@ -243,7 +243,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    DISPLAY,
+    DISPLAY (false),
 
 	/**
 	 * Available Synchronously after Register App Interface response <br>
@@ -265,7 +265,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    AUDIO_PASSTHROUGH,
+    AUDIO_PASSTHROUGH (false),
 
 	/**
 	 * Available Synchronously after Register App Interface response <br>
@@ -287,7 +287,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-	PCM_STREAMING,
+	PCM_STREAMING (false),
 
 	/**
 	 * Available Synchronously after Register App Interface response <br>
@@ -309,7 +309,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    BUTTON,
+    BUTTON (false),
 
 	/**
 	 * Available Synchronously after Register App Interface response <br>
@@ -330,7 +330,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    HMI_ZONE,
+    HMI_ZONE (false),
 
 	/**
 	 * Available Synchronously after Register App Interface response <br>
@@ -351,7 +351,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    PRESET_BANK,
+    PRESET_BANK (false),
 
 	/**
 	 * Available Synchronously after Register App Interface response <br>
@@ -374,7 +374,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    SOFTBUTTON,
+    SOFTBUTTON (false),
 
 	/**
 	 * Available Synchronously after Register App Interface response <br>
@@ -395,7 +395,7 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    SPEECH,
+    SPEECH (false),
 	/**
 	 * Available Synchronously after Register App Interface response <br>
 	 * <table border="1" rules="all">
@@ -415,9 +415,19 @@ public enum SystemCapabilityType {
 	 * 		</tr>
 	 * 	</table>
 	 */
-    VOICE_RECOGNITION,
+    VOICE_RECOGNITION (false),
 
 	;
+
+    boolean IS_ASYNC;
+
+    SystemCapabilityType (boolean isAsync){
+    	this.IS_ASYNC = isAsync;
+	}
+
+	public boolean getIsAsync(){
+    	return IS_ASYNC;
+	}
 
     public static SystemCapabilityType valueForString(String value) {
         try{


### PR DESCRIPTION
Fixes #965 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR modifies `SystemCapabilityManager` to make it query only for queryable capabilities  

### Changes
* Add `isQueryable` boolean to `SystemCapabilityType` enum
* Update `SystemCapabilityManager.retrieveCapability()` to query only for for queryable capabilities  

### CLA
- [ x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
