### PR TITLE
Show warning if default SdlRouterService class is used in SdlReceiver

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -151,7 +151,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 		}
 
 		if(localRouterClass != null && localRouterClass.getName().equalsIgnoreCase(com.smartdevicelink.transport.SdlRouterService.class.getName())){
-			Log.e(TAG, "Can't use default SdlRouterService class, must be extended in your project. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
+			Log.e(TAG, "You cannot use the default SdlRouterService class, it must be extended in your project. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
 		}
 
 		//This will only be true if we are being told to reopen our SDL service because SDL is enabled

--- a/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -149,7 +149,11 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 				}
 			}
 		}
-        
+
+		if(localRouterClass != null && localRouterClass.getName().equalsIgnoreCase(com.smartdevicelink.transport.SdlRouterService.class.getName())){
+			Log.e(TAG, "Can't use default SdlRouterService class, must be extended in your project. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
+		}
+
 		//This will only be true if we are being told to reopen our SDL service because SDL is enabled
 		if(action.equalsIgnoreCase(TransportConstants.START_ROUTER_SERVICE_ACTION)){ 
 			if(intent.hasExtra(TransportConstants.START_ROUTER_SERVICE_SDL_ENABLED_EXTRA)){	


### PR DESCRIPTION
Fixes #975 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- Test with any sdl app that has a RouterService
- Use the default SdlRouterService class in`SdlReceiver.defineLocalSdlRouterClass` and confirm that you see this message in the logs
```
Can't use default SdlRouterService class, must be extended in your project
```
- Use the app's SdlRouterService class in`SdlReceiver.defineLocalSdlRouterClass` and confirm that the previous error message is not logged 

### Summary
This PR logs a warning message if the developer used the default SdlRouterService class in `SdlReceiver.defineLocalSdlRouterClass` instead of using the app's SdlRouterService class

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
