### PR TITLE
Fix the UnsubscribeVehicleData.setCloudAppVehicleID() method 

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/UnsubscribeVehicleDataTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/requests/UnsubscribeVehicleDataTests.java
@@ -53,6 +53,7 @@ public class UnsubscribeVehicleDataTests extends BaseRpcTests {
 		msg.setFuelRange(Test.GENERAL_BOOLEAN);
 		msg.setTurnSignal(Test.GENERAL_BOOLEAN);
 		msg.setElectronicParkBrakeStatus(Test.GENERAL_BOOLEAN);
+		msg.setCloudAppVehicleID(Test.GENERAL_BOOLEAN);
 
 		return msg;
 	}
@@ -99,7 +100,8 @@ public class UnsubscribeVehicleDataTests extends BaseRpcTests {
             result.put(UnsubscribeVehicleData.KEY_MY_KEY, Test.GENERAL_BOOLEAN);
             result.put(UnsubscribeVehicleData.KEY_FUEL_RANGE, Test.GENERAL_BOOLEAN);
             result.put(UnsubscribeVehicleData.KEY_TURN_SIGNAL, Test.GENERAL_BOOLEAN);
-            result.put(UnsubscribeVehicleData.KEY_ELECTRONIC_PARK_BRAKE_STATUS, Test.GENERAL_BOOLEAN);
+			result.put(UnsubscribeVehicleData.KEY_ELECTRONIC_PARK_BRAKE_STATUS, Test.GENERAL_BOOLEAN);
+			result.put(UnsubscribeVehicleData.KEY_CLOUD_APP_VEHICLE_ID, Test.GENERAL_BOOLEAN);
 		} catch (JSONException e) {
 			fail(Test.JSON_FAIL);
 		}
@@ -140,6 +142,7 @@ public class UnsubscribeVehicleDataTests extends BaseRpcTests {
 		assertTrue(Test.TRUE,( (UnsubscribeVehicleData) msg ).getFuelRange());
 		assertTrue(Test.TRUE,( (UnsubscribeVehicleData) msg ).getTurnSignal());
 		assertTrue(Test.TRUE,( (UnsubscribeVehicleData) msg ).getElectronicParkBrakeStatus());
+		assertTrue(Test.TRUE,( (UnsubscribeVehicleData) msg ).getCloudAppVehicleID());
 		
 		// Invalid/Null Tests
 		UnsubscribeVehicleData msg = new UnsubscribeVehicleData();
@@ -173,7 +176,8 @@ public class UnsubscribeVehicleDataTests extends BaseRpcTests {
         assertNull(Test.NULL, msg.getMyKey());
         assertNull(Test.NULL, msg.getFuelRange());
         assertNull(Test.NULL, msg.getTurnSignal());
-        assertNull(Test.NULL, msg.getElectronicParkBrakeStatus());
+		assertNull(Test.NULL, msg.getElectronicParkBrakeStatus());
+		assertNull(Test.NULL, msg.getCloudAppVehicleID());
 	}
 
 	/**
@@ -223,6 +227,8 @@ public class UnsubscribeVehicleDataTests extends BaseRpcTests {
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, UnsubscribeVehicleData.KEY_FUEL_RANGE), cmd.getFuelRange());
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, UnsubscribeVehicleData.KEY_TURN_SIGNAL), cmd.getTurnSignal());
 			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, UnsubscribeVehicleData.KEY_ELECTRONIC_PARK_BRAKE_STATUS), cmd.getElectronicParkBrakeStatus());
+			assertEquals(Test.MATCH, JsonUtils.readBooleanFromJsonObject(parameters, UnsubscribeVehicleData.KEY_CLOUD_APP_VEHICLE_ID), cmd.getCloudAppVehicleID());
+
 		} 
 		catch (JSONException e) {
 			fail(Test.JSON_FAIL);

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
@@ -24,7 +24,7 @@ import java.util.Hashtable;
  * 		<tr>
  * 			<td>gps</td>
  * 			<td>Boolean</td>
- * 			<td>GPS data. See {@linkplain GPSdata} for details</td>
+ * 			<td>GPS data. See {@linkplain GPSData} for details</td>
  *                 <td>N</td>
  *                 <td>Subscribable</td>
  * 			<td>SmartDeviceLink 2.0 </td>
@@ -808,7 +808,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
 	 * Sets cloudAppVehicleID
 	 * @param cloudAppVehicleID a boolean value
 	 */
-	public void setCloudAppVehicleID(VehicleDataResult cloudAppVehicleID){
+	public void setCloudAppVehicleID(boolean cloudAppVehicleID){
 		setParameters(KEY_CLOUD_APP_VEHICLE_ID, cloudAppVehicleID);
 	}
 
@@ -816,7 +816,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
 	 * Gets a boolean value. If true, means the cloudAppVehicleDataID data should be  unsubscribed.
 	 * @return a Boolean value.
 	 */
-	public VehicleDataResult getCloudAppVehicleID(){
-		return (VehicleDataResult) getObject(VehicleDataResult.class, KEY_CLOUD_APP_VEHICLE_ID);
+	public Boolean getCloudAppVehicleID(){
+		return getBoolean( KEY_CLOUD_APP_VEHICLE_ID);
 	}
 }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/UnsubscribeVehicleData.java
@@ -297,7 +297,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes Gps data
+	 * Sets a boolean value. If true, unsubscribes from Gps data
 	 * 
 	 * @param gps
 	 *            a boolean value
@@ -317,7 +317,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes speed data
+	 * Sets a boolean value. If true, unsubscribes from speed data
 	 * 
 	 * @param speed
 	 *            a boolean value
@@ -357,7 +357,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes FuelLevel data
+	 * Sets a boolean value. If true, unsubscribes from FuelLevel data
 	 * 
 	 * @param fuelLevel
 	 *            a boolean value
@@ -378,7 +378,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
     /**
-     * Sets a boolean value. If true, unsubscribes fuelLevel_State data
+     * Sets a boolean value. If true, unsubscribes from fuelLevel_State data
      * 
      * @param fuelLevel_State
      *            a boolean value
@@ -401,7 +401,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
     /**
-     * Sets a boolean value. If true, unsubscribes fuelLevelState data
+     * Sets a boolean value. If true, unsubscribes from fuelLevelState data
      * 
      * @param fuelLevelState
      *            a boolean value
@@ -422,7 +422,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes instantFuelConsumption data
+	 * Sets a boolean value. If true, unsubscribes from instantFuelConsumption data
 	 * 
 	 * @param instantFuelConsumption
 	 *            a boolean value
@@ -443,7 +443,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes externalTemperature data
+	 * Sets a boolean value. If true, unsubscribes from externalTemperature data
 	 * 
 	 * @param externalTemperature
 	 *            a boolean value
@@ -485,7 +485,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes tire pressure status data
+	 * Sets a boolean value. If true, unsubscribes from tire pressure status data
 	 * 
 	 * @param tirePressure
 	 *            a boolean value
@@ -506,7 +506,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes odometer data
+	 * Sets a boolean value. If true, unsubscribes from odometer data
 	 * 
 	 * @param odometer
 	 *            a boolean value
@@ -527,7 +527,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes belt Status data
+	 * Sets a boolean value. If true, unsubscribes from belt Status data
 	 * 
 	 * @param beltStatus
 	 *            a boolean value
@@ -548,7 +548,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes body Information data
+	 * Sets a boolean value. If true, unsubscribes from body Information data
 	 * 
 	 * @param bodyInformation
 	 *            a boolean value
@@ -569,7 +569,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes device Status data
+	 * Sets a boolean value. If true, unsubscribes from device Status data
 	 * 
 	 * @param deviceStatus
 	 *            a boolean value
@@ -590,7 +590,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes driver Braking data
+	 * Sets a boolean value. If true, unsubscribes from driver Braking data
 	 * 
 	 * @param driverBraking
 	 *            a boolean value
@@ -611,7 +611,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes wiper Status data
+	 * Sets a boolean value. If true, unsubscribes from wiper Status data
 	 * 
 	 * @param wiperStatus
 	 *            a boolean value
@@ -632,7 +632,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes Head Lamp Status data
+	 * Sets a boolean value. If true, unsubscribes from Head Lamp Status data
 	 * 
 	 * @param headLampStatus
 	 *            a boolean value
@@ -653,7 +653,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes Engine Torque data
+	 * Sets a boolean value. If true, unsubscribes from Engine Torque data
 	 *
 	 * @param engineTorque
 	 *            a boolean value
@@ -674,7 +674,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
 	}
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes Engine Oil Life data
+	 * Sets a boolean value. If true, unsubscribes from Engine Oil Life data
 	 *
 	 * @param engineOilLife
 	 *            a boolean value
@@ -696,7 +696,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
 
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes accPedalPosition data
+	 * Sets a boolean value. If true, unsubscribes from accPedalPosition data
 	 * 
 	 * @param accPedalPosition
 	 *            a boolean value
@@ -756,7 +756,7 @@ public class UnsubscribeVehicleData extends RPCRequest {
     }
 
 	/**
-	 * Sets a boolean value. If true, unsubscribes fuelRange data
+	 * Sets a boolean value. If true, unsubscribes from fuelRange data
 	 *
 	 * @param fuelRange
 	 *            a boolean value
@@ -777,19 +777,19 @@ public class UnsubscribeVehicleData extends RPCRequest {
 	}
 
 	/**
-	 * Sets a boolean value. If true, subscribes turnSignal data
+	 * Sets a boolean value. If true, unsubscribes from turnSignal data
 	 * @param turnSignal a boolean value
 	 */
 	public void setTurnSignal(Boolean turnSignal) { setParameters(KEY_TURN_SIGNAL, turnSignal); }
 
 	/**
-	 * Gets a boolean value. If true, means the turnSignal data has been subscribed.
+	 * Gets a boolean value. If true, means the turnSignal data has been unsubscribed.
 	 * @return a Boolean value.
 	 */
 	public Boolean getTurnSignal() { return getBoolean(KEY_TURN_SIGNAL); }
 
 	/**
-	 * Sets a boolean value. If true, subscribes electronicParkBrakeStatus data
+	 * Sets a boolean value. If true, unsubscribes from electronicParkBrakeStatus data
 	 * @param electronicParkBrakeStatus a boolean value
 	 */
 	public void setElectronicParkBrakeStatus(Boolean electronicParkBrakeStatus) {
@@ -805,15 +805,15 @@ public class UnsubscribeVehicleData extends RPCRequest {
 	}
 
 	/**
-	 * Sets cloudAppVehicleID
-	 * @param cloudAppVehicleID a boolean value
+	 * Sets a boolean value. If true, unsubscribes from cloudAppVehicleID data
+	 * @param cloudAppVehicleID a boolean value. 
 	 */
 	public void setCloudAppVehicleID(boolean cloudAppVehicleID){
 		setParameters(KEY_CLOUD_APP_VEHICLE_ID, cloudAppVehicleID);
 	}
 
 	/**
-	 * Gets a boolean value. If true, means the cloudAppVehicleDataID data should be  unsubscribed.
+	 * Gets a boolean value. If true, means the cloudAppVehicleID data has been unsubscribed.
 	 * @return a Boolean value.
 	 */
 	public Boolean getCloudAppVehicleID(){


### PR DESCRIPTION
Fixes #1026 

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Summary
Fix the `UnsubscribeVehicleData.setCloudAppVehicleID()` method signature as described in the issue 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
