### PR TITLE
Add bintray upload support to javaSE & java EE

### DIFF
--- a/javaEE/bintray.gradle
+++ b/javaEE/bintray.gradle
@@ -1,0 +1,96 @@
+apply plugin: "com.jfrog.bintray"
+apply plugin: 'maven-publish'
+apply plugin: 'maven'
+
+def siteUrl = 'https://github.com/smartdevicelink/sdl_android'      // Homepage URL of the library
+def gitUrl = 'https://github.com/smartdevicelink/sdl_android.git'   // Git repository URL
+group = "com.smartdevicelink" // Maven Group ID for the artifact
+def libDescription = 'SmartDeviceLink mobile library'
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+javadoc.failOnError = false
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+bintray {
+    Properties props = new Properties()
+    props.load(new FileInputStream("$projectDir/bintray.properties"))
+
+    // Authorization
+    user = props.getProperty("bintray.user")
+    key = props.getProperty("bintray.key")
+    version = props.getProperty("bintray.version")
+    publications = ['mavenPublication']
+
+
+    pkg {
+        repo = props.getProperty("bintray.repo")
+        name = props.getProperty("bintray.artifact")
+        websiteUrl = siteUrl
+        vcsUrl = gitUrl
+        userOrg = props.getProperty("bintray.userorg")
+        licenses = ["BSD 3-Clause"]
+        publish = props.getProperty("bintray.publish")  // Will upload to jCenter
+        version {
+            name = props.getProperty("bintray.version")  // Change to release version
+            desc = libDescription
+            released  = new Date()  // Will be the current date & time
+            vcsTag = props.getProperty("bintray.vcs") // Should match git tag
+        }
+    }
+}
+
+def pomConfig = {
+    Properties props = new Properties()
+    props.load(new FileInputStream("$projectDir/bintray.properties"))
+    
+    licenses {
+        license {
+            name 'BSD 3-Clause'
+            url 'https://opensource.org/licenses/BSD-3-Clause'
+            distribution "repo"
+        }
+    }
+
+    scm {
+        url siteUrl
+    }
+}
+
+publishing {
+    publications {
+        mavenPublication(MavenPublication) {
+            Properties props = new Properties()
+            props.load(new FileInputStream("$projectDir/bintray.properties"))
+
+            from components.java
+            artifact sourcesJar {
+                classifier "sources"
+            }
+            artifact javadocJar {
+                classifier "javadoc"
+            }
+            groupId props.getProperty("bintray.userorg")
+            artifactId props.getProperty("bintray.artifact")
+            version props.getProperty("bintray.vcs")
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', libDescription)
+                root.appendNode('name', props.getProperty("bintray.artifact"))
+                root.appendNode('url', siteUrl)
+                root.children().last() + pomConfig
+            }
+        }
+    }
+}

--- a/javaEE/bintray.properties
+++ b/javaEE/bintray.properties
@@ -1,0 +1,8 @@
+bintray.user=username
+bintray.key=apikey
+bintray.repo=sdl_android
+bintray.artifact=sdl_android
+bintray.userorg=smartdevicelink
+bintray.publish=true
+bintray.version=X.X.X
+bintray.vcs=X.X.X

--- a/javaEE/bintray.properties
+++ b/javaEE/bintray.properties
@@ -1,7 +1,7 @@
 bintray.user=username
 bintray.key=apikey
-bintray.repo=sdl_android
-bintray.artifact=sdl_android
+bintray.repo=sdl_java_ee
+bintray.artifact=sdl_java_ee
 bintray.userorg=smartdevicelink
 bintray.publish=true
 bintray.version=X.X.X

--- a/javaEE/build.gradle
+++ b/javaEE/build.gradle
@@ -1,11 +1,18 @@
-plugins {
-    id 'java-library'
-}
+apply plugin: 'java-library'
 
 group 'com.smartdevicelink'
 version '4.7.2'
 
 sourceCompatibility = 1.8
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+    }
+}
 
 repositories {
     google()
@@ -28,4 +35,13 @@ jar {
     from {
         configurations.extraLibs.collect { it.isDirectory() ? it : zipTree(it) }
     }
+}
+
+apply from: 'bintray.gradle'
+
+// Excluded :javaSE:bintrayUpload from running when we run bintrayUpload in javaEE
+def taskRequests = gradle.startParameter.taskRequests
+def runTaskRequest = taskRequests.find { it.args.contains('bintrayUpload') }
+if (runTaskRequest) {
+    gradle.startParameter.excludedTaskNames = [':javaSE:bintrayUpload']
 }

--- a/javaSE/bintray.gradle
+++ b/javaSE/bintray.gradle
@@ -1,0 +1,96 @@
+apply plugin: "com.jfrog.bintray"
+apply plugin: 'maven-publish'
+apply plugin: 'maven'
+
+def siteUrl = 'https://github.com/smartdevicelink/sdl_android'      // Homepage URL of the library
+def gitUrl = 'https://github.com/smartdevicelink/sdl_android.git'   // Git repository URL
+group = "com.smartdevicelink" // Maven Group ID for the artifact
+def libDescription = 'SmartDeviceLink mobile library'
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+javadoc.failOnError = false
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+bintray {
+    Properties props = new Properties()
+    props.load(new FileInputStream("$projectDir/bintray.properties"))
+
+    // Authorization
+    user = props.getProperty("bintray.user")
+    key = props.getProperty("bintray.key")
+    version = props.getProperty("bintray.version")
+    publications = ['mavenPublication']
+
+
+    pkg {
+        repo = props.getProperty("bintray.repo")
+        name = props.getProperty("bintray.artifact")
+        websiteUrl = siteUrl
+        vcsUrl = gitUrl
+        userOrg = props.getProperty("bintray.userorg")
+        licenses = ["BSD 3-Clause"]
+        publish = props.getProperty("bintray.publish")  // Will upload to jCenter
+        version {
+            name = props.getProperty("bintray.version")  // Change to release version
+            desc = libDescription
+            released  = new Date()  // Will be the current date & time
+            vcsTag = props.getProperty("bintray.vcs") // Should match git tag
+        }
+    }
+}
+
+def pomConfig = {
+    Properties props = new Properties()
+    props.load(new FileInputStream("$projectDir/bintray.properties"))
+    
+    licenses {
+        license {
+            name 'BSD 3-Clause'
+            url 'https://opensource.org/licenses/BSD-3-Clause'
+            distribution "repo"
+        }
+    }
+
+    scm {
+        url siteUrl
+    }
+}
+
+publishing {
+    publications {
+        mavenPublication(MavenPublication) {
+            Properties props = new Properties()
+            props.load(new FileInputStream("$projectDir/bintray.properties"))
+
+            from components.java
+            artifact sourcesJar {
+                classifier "sources"
+            }
+            artifact javadocJar {
+                classifier "javadoc"
+            }
+            groupId props.getProperty("bintray.userorg")
+            artifactId props.getProperty("bintray.artifact")
+            version props.getProperty("bintray.vcs")
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', libDescription)
+                root.appendNode('name', props.getProperty("bintray.artifact"))
+                root.appendNode('url', siteUrl)
+                root.children().last() + pomConfig
+            }
+        }
+    }
+}

--- a/javaSE/bintray.properties
+++ b/javaSE/bintray.properties
@@ -1,0 +1,8 @@
+bintray.user=username
+bintray.key=apikey
+bintray.repo=sdl_android
+bintray.artifact=sdl_android
+bintray.userorg=smartdevicelink
+bintray.publish=true
+bintray.version=X.X.X
+bintray.vcs=X.X.X

--- a/javaSE/bintray.properties
+++ b/javaSE/bintray.properties
@@ -1,7 +1,7 @@
 bintray.user=username
 bintray.key=apikey
-bintray.repo=sdl_android
-bintray.artifact=sdl_android
+bintray.repo=sdl_java_se
+bintray.artifact=sdl_java_se
 bintray.userorg=smartdevicelink
 bintray.publish=true
 bintray.version=X.X.X

--- a/javaSE/build.gradle
+++ b/javaSE/build.gradle
@@ -1,11 +1,19 @@
-plugins {
-    id 'java-library'
-}
+apply plugin: 'java-library'
 
 group 'com.smartdevicelink'
 version '4.7.2'
 
 sourceCompatibility = 1.8
+
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+    }
+}
 
 repositories {
     google()
@@ -49,4 +57,7 @@ public final class BuildConfig {
 }""")
     }
 }
+
 compileJava.dependsOn generateSources
+
+apply from: 'bintray.gradle'


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Update bintray.properties file then try to run `gradle bintrayUpload` for javaSE and javaEE and make sure it actually uploads to bintray.

### Summary
This PR adds bintray support to javaSE and javaEE in a way that is similar to how it works for Android.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
