### PR TITLE
SDL 0196 - Add Support for Static Icons to SDLArtwork

### DIFF
--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/file/FileManagerTests.java
@@ -16,6 +16,7 @@ import com.smartdevicelink.proxy.rpc.PutFile;
 import com.smartdevicelink.proxy.rpc.PutFileResponse;
 import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.Result;
+import com.smartdevicelink.proxy.rpc.enums.StaticIconName;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
 import com.smartdevicelink.test.Test;
 
@@ -213,6 +214,27 @@ public class FileManagerTests extends AndroidTestCase2 {
 						assertFalse(success);
 						assertFalse(fileManager.getRemoteFileNames().contains(validFile.getName()));
 						assertFalse(fileManager.hasUploadedFile(validFile));
+					}
+				});
+			}
+		});
+	}
+
+	public void testFileUploadForStaticIcon(){
+		ISdl internalInterface = mock(ISdl.class);
+
+		doAnswer(onListFilesSuccess).when(internalInterface).sendRPCRequest(any(ListFiles.class));
+
+		final FileManager fileManager = new FileManager(internalInterface, mTestContext);
+		fileManager.start(new CompletionListener() {
+			@Override
+			public void onComplete(boolean success) {
+				assertTrue(success);
+				SdlArtwork artwork = new SdlArtwork(StaticIconName.ALBUM);
+				fileManager.uploadFile(artwork, new CompletionListener() {
+					@Override
+					public void onComplete(boolean success) {
+						assertTrue(success);
 					}
 				});
 			}

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -16,6 +16,7 @@ import com.smartdevicelink.proxy.rpc.enums.FileType;
 import com.smartdevicelink.proxy.rpc.enums.HMILevel;
 import com.smartdevicelink.proxy.rpc.enums.ImageType;
 import com.smartdevicelink.proxy.rpc.enums.SoftButtonType;
+import com.smartdevicelink.proxy.rpc.enums.StaticIconName;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCNotificationListener;
 import com.smartdevicelink.test.Validator;
 
@@ -108,7 +109,7 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
 
         // Create soft button objects
         softButtonState1 = new SoftButtonState("object1-state1", "o1s1", new SdlArtwork("image1", FileType.GRAPHIC_PNG, 1, true));
-        softButtonState2 = new SoftButtonState("object1-state2", "o1s2", new SdlArtwork("image2", FileType.GRAPHIC_PNG, 2, true));
+        softButtonState2 = new SoftButtonState("object1-state2", "o1s2", new SdlArtwork(StaticIconName.ALBUM));
         softButtonObject1 = new SoftButtonObject("object1", Arrays.asList(softButtonState1, softButtonState2), softButtonState1.getName(), null);
         softButtonState3 = new SoftButtonState("object2-state1", "o2s1", null);
         softButtonState4 = new SoftButtonState("object2-state2", "o2s2", new SdlArtwork("image3", FileType.GRAPHIC_PNG, 3, true));
@@ -184,6 +185,8 @@ public class SoftButtonManagerTests extends AndroidTestCase2 {
         // Test SoftButtonState.getArtwork()
         SdlArtwork artworkExpectedValue = new SdlArtwork("image1", FileType.GRAPHIC_PNG, 1, true);
         assertTrue("Returned SdlArtwork doesn't match the expected value", Validator.validateSdlFile(artworkExpectedValue, softButtonState1.getArtwork()));
+        SdlArtwork artworkExpectedValue2 = new SdlArtwork(StaticIconName.ALBUM);
+        assertTrue("Returned SdlArtwork doesn't match the expected value", Validator.validateSdlFile(artworkExpectedValue2, softButtonState2.getArtwork()));
 
 
         // Test SoftButtonState.getSoftButton()

--- a/sdl_android/src/androidTest/java/com/smartdevicelink/test/Validator.java
+++ b/sdl_android/src/androidTest/java/com/smartdevicelink/test/Validator.java
@@ -280,7 +280,7 @@ public class Validator{
             return false;
         }
 
-        if(!( sdlFile1.getType().equals(sdlFile2.getType()) )){
+        if((sdlFile1.getType()!= null && sdlFile2.getType() != null) && !( sdlFile1.getType().equals(sdlFile2.getType()) )){
             log("validateSdlFile",
                     "sdlFile1 type \"" + sdlFile1.getType() + "\" didn't match sdlFile2 type \"" + sdlFile2.getType() + "\".");
             return false;

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/file/FileManager.java
@@ -272,6 +272,11 @@ public class FileManager extends BaseSubManager {
 	 * @param listener called when core responds to the attempt to upload the file
 	 */
 	public void uploadFile(@NonNull final SdlFile file, final CompletionListener listener){
+		if (file.isStaticIcon()){
+			Log.w(TAG, "Static icons don't need to be uploaded");
+			listener.onComplete(true);
+			return;
+		}
 		PutFile putFile = createPutFile(file);
 
 		putFile.setOnRPCResponseListener(new OnRPCResponseListener() {

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
@@ -3,13 +3,17 @@ package com.smartdevicelink.managers.file.filetypes;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import com.smartdevicelink.proxy.rpc.Image;
 import com.smartdevicelink.proxy.rpc.enums.FileType;
+import com.smartdevicelink.proxy.rpc.enums.ImageType;
+import com.smartdevicelink.proxy.rpc.enums.StaticIconName;
 
 /**
  * A class that extends SdlFile, representing artwork (JPEG, PNG, or BMP) to be uploaded to core
  */
 public class SdlArtwork extends SdlFile {
     private boolean isTemplate;
+    private Image imageRPC;
 
     public SdlArtwork(){}
 
@@ -23,6 +27,10 @@ public class SdlArtwork extends SdlFile {
 
     public SdlArtwork(@NonNull String fileName, @NonNull FileType fileType, byte[] data, boolean persistentFile) {
         super(fileName, fileType, data, persistentFile);
+    }
+
+    public SdlArtwork(@NonNull StaticIconName staticIconName) {
+        super(staticIconName);
     }
 
     /**
@@ -49,5 +57,22 @@ public class SdlArtwork extends SdlFile {
         }else{
             throw new IllegalArgumentException("Only JPEG, PNG, and BMP image types are supported.");
         }
+    }
+
+    /**
+     * Get the Image RPC representing this artwork. Generally for use internally, you should instead pass an artwork to a Screen Manager method.
+     * @return The Image RPC representing this artwork.
+     */
+    public Image getImageRPC() {
+        if (imageRPC == null) {
+            if (isStaticIcon()) {
+                imageRPC = new Image(getName(), ImageType.STATIC);
+                imageRPC.setIsTemplate(true);
+            } else {
+                imageRPC = new Image(getName(), ImageType.DYNAMIC);
+                imageRPC.setIsTemplate(isTemplate);
+            }
+        }
+        return imageRPC;
     }
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 
 import com.smartdevicelink.proxy.rpc.enums.FileType;
+import com.smartdevicelink.proxy.rpc.enums.StaticIconName;
 
 /**
  * A class representing data to be uploaded to core
@@ -15,6 +16,8 @@ public class SdlFile{
     private byte[]      fileData;
     private FileType    fileType;
     private boolean     persistentFile;
+    private boolean     isStaticIcon;
+
 
     public SdlFile(){}
 
@@ -37,6 +40,13 @@ public class SdlFile{
         this.fileType = fileType;
         this.fileData = data;
         this.persistentFile = persistentFile;
+    }
+
+    public SdlFile(@NonNull StaticIconName staticIconName){
+        this.fileName = staticIconName.toString();
+        this.fileData = staticIconName.toString().getBytes();
+        this.persistentFile = false;
+        this.isStaticIcon = true;
     }
 
     public void setName(@NonNull String fileName){
@@ -79,5 +89,12 @@ public class SdlFile{
     }
     public boolean isPersistent(){
         return this.persistentFile;
+    }
+
+    public void setStaticIcon(boolean staticIcon) {
+        isStaticIcon = staticIcon;
+    }
+    public boolean isStaticIcon() {
+        return isStaticIcon;
     }
 }

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/SoftButtonManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/SoftButtonManager.java
@@ -287,7 +287,7 @@ class SoftButtonManager extends BaseSubManager {
                 }
                 if (initialState != null && softButtonObject.getStates() != null) {
                     for (SoftButtonState softButtonState : softButtonObject.getStates()) {
-                        if (softButtonState != null && softButtonState.getName() != null && softButtonState.getArtwork() != null && !fileManager.get().hasUploadedFile(softButtonState.getArtwork())) {
+                        if (softButtonState != null && softButtonState.getName() != null && sdlArtworkNeedsUpload(softButtonState.getArtwork())) {
                             if (softButtonState.getName().equals(initialState.getName())) {
                                 initialStatesToBeUploaded.add(softButtonObject.getCurrentState().getArtwork());
                             } else{
@@ -527,12 +527,19 @@ class SoftButtonManager extends BaseSubManager {
         if (fileManager.get() != null) {
             for (SoftButtonObject softButtonObject : softButtonObjects) {
                 SoftButtonState currentState = softButtonObject.getCurrentState();
-                if (currentState != null && currentState.getArtwork() != null && !fileManager.get().hasUploadedFile(currentState.getArtwork())) {
+                if (currentState != null && sdlArtworkNeedsUpload(currentState.getArtwork())) {
                     return false;
                 }
             }
         }
         return true;
+    }
+
+    private boolean sdlArtworkNeedsUpload(SdlArtwork artwork){
+        if (fileManager.get() != null) {
+            return artwork != null && !fileManager.get().hasUploadedFile(artwork) && !artwork.isStaticIcon();
+        }
+        return false;
     }
 
     /**

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/SoftButtonState.java
@@ -54,9 +54,7 @@ public class SoftButtonState {
 
         // Set the SoftButton's image
         if (artwork != null) {
-            Image image = new Image(artwork.getName(), ImageType.DYNAMIC);
-            image.setIsTemplate(artwork.isTemplateImage());
-            softButton.setImage(image);
+            softButton.setImage(artwork.getImageRPC());
         }
 
         // Set the SoftButton's text

--- a/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/managers/screen/TextAndGraphicManager.java
@@ -218,7 +218,7 @@ class TextAndGraphicManager extends BaseSubManager {
 			inProgressUpdate = extractTextFromShow(fullShow);
 			sendShow();
 
-		}else if (isArtworkUploadedOrDoesntExist(primaryGraphic) && ( secondaryGraphic == blankArtwork || isArtworkUploadedOrDoesntExist(secondaryGraphic))){
+		}else if (!sdlArtworkNeedsUpload(primaryGraphic) && (secondaryGraphic == blankArtwork || !sdlArtworkNeedsUpload(secondaryGraphic))){
 
 			//Images already uploaded, sending full update
 			// The files to be updated are already uploaded, send the full show immediately
@@ -298,13 +298,18 @@ class TextAndGraphicManager extends BaseSubManager {
 		List<SdlArtwork> artworksToUpload = new ArrayList<>();
 
 		// add primary image
-		if (shouldUpdatePrimaryImage()){
+		if (shouldUpdatePrimaryImage() && !primaryGraphic.isStaticIcon()){
 			artworksToUpload.add(primaryGraphic);
 		}
 
 		// add secondary image
-		if (shouldUpdateSecondaryImage()){
+		if (shouldUpdateSecondaryImage() && !secondaryGraphic.isStaticIcon()){
 			artworksToUpload.add(secondaryGraphic);
+		}
+
+		if (artworksToUpload.size() == 0 && (primaryGraphic.isStaticIcon() || secondaryGraphic.isStaticIcon())){
+			DebugTool.logInfo("Upload attempted on static icons, sending them without upload instead");
+			listener.onComplete(true);
 		}
 
 		// use file manager to upload art
@@ -326,15 +331,11 @@ class TextAndGraphicManager extends BaseSubManager {
 	private Show assembleShowImages(Show show){
 
 		if (shouldUpdatePrimaryImage()){
-			Image primaryImage = new Image(primaryGraphic.getName(), ImageType.DYNAMIC);
-			primaryImage.setIsTemplate(primaryGraphic.isTemplateImage());
-			show.setGraphic(primaryImage);
+			show.setGraphic(primaryGraphic.getImageRPC());
 		}
 
 		if (shouldUpdateSecondaryImage()){
-			Image secondaryImage = new Image(secondaryGraphic.getName(), ImageType.DYNAMIC);
-			secondaryImage.setIsTemplate(secondaryGraphic.isTemplateImage());
-			show.setSecondaryGraphic(secondaryImage);
+			show.setSecondaryGraphic(secondaryGraphic.getImageRPC());
 		}
 
 		return show;
@@ -683,12 +684,10 @@ class TextAndGraphicManager extends BaseSubManager {
 		return blankArtwork;
 	}
 
-	private boolean isArtworkUploadedOrDoesntExist(SdlArtwork artwork){
-
-		if (fileManager.get() != null){
-			return artwork != null && fileManager.get().hasUploadedFile(artwork);
+	private boolean sdlArtworkNeedsUpload(SdlArtwork artwork){
+		if (fileManager.get() != null) {
+			return artwork != null && !fileManager.get().hasUploadedFile(artwork) && !artwork.isStaticIcon();
 		}
-
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #848 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Unit tests were modified to test static icons additions. 

### Summary
This PR adds support for static icons to SdlArtwork and managers as described in the proposal.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
