### PR TITLE
SDL 0197 - Update SetMediaClockTimer Initializers

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/StartTimeTest.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/StartTimeTest.java
@@ -13,7 +13,7 @@ import com.smartdevicelink.test.Test;
 
 /**
  * This is a unit test class for the SmartDeviceLink library project class : 
- * {@link com.smartdevicelink.rpc.StartTime}
+ * {@link com.smartdevicelink.proxy.rpc.StartTime}
  */
 public class StartTimeTest extends TestCase {
 	
@@ -41,11 +41,16 @@ public class StartTimeTest extends TestCase {
 		assertEquals(Test.MATCH, (Integer) Test.GENERAL_INT, hours);
 		assertEquals(Test.MATCH, (Integer) Test.GENERAL_INT, minutes);
 		assertEquals(Test.MATCH, (Integer) Test.GENERAL_INT, seconds);
-		
+
+		// TimeInterval constructor test
+		StartTime startTime = new StartTime(7000);
+		assertEquals(Test.MATCH, (Integer) 1, startTime.getHours());
+		assertEquals(Test.MATCH, (Integer) 56, startTime.getMinutes());
+		assertEquals(Test.MATCH, (Integer) 40, startTime.getSeconds());
+
 		// Invalid/Null Tests
 		StartTime msg = new StartTime();
 		assertNotNull(Test.NOT_NULL, msg);
-
 		assertNull(Test.NULL, msg.getHours());
 		assertNull(Test.NULL, msg.getMinutes());
 		assertNull(Test.NULL, msg.getSeconds());

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/SetMediaClockTimerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/SetMediaClockTimerTests.java
@@ -88,6 +88,71 @@ public class SetMediaClockTimerTests extends BaseRpcTests {
 		assertNull(Test.NULL, msg.getUpdateMode());
 		assertNull(Test.NULL, msg.getAudioStreamingIndicator());
 	}
+
+	/**
+	 * Test static initializers
+	 */
+	public void testInitializers(){
+		Integer timeInterval1 = 5000;
+		StartTime startTime1 = new StartTime(timeInterval1);
+		Integer timeInterval2 = 7000;
+		StartTime startTime2 = new StartTime(timeInterval2);
+		SetMediaClockTimer msg;
+
+		msg = SetMediaClockTimer.countUpFromStartTimeInterval(timeInterval1, timeInterval2, Test.GENERAL_AUDIO_STREAMING_INDICATOR);
+		assertEquals(Test.MATCH, msg.getUpdateMode(), UpdateMode.COUNTUP);
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime1, msg.getStartTime()));
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime2, msg.getEndTime()));
+		assertEquals(Test.MATCH, Test.GENERAL_AUDIO_STREAMING_INDICATOR, msg.getAudioStreamingIndicator());
+
+		msg = SetMediaClockTimer.countUpFromStartTime(startTime1, startTime2, Test.GENERAL_AUDIO_STREAMING_INDICATOR);
+		assertEquals(Test.MATCH, msg.getUpdateMode(), UpdateMode.COUNTUP);
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime1, msg.getStartTime()));
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime2, msg.getEndTime()));
+		assertEquals(Test.MATCH, Test.GENERAL_AUDIO_STREAMING_INDICATOR, msg.getAudioStreamingIndicator());
+
+		msg = SetMediaClockTimer.countDownFromStartTimeInterval(timeInterval1, timeInterval2, Test.GENERAL_AUDIO_STREAMING_INDICATOR);
+		assertEquals(Test.MATCH, msg.getUpdateMode(), UpdateMode.COUNTDOWN);
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime1, msg.getStartTime()));
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime2, msg.getEndTime()));
+		assertEquals(Test.MATCH, Test.GENERAL_AUDIO_STREAMING_INDICATOR, msg.getAudioStreamingIndicator());
+
+		msg = SetMediaClockTimer.countDownFromStartTime(startTime1, startTime2, Test.GENERAL_AUDIO_STREAMING_INDICATOR);
+		assertEquals(Test.MATCH, msg.getUpdateMode(), UpdateMode.COUNTDOWN);
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime1, msg.getStartTime()));
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime2, msg.getEndTime()));
+		assertEquals(Test.MATCH, Test.GENERAL_AUDIO_STREAMING_INDICATOR, msg.getAudioStreamingIndicator());
+
+		msg = SetMediaClockTimer.pauseWithPlayPauseIndicator(Test.GENERAL_AUDIO_STREAMING_INDICATOR);
+		assertEquals(Test.MATCH, msg.getUpdateMode(), UpdateMode.PAUSE);
+		assertNull(Test.NULL, msg.getStartTime());
+		assertNull(Test.NULL, msg.getEndTime());
+		assertEquals(Test.MATCH, Test.GENERAL_AUDIO_STREAMING_INDICATOR, msg.getAudioStreamingIndicator());
+
+		msg = SetMediaClockTimer.updatePauseWithNewStartTimeInterval(timeInterval1, timeInterval2, Test.GENERAL_AUDIO_STREAMING_INDICATOR);
+		assertEquals(Test.MATCH, msg.getUpdateMode(), UpdateMode.PAUSE);
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime1, msg.getStartTime()));
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime2, msg.getEndTime()));
+		assertEquals(Test.MATCH, Test.GENERAL_AUDIO_STREAMING_INDICATOR, msg.getAudioStreamingIndicator());
+
+		msg = SetMediaClockTimer.updatePauseWithNewStartTime(startTime1, startTime2, Test.GENERAL_AUDIO_STREAMING_INDICATOR);
+		assertEquals(Test.MATCH, msg.getUpdateMode(), UpdateMode.PAUSE);
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime1, msg.getStartTime()));
+		assertTrue(Test.TRUE, Validator.validateStartTime(startTime2, msg.getEndTime()));
+		assertEquals(Test.MATCH, Test.GENERAL_AUDIO_STREAMING_INDICATOR, msg.getAudioStreamingIndicator());
+
+		msg = SetMediaClockTimer.resumeWithPlayPauseIndicator(Test.GENERAL_AUDIO_STREAMING_INDICATOR);
+		assertEquals(Test.MATCH, msg.getUpdateMode(), UpdateMode.RESUME);
+		assertNull(Test.NULL, msg.getStartTime());
+		assertNull(Test.NULL, msg.getEndTime());
+		assertEquals(Test.MATCH, Test.GENERAL_AUDIO_STREAMING_INDICATOR, msg.getAudioStreamingIndicator());
+
+		msg = SetMediaClockTimer.clearWithPlayPauseIndicator(Test.GENERAL_AUDIO_STREAMING_INDICATOR);
+		assertEquals(Test.MATCH, msg.getUpdateMode(), UpdateMode.CLEAR);
+		assertNull(Test.NULL, msg.getStartTime());
+		assertNull(Test.NULL, msg.getEndTime());
+		assertEquals(Test.MATCH, Test.GENERAL_AUDIO_STREAMING_INDICATOR, msg.getAudioStreamingIndicator());
+	}
 	
 	/**
      * Tests a valid JSON construction of this RPC message.

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SetMediaClockTimer.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/SetMediaClockTimer.java
@@ -1,6 +1,7 @@
 package com.smartdevicelink.proxy.rpc;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCRequest;
@@ -115,6 +116,114 @@ public class SetMediaClockTimer extends RPCRequest {
 	public SetMediaClockTimer(@NonNull UpdateMode updateMode) {
 		this();
 		setUpdateMode(updateMode);
+	}
+	private SetMediaClockTimer(@NonNull UpdateMode updateMode, @Nullable StartTime startTime, @Nullable StartTime endTime, @Nullable AudioStreamingIndicator audioStreamingIndicator){
+		this();
+		this.setUpdateMode(updateMode);
+		if (startTime != null) {
+			this.setStartTime(startTime);
+		}
+		if (endTime != null) {
+			this.setEndTime(endTime);
+		}
+		if (audioStreamingIndicator != null) {
+			this.setAudioStreamingIndicator(audioStreamingIndicator);
+		}
+	}
+	/**
+	 * Create a media clock timer that counts up, e.g from 0:00 to 4:18.
+	 *
+	 * @param startTimeInterval       The start time interval, e.g. (0) 0:00
+	 * @param endTimeInterval         The end time interval, e.g. (258) 4:18
+	 * @param audioStreamingIndicator playPauseIndicator An optional audio indicator to change the play/pause button
+	 * @return An object of SetMediaClockTimer
+	 */
+	public static SetMediaClockTimer countUpFromStartTimeInterval(@NonNull Integer startTimeInterval, @NonNull Integer endTimeInterval, @Nullable AudioStreamingIndicator audioStreamingIndicator) {
+		return new SetMediaClockTimer(UpdateMode.COUNTUP, new StartTime(startTimeInterval), new StartTime(endTimeInterval), audioStreamingIndicator);
+	}
+	/**
+	 * Create a media clock timer that counts up, e.g from 0:00 to 4:18.
+	 *
+	 * @param startTime               The start time interval, e.g. 0:00
+	 * @param endTime                 The end time interval, e.g. 4:18
+	 * @param audioStreamingIndicator An optional audio indicator to change the play/pause button
+	 * @return An object of SetMediaClockTimer
+	 */
+	public static SetMediaClockTimer countUpFromStartTime(@NonNull StartTime startTime, @NonNull StartTime endTime, @Nullable AudioStreamingIndicator audioStreamingIndicator) {
+		return new SetMediaClockTimer(UpdateMode.COUNTUP, startTime, endTime, audioStreamingIndicator);
+	}
+	/**
+	 * Create a media clock timer that counts down, e.g. from 4:18 to 0:00
+	 * This will fail if endTime is greater than startTime
+	 *
+	 * @param startTimeInterval       The start time interval, e.g. (258) 4:18
+	 * @param endTimeInterval         The end time interval, e.g. (0) 0:00
+	 * @param audioStreamingIndicator An optional audio indicator to change the play/pause button
+	 * @return An object of SetMediaClockTimer
+	 */
+	public static SetMediaClockTimer countDownFromStartTimeInterval(@NonNull Integer startTimeInterval, @NonNull Integer endTimeInterval, @Nullable AudioStreamingIndicator audioStreamingIndicator) {
+		return new SetMediaClockTimer(UpdateMode.COUNTDOWN, new StartTime(startTimeInterval), new StartTime(endTimeInterval), audioStreamingIndicator);
+	}
+	/**
+	 * Create a media clock timer that counts down, e.g. from 4:18 to 0:00
+	 * This will fail if endTime is greater than startTime
+	 *
+	 * @param startTime               The start time interval, e.g. 4:18
+	 * @param endTime                 The end time interval, e.g. 0:00
+	 * @param audioStreamingIndicator An optional audio indicator to change the play/pause button
+	 * @return An object of SetMediaClockTimer
+	 */
+	public static SetMediaClockTimer countDownFromStartTime(@NonNull StartTime startTime, @NonNull StartTime endTime, @Nullable AudioStreamingIndicator audioStreamingIndicator) {
+		return new SetMediaClockTimer(UpdateMode.COUNTDOWN, startTime, endTime, audioStreamingIndicator);
+	}
+	/**
+	 * Pause an existing (counting up / down) media clock timer
+	 *
+	 * @param audioStreamingIndicator An optional audio indicator to change the play/pause button
+	 * @return An object of SetMediaClockTimer
+	 */
+	public static SetMediaClockTimer pauseWithPlayPauseIndicator(@Nullable AudioStreamingIndicator audioStreamingIndicator) {
+		return new SetMediaClockTimer(UpdateMode.PAUSE, null, null, audioStreamingIndicator);
+	}
+	/**
+	 * Update a pause time (or pause and update the time) on a media clock timer
+	 *
+	 * @param startTimeInterval       The new start time interval
+	 * @param endTimeInterval         The new end time interval
+	 * @param audioStreamingIndicator An optional audio indicator to change the play/pause button
+	 * @return An object of SetMediaClockTimer
+	 */
+	public static SetMediaClockTimer updatePauseWithNewStartTimeInterval(@NonNull Integer startTimeInterval, @NonNull Integer endTimeInterval, @Nullable AudioStreamingIndicator audioStreamingIndicator) {
+		return new SetMediaClockTimer(UpdateMode.PAUSE, new StartTime(startTimeInterval), new StartTime(endTimeInterval), audioStreamingIndicator);
+	}
+	/**
+	 * Update a pause time (or pause and update the time) on a media clock timer
+	 *
+	 * @param startTime               The new start time
+	 * @param endTime                 The new end time
+	 * @param audioStreamingIndicator An optional audio indicator to change the play/pause button
+	 * @return An object of SetMediaClockTimer
+	 */
+	public static SetMediaClockTimer updatePauseWithNewStartTime(@NonNull StartTime startTime, @NonNull StartTime endTime, @Nullable AudioStreamingIndicator audioStreamingIndicator) {
+		return new SetMediaClockTimer(UpdateMode.PAUSE, startTime, endTime, audioStreamingIndicator);
+	}
+	/**
+	 * Resume a paused media clock timer. It resumes at the same time at which it was paused.
+	 *
+	 * @param audioStreamingIndicator An optional audio indicator to change the play/pause button
+	 * @return An object of SetMediaClockTimer
+	 */
+	public static SetMediaClockTimer resumeWithPlayPauseIndicator(@Nullable AudioStreamingIndicator audioStreamingIndicator) {
+		return new SetMediaClockTimer(UpdateMode.RESUME, null, null, audioStreamingIndicator);
+	}
+	/**
+	 * Remove a media clock timer from the screen
+	 *
+	 * @param audioStreamingIndicator An optional audio indicator to change the play/pause button
+	 * @return An object of SetMediaClockTimer
+	 */
+	public static SetMediaClockTimer clearWithPlayPauseIndicator(@Nullable AudioStreamingIndicator audioStreamingIndicator) {
+		return new SetMediaClockTimer(UpdateMode.CLEAR, null, null, audioStreamingIndicator);
 	}
 	/**
 	 * Gets the Start Time which media clock timer is set

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/StartTime.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/StartTime.java
@@ -55,31 +55,32 @@ public class StartTime extends RPCStruct {
     public StartTime(Hashtable<String, Object> hash) {
         super(hash);
     }
+
 	/**
 	 * Constructs a newly allocated StartTime object
 	 * @param timeInterval time interval in seconds
 	 */
 	public StartTime(@NonNull Integer timeInterval){
-        this();
-        int hours = timeInterval / 3600;
-        int minutes = (timeInterval % 3600) / 60;
-        int seconds = timeInterval % 60;
-        setHours(hours);
-        setMinutes(minutes);
-        setSeconds(seconds);
+		this();
+		int hours = timeInterval / 3600;
+		int minutes = (timeInterval % 3600) / 60;
+		int seconds = timeInterval % 60;
+		setHours(hours);
+		setMinutes(minutes);
+		setSeconds(seconds);
 	}
-    /**
-     * Constructs a newly allocated StartTime object
-     * @param hours The hour
-     * @param minutes The minute
-     * @param seconds The second
-     */
-    public StartTime(@NonNull Integer hours, @NonNull Integer minutes, @NonNull Integer seconds){
-        this();
-        setHours(hours);
-        setMinutes(minutes);
-        setSeconds(seconds);
-    }
+	/**
+	 * Constructs a newly allocated StartTime object
+	 * @param hours The hour
+	 * @param minutes The minute
+	 * @param seconds The second
+	 */
+	public StartTime(@NonNull Integer hours, @NonNull Integer minutes, @NonNull Integer seconds){
+		this();
+		setHours(hours);
+		setMinutes(minutes);
+		setSeconds(seconds);
+	}
     /**
      * Get the hour. Minvalue="0", maxvalue="59"
  *					<p><b>Note:</b></p>Some display types only support a max value of 19. If out of range, it will be rejected.

--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/StartTime.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/rpc/StartTime.java
@@ -55,19 +55,31 @@ public class StartTime extends RPCStruct {
     public StartTime(Hashtable<String, Object> hash) {
         super(hash);
     }
-
 	/**
 	 * Constructs a newly allocated StartTime object
-	 * @param hours The hour
-	 * @param minutes The minute
-	 * @param seconds The second
+	 * @param timeInterval time interval in seconds
 	 */
-	public StartTime(@NonNull Integer hours, @NonNull Integer minutes, @NonNull Integer seconds){
-		this();
-		setHours(hours);
-		setMinutes(minutes);
-		setSeconds(seconds);
+	public StartTime(@NonNull Integer timeInterval){
+        this();
+        int hours = timeInterval / 3600;
+        int minutes = (timeInterval % 3600) / 60;
+        int seconds = timeInterval % 60;
+        setHours(hours);
+        setMinutes(minutes);
+        setSeconds(seconds);
 	}
+    /**
+     * Constructs a newly allocated StartTime object
+     * @param hours The hour
+     * @param minutes The minute
+     * @param seconds The second
+     */
+    public StartTime(@NonNull Integer hours, @NonNull Integer minutes, @NonNull Integer seconds){
+        this();
+        setHours(hours);
+        setMinutes(minutes);
+        setSeconds(seconds);
+    }
     /**
      * Get the hour. Minvalue="0", maxvalue="59"
  *					<p><b>Note:</b></p>Some display types only support a max value of 19. If out of range, it will be rejected.


### PR DESCRIPTION
Fixes #856 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests are added to make sure that the values are set correctly in the Initializers

### Summary
This PR implements the updated SetMediaClockTimer Initializers to match the ones in iOS

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
