### PR TITLE
Cloud RPC Request Listeners

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -158,6 +158,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 								OUTGOING_MESSAGE_QUEUE_THREAD_LOCK = new Object(),
 								INTERNAL_MESSAGE_QUEUE_THREAD_LOCK = new Object(),
 								ON_UPDATE_LISTENER_LOCK = new Object(),
+								RPC_LISTENER_LOCK = new Object(),
 								ON_NOTIFICATION_LISTENER_LOCK = new Object();
 	
 	private final Object APP_INTERFACE_REGISTERED_LOCK = new Object();
@@ -259,6 +260,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	protected SparseArray<OnRPCResponseListener> rpcResponseListeners = null;
 	protected SparseArray<CopyOnWriteArrayList<OnRPCNotificationListener>> rpcNotificationListeners = null;
 	protected SparseArray<CopyOnWriteArrayList<OnRPCRequestListener>> rpcRequestListeners = null;
+	protected SparseArray<CopyOnWriteArrayList<OnRPCListener>> rpcListeners = null;
 
 	protected VideoStreamingManager manager; //Will move to SdlSession once the class becomes public
 
@@ -365,14 +367,12 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 		@Override
 		public void addOnRPCListener(FunctionID responseId, OnRPCListener listener) {
-			DebugTool.logError("Proxy.addOnRPCResponseListener() is not implemented yet");
-
+			SdlProxyBase.this.addOnRPCListener(responseId, listener);
 		}
 
 		@Override
 		public boolean removeOnRPCListener(FunctionID responseId, OnRPCListener listener) {
-			DebugTool.logError("Proxy.removeOnRPCResponseListener() is not implemented yet");
-			return false;
+			return SdlProxyBase.this.removeOnRPCListener(responseId, listener);
 		}
 
 		@Override
@@ -940,6 +940,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 		rpcResponseListeners = new SparseArray<OnRPCResponseListener>();
 		rpcNotificationListeners = new SparseArray<CopyOnWriteArrayList<OnRPCNotificationListener>>();
 		rpcRequestListeners = new SparseArray<CopyOnWriteArrayList<OnRPCRequestListener>>();
+		rpcListeners = new SparseArray<CopyOnWriteArrayList<OnRPCListener>>();
 
 		// Initialize the proxy
 		try {
@@ -2195,6 +2196,20 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	}
 
 	@SuppressWarnings("UnusedReturnValue")
+	public boolean onRPCReceived(RPCMessage message){
+		synchronized(RPC_LISTENER_LOCK){
+			CopyOnWriteArrayList<OnRPCListener> listeners = rpcListeners.get(FunctionID.getFunctionId(message.getFunctionName()));
+			if(listeners!=null && listeners.size()>0) {
+				for (OnRPCListener listener : listeners) {
+					listener.onReceived(message);
+				}
+				return true;
+			}
+			return false;
+		}
+	}
+
+	@SuppressWarnings("UnusedReturnValue")
 	public boolean onRPCRequestReceived(RPCRequest request){
 		synchronized(ON_NOTIFICATION_LISTENER_LOCK){
 			CopyOnWriteArrayList<OnRPCRequestListener> listeners = rpcRequestListeners.get(FunctionID.getFunctionId(request.getFunctionName()));
@@ -2227,7 +2242,37 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	}
 
 	/**
-	 * This will ad a listener for the specific type of request. As of now it will only allow
+	 * This will add a listener for the specific type of message. As of now it will only allow
+	 * a single listener per request function id
+	 * @param messageId The message type that this listener is designated for
+	 * @param listener The listener that will be called when a request of the provided type is received
+	 */
+	@SuppressWarnings("unused")
+	public void addOnRPCListener(FunctionID messageId, OnRPCListener listener){
+		synchronized(RPC_LISTENER_LOCK){
+			if(messageId != null && listener != null){
+				if(rpcListeners.indexOfKey(messageId.getId()) < 0 ){
+					rpcListeners.put(messageId.getId(),new CopyOnWriteArrayList<OnRPCListener>());
+				}
+				rpcListeners.get(messageId.getId()).add(listener);
+			}
+		}
+	}
+
+	public boolean removeOnRPCListener(FunctionID messageId, OnRPCListener listener){
+		synchronized(RPC_LISTENER_LOCK){
+			if(rpcListeners!= null
+					&& messageId != null
+					&& listener != null
+					&& rpcListeners.indexOfKey(messageId.getId()) >= 0){
+				return rpcListeners.get(messageId.getId()).remove(listener);
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * This will add a listener for the specific type of request. As of now it will only allow
 	 * a single listener per request function id
 	 * @param requestId The request type that this listener is designated for
 	 * @param listener The listener that will be called when a request of the provided type is received
@@ -2330,22 +2375,25 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	}
 	
 	private void handleRPCMessage(Hashtable<String, Object> hash) {
-		RPCMessage rpcMsg = new RPCMessage(hash);
-		//Call format to ensure the RPC is ready to be handled regardless of RPC spec version
+
+		RPCMessage rpcMsg = RpcConverter.convertTableToRpc(hash);
+
+		SdlTrace.logRPCEvent(InterfaceActivityDirection.Receive, rpcMsg, SDL_LIB_TRACE_KEY);
+
 		String functionName = rpcMsg.getFunctionName();
 		String messageType = rpcMsg.getMessageType();
 
-		SdlTrace.logRPCEvent(InterfaceActivityDirection.Receive, rpcMsg, SDL_LIB_TRACE_KEY);
+		if (rpcMsg != null) {
+			rpcMsg.format(rpcSpecVersion, true);
+			onRPCReceived(rpcMsg);
+		}
 
 		// Requests need to be listened for using the SDLManager's addOnRPCRequestListener method.
 		// Requests are not supported by IProxyListenerBase
 		if (messageType.equals(RPCMessage.KEY_REQUEST)) {
 
-			RPCMessage convertedRPCMsg = RpcConverter.convertTableToRpc(hash);
-
-			if (convertedRPCMsg != null) {
-				convertedRPCMsg.format(rpcSpecVersion, true);
-				onRPCRequestReceived((RPCRequest) convertedRPCMsg);
+			if (rpcMsg != null) {
+				onRPCRequestReceived((RPCRequest) rpcMsg);
 			}else{
 				DebugTool.logError("Received a null RPC Request, discarding.");
 			}
@@ -3089,14 +3137,6 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
                 // SetDisplayLayout
                 final SetDisplayLayoutResponse msg = new SetDisplayLayoutResponse(hash);
 				msg.format(rpcSpecVersion,true);
-                // successfully changed display layout - update layout capabilities
-                if(msg.getSuccess() && _systemCapabilityManager!=null){
-					_systemCapabilityManager.setCapability(SystemCapabilityType.DISPLAY, msg.getDisplayCapabilities());
-					_systemCapabilityManager.setCapability(SystemCapabilityType.BUTTON, msg.getButtonCapabilities());
-					_systemCapabilityManager.setCapability(SystemCapabilityType.PRESET_BANK, msg.getPresetBankCapabilities());
-					_systemCapabilityManager.setCapability(SystemCapabilityType.SOFTBUTTON, msg.getSoftButtonCapabilities());
-                }
-                
                 if (_callbackToUIThread) {
                     // Run in UI thread
                     _mainUIHandler.post(new Runnable() {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2376,27 +2376,32 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	
 	private void handleRPCMessage(Hashtable<String, Object> hash) {
 
+		if (hash == null){
+			DebugTool.logError("handleRPCMessage: hash is null, returning.");
+			return;
+		}
+
 		RPCMessage rpcMsg = RpcConverter.convertTableToRpc(hash);
+
+		if (rpcMsg == null){
+			DebugTool.logError("handleRPCMessage: rpcMsg is null, returning.");
+			return;
+		}
 
 		SdlTrace.logRPCEvent(InterfaceActivityDirection.Receive, rpcMsg, SDL_LIB_TRACE_KEY);
 
 		String functionName = rpcMsg.getFunctionName();
 		String messageType = rpcMsg.getMessageType();
 
-		if (rpcMsg != null) {
-			rpcMsg.format(rpcSpecVersion, true);
-			onRPCReceived(rpcMsg);
-		}
+		rpcMsg.format(rpcSpecVersion, true);
+
+		onRPCReceived(rpcMsg); // Should only be called for internal use
 
 		// Requests need to be listened for using the SDLManager's addOnRPCRequestListener method.
 		// Requests are not supported by IProxyListenerBase
 		if (messageType.equals(RPCMessage.KEY_REQUEST)) {
 
-			if (rpcMsg != null) {
-				onRPCRequestReceived((RPCRequest) rpcMsg);
-			}else{
-				DebugTool.logError("Received a null RPC Request, discarding.");
-			}
+			onRPCRequestReceived((RPCRequest) rpcMsg);
 
 		} else if (messageType.equals(RPCMessage.KEY_RESPONSE)) {
 			// Check to ensure response is not from an internal message (reserved correlation ID)

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -98,7 +98,6 @@ import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.util.CorrelationIdGenerator;
 import com.smartdevicelink.util.DebugTool;
 import com.smartdevicelink.util.FileUtls;
-import com.smartdevicelink.util.HttpUtils;
 import com.smartdevicelink.util.Version;
 
 import org.json.JSONArray;

--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseScreenManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseScreenManager.java
@@ -348,7 +348,9 @@ abstract public class BaseScreenManager extends BaseSubManager {
 						if (!success){
 							updateSuccessful = false;
 						}
-						listener.onComplete(updateSuccessful);
+						if (listener != null) {
+							listener.onComplete(updateSuccessful);
+						}
 					}
 				});
 			}

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -16,8 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import static com.smartdevicelink.protocol.enums.FunctionID.SET_DISPLAY_LAYOUT;
-
 public class SystemCapabilityManager {
 	private final HashMap<SystemCapabilityType, Object> cachedSystemCapabilities;
 	private final HashMap<SystemCapabilityType, CopyOnWriteArrayList<OnSystemCapabilityListener>> onSystemCapabilityListeners;

--- a/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/SdlManager.java
@@ -21,6 +21,7 @@ import com.smartdevicelink.proxy.rpc.enums.*;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCListener;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCNotificationListener;
+import com.smartdevicelink.proxy.rpc.listeners.OnRPCRequestListener;
 import com.smartdevicelink.security.SdlSecurityBase;
 import com.smartdevicelink.streaming.audio.AudioStreamingCodec;
 import com.smartdevicelink.streaming.audio.AudioStreamingParams;
@@ -435,14 +436,10 @@ public class SdlManager extends BaseSdlManager{
 
 	/**
 	 * Send RPC Message <br>
-	 * <strong>Note: Only takes type of RPCRequest for now, notifications and responses will be thrown out</strong>
 	 * @param message RPCMessage
 	 */
 	public void sendRPC(RPCMessage message) {
-
-		if (message instanceof RPCRequest){
-			proxy.sendRpc(message);
-		}
+		proxy.sendRpc(message);
 	}
 
 	/**
@@ -518,6 +515,22 @@ public class SdlManager extends BaseSdlManager{
 	 */
 	public void removeOnRPCNotificationListener(FunctionID notificationId, OnRPCNotificationListener listener){
 		proxy.removeOnRPCNotificationListener(notificationId, listener);
+	}
+
+	/**
+	 * Add an OnRPCRequestListener
+	 * @param listener listener that will be called when a request is received
+	 */
+	public void addOnRPCRequestListener(FunctionID requestId, OnRPCRequestListener listener){
+		proxy.addOnRPCRequestListener(requestId,listener);
+	}
+
+	/**
+	 * Remove an OnRPCRequestListener
+	 * @param listener listener that was previously added
+	 */
+	public void removeOnRPCRequestListener(FunctionID requestId, OnRPCRequestListener listener){
+		proxy.removeOnRPCRequestListener(requestId, listener);
 	}
 
 	// LIFECYCLE / OTHER

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -495,7 +495,7 @@ public class LifecycleManager extends BaseLifecycleManager {
     }
 
     @SuppressWarnings("UnusedReturnValue")
-    public boolean onRPCRequestReceived(RPCRequest request){
+    private boolean onRPCRequestReceived(RPCRequest request){
         if(request == null){
             DebugTool.logError("onRPCRequestReceived - request was null");
             return false;
@@ -532,6 +532,7 @@ public class LifecycleManager extends BaseLifecycleManager {
         }
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     public boolean removeOnRPCRequestListener(FunctionID requestId, OnRPCRequestListener listener){
         synchronized(ON_REQUEST_LISTENER_LOCK){
             if(rpcRequestListeners!= null

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -3,7 +3,6 @@ package com.smartdevicelink.managers.lifecycle;
 import android.util.Log;
 import com.smartdevicelink.SdlConnection.SdlSession;
 import com.smartdevicelink.exception.SdlException;
-import com.smartdevicelink.exception.SdlExceptionCause;
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
 import com.smartdevicelink.protocol.ProtocolMessage;
 import com.smartdevicelink.protocol.enums.FunctionID;

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -452,7 +452,7 @@ public class LifecycleManager extends BaseLifecycleManager {
     }
 
     /**
-     * This will ad a listener for the specific type of notification. As of now it will only allow
+     * This will add a listener for the specific type of notification. As of now it will only allow
      * a single listener per notification function id
      * @param notificationId The notification type that this listener is designated for
      * @param listener The listener that will be called when a notification of the provided type is received
@@ -515,7 +515,7 @@ public class LifecycleManager extends BaseLifecycleManager {
     }
 
     /**
-     * This will ad a listener for the specific type of request. As of now it will only allow
+     * This will add a listener for the specific type of request. As of now it will only allow
      * a single listener per notification function id
      * @param requestId The request type that this listener is designated for
      * @param listener The listener that will be called when a request of the provided type is received

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -1,9 +1,9 @@
 package com.smartdevicelink.managers.lifecycle;
 
-import android.support.annotation.NonNull;
 import android.util.Log;
 import com.smartdevicelink.SdlConnection.SdlSession;
 import com.smartdevicelink.exception.SdlException;
+import com.smartdevicelink.exception.SdlExceptionCause;
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
 import com.smartdevicelink.protocol.ProtocolMessage;
 import com.smartdevicelink.protocol.enums.FunctionID;
@@ -46,6 +46,7 @@ public class LifecycleManager extends BaseLifecycleManager {
     // Sdl Synchronization Objects
     private static final Object  RPC_LISTENER_LOCK = new Object(),
                                  ON_UPDATE_LISTENER_LOCK = new Object(),
+                                 ON_REQUEST_LISTENER_LOCK = new Object(),
                                  ON_NOTIFICATION_LISTENER_LOCK = new Object();
 
 
@@ -57,9 +58,10 @@ public class LifecycleManager extends BaseLifecycleManager {
     protected Version rpcSpecVersion = MAX_SUPPORTED_RPC_VERSION;
 
     //FIXME these were sparse arrays in android
-    protected final  HashMap<Integer,CopyOnWriteArrayList<OnRPCListener>> rpcListeners;
-    protected final HashMap<Integer, OnRPCResponseListener> rpcResponseListeners;
-    protected final HashMap<Integer, CopyOnWriteArrayList<OnRPCNotificationListener>> rpcNotificationListeners;
+    private final HashMap<Integer,CopyOnWriteArrayList<OnRPCListener>> rpcListeners;
+    private final HashMap<Integer, OnRPCResponseListener> rpcResponseListeners;
+    private final HashMap<Integer, CopyOnWriteArrayList<OnRPCNotificationListener>> rpcNotificationListeners;
+    private final HashMap<Integer, CopyOnWriteArrayList<OnRPCRequestListener>> rpcRequestListeners;
 
     protected final SystemCapabilityManager systemCapabilityManager;
 
@@ -82,6 +84,7 @@ public class LifecycleManager extends BaseLifecycleManager {
         this.rpcListeners = new HashMap<>();
         this.rpcResponseListeners = new HashMap<>();
         this.rpcNotificationListeners = new HashMap<>();
+        this.rpcRequestListeners = new HashMap<>();
 
         this.appConfig = appConfig;
         this.session = new SdlSession(this, config);
@@ -491,7 +494,55 @@ public class LifecycleManager extends BaseLifecycleManager {
         return false;
     }
 
+    @SuppressWarnings("UnusedReturnValue")
+    public boolean onRPCRequestReceived(RPCRequest request){
+        if(request == null){
+            DebugTool.logError("onRPCRequestReceived - request was null");
+            return false;
+        }
+        DebugTool.logInfo("onRPCRequestReceived - " + request.getFunctionName() );
 
+        synchronized(ON_REQUEST_LISTENER_LOCK){
+            CopyOnWriteArrayList<OnRPCRequestListener> listeners = rpcRequestListeners.get(FunctionID.getFunctionId(request.getFunctionName()));
+            if(listeners!=null && listeners.size()>0) {
+                for (OnRPCRequestListener listener : listeners) {
+                    listener.onRequest(request);
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+
+    /**
+     * This will ad a listener for the specific type of request. As of now it will only allow
+     * a single listener per notification function id
+     * @param requestId The request type that this listener is designated for
+     * @param listener The listener that will be called when a request of the provided type is received
+     */
+    @SuppressWarnings("unused")
+    public void addOnRPCRequestListener(FunctionID requestId, OnRPCRequestListener listener){
+        synchronized(ON_REQUEST_LISTENER_LOCK){
+            if(requestId != null && listener != null){
+                if(!rpcRequestListeners.containsKey(requestId.getId())){
+                    rpcRequestListeners.put(requestId.getId(),new CopyOnWriteArrayList<OnRPCRequestListener>());
+                }
+                rpcRequestListeners.get(requestId.getId()).add(listener);
+            }
+        }
+    }
+
+    public boolean removeOnRPCRequestListener(FunctionID requestId, OnRPCRequestListener listener){
+        synchronized(ON_REQUEST_LISTENER_LOCK){
+            if(rpcRequestListeners!= null
+                    && requestId != null
+                    && listener != null
+                    && rpcRequestListeners.containsKey(requestId.getId())){
+                return rpcRequestListeners.get(requestId.getId()).remove(listener);
+            }
+        }
+        return false;
+    }
 
     /* *******************************************************************************************************
      **************************************** RPC LISTENERS !! END !! ****************************************
@@ -522,7 +573,8 @@ public class LifecycleManager extends BaseLifecycleManager {
 
                        //FIXME Log error here
                        //throw new SdlException("CorrelationID cannot be null. RPC: " + message.getFunctionName(), SdlExceptionCause.INVALID_ARGUMENT);
-                       Log.e(TAG, "No correlation ID attatched to request. Not sending");
+                       Log.e(TAG, "No correlation ID attached to request. Not sending");
+                       return;
                    }else{
                        pm.setCorrID(corrId);
 
@@ -531,6 +583,16 @@ public class LifecycleManager extends BaseLifecycleManager {
                            addOnRPCResponseListener(listener, corrId, msgBytes.length);
                        }
                    }
+            }else if (RPCMessage.KEY_RESPONSE.equals(message.getMessageType())){
+                RPCResponse response = (RPCResponse) message;
+                if (response.getCorrelationID() == null) {
+                    //Log error here
+                    //throw new SdlException("CorrelationID cannot be null. RPC: " + response.getFunctionName(), SdlExceptionCause.INVALID_ARGUMENT);
+                    Log.e(TAG, "No correlation ID attached to response. Not sending");
+                    return;
+                } else {
+                    pm.setCorrID(response.getCorrelationID());
+                }
             }
 
             if (message.getBulkData() != null){
@@ -602,6 +664,11 @@ public class LifecycleManager extends BaseLifecycleManager {
                     }else if(RPCMessage.KEY_NOTIFICATION.equals(messageType)){
 
                         onRPCNotificationReceived((RPCNotification)rpc);
+
+                    } else if (RPCMessage.KEY_REQUEST.equals(messageType)){
+
+                        onRPCRequestReceived((RPCRequest) rpc);
+
                     }
                 }else{
                     Log.w(TAG, "Shouldn't be here");
@@ -970,6 +1037,9 @@ public class LifecycleManager extends BaseLifecycleManager {
         }
         if (rpcNotificationListeners != null) {
             rpcNotificationListeners.clear();
+        }
+        if (rpcRequestListeners != null) {
+            rpcRequestListeners.clear();
         }
         if (session != null && session.getIsConnected()) {
             session.close();

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -516,7 +516,7 @@ public class LifecycleManager extends BaseLifecycleManager {
 
     /**
      * This will add a listener for the specific type of request. As of now it will only allow
-     * a single listener per notification function id
+     * a single listener per request function id
      * @param requestId The request type that this listener is designated for
      * @param listener The listener that will be called when a request of the provided type is received
      */

--- a/javaSE/src/main/java/hello_sdl/Main.java
+++ b/javaSE/src/main/java/hello_sdl/Main.java
@@ -7,12 +7,14 @@ import com.smartdevicelink.managers.lifecycle.LifecycleManager;
 import com.smartdevicelink.marshal.JsonRPCMarshaller;
 import com.smartdevicelink.protocol.enums.FunctionID;
 import com.smartdevicelink.proxy.RPCNotification;
+import com.smartdevicelink.proxy.RPCRequest;
 import com.smartdevicelink.proxy.callbacks.OnServiceEnded;
 import com.smartdevicelink.proxy.callbacks.OnServiceNACKed;
 import com.smartdevicelink.proxy.rpc.*;
 import com.smartdevicelink.proxy.rpc.enums.HMILevel;
 import com.smartdevicelink.proxy.rpc.enums.SdlDisconnectedReason;
 import com.smartdevicelink.proxy.rpc.listeners.OnRPCNotificationListener;
+import com.smartdevicelink.proxy.rpc.listeners.OnRPCRequestListener;
 import com.smartdevicelink.transport.WebSocketServerConfig;
 import com.smartdevicelink.util.Version;
 import org.json.JSONException;
@@ -24,7 +26,8 @@ public class Main {
 
     public static void main(String[] args) {
        // testRAIString();
-        startSdl();
+        //startSdl();
+        attemptSdlManager();
     }
 
     public static void testRAI(){
@@ -83,9 +86,18 @@ public class Main {
                                 show.setMainField2("YEET THAT SUCKER!");
                                 manager.sendRPC(show);
                                 Log.i(TAG, "Attempting sending show");
-
-
                             }
+                        }
+                    }
+                });
+
+                manager.addOnRPCRequestListener(FunctionID.BUTTON_PRESS, new OnRPCRequestListener() {
+                    @Override
+                    public void onRequest(RPCRequest request) {
+                        try {
+                            Log.i(TAG, request.serializeJSON().toString());
+                        } catch (JSONException e) {
+                            e.printStackTrace();
                         }
                     }
                 });
@@ -103,10 +115,10 @@ public class Main {
             }
         });
         //FIXME have to add websocket setting
-       SdlManager manager =  builder.build();
-       manager.start();
-
-
+        WebSocketServerConfig serverConfig = new WebSocketServerConfig(5679,0);
+        builder.setTransportType(serverConfig);
+        SdlManager manager =  builder.build();
+        manager.start();
     }
 
     public static void startSdl(){

--- a/javaSE/src/main/java/hello_sdl/Main.java
+++ b/javaSE/src/main/java/hello_sdl/Main.java
@@ -91,7 +91,7 @@ public class Main {
                     }
                 });
 
-                manager.addOnRPCRequestListener(FunctionID.BUTTON_PRESS, new OnRPCRequestListener() {
+                manager.addOnRPCRequestListener(FunctionID.SEND_LOCATION, new OnRPCRequestListener() {
                     @Override
                     public void onRequest(RPCRequest request) {
                         try {


### PR DESCRIPTION
- JAVA: Add ability to listen for requests
- JAVA: allow sending of notifications and responses
- ANDROID: hook up `addOnRPCListener` and `removeOnRPCListener` in proxy base
- ANDROID: remove direct call to SCM from `sendDisplayLayoutResponse` in proxy base 