### PR TITLE
Fix issue in RS when removing Parcel objects for notifying all cliets

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -939,8 +939,8 @@ public class SdlRouterService extends Service{
 		return super.onUnbind(intent);
 	}
 
-	
-	private void notifyClients(Message message){
+
+	private void notifyClients(final Message message){
 		if(message==null){
 			Log.w(TAG, "Can't notify clients, message was null");
 			return;
@@ -950,11 +950,13 @@ public class SdlRouterService extends Service{
 		synchronized(REGISTERED_APPS_LOCK){
 			Collection<RegisteredApp> apps = registeredApps.values();
 			Iterator<RegisteredApp> it = apps.iterator();
+			Message formattedMessage = new Message();
 			while(it.hasNext()){
 				RegisteredApp app = it.next();
+				formattedMessage.copyFrom(message);
 				//Format the message for the receiving app and appropriate messaging version
-				if(formatMessage(app, message)) {
-					result = app.sendMessage(message);
+				if(formatMessage(app, formattedMessage)) {
+					result = app.sendMessage(formattedMessage);
 					if (result == RegisteredApp.SEND_MESSAGE_ERROR_MESSENGER_DEAD_OBJECT) {
 						app.close();
 						it.remove();


### PR DESCRIPTION
Fixes #932 (again...hopefully for good)

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Two tests are really needed to ensure everything works properly.

##### Test with older router service:
1. Delete all SDL enabled apps from device
2. Install Ford Alexa app, connect to tdk, Alexa shows and hosts router service
3. Install Hello Sdl app, app also shows on tdk
4. Turn off tdk, Hello SDL app notification should be removed.

##### Test with newer router service:

1. Install WebEx and Acast App from Play Store
2. Install Hello SDL App from Tag RC2 or use attached APK.
3. Connect Android device to SYNC
4. Wait for all Apps to show up on SYNC. Observe notifications on Android device. All 3 apps will show notifications.
5. Disable Bluetooth on Ford SYNC. Alternatively, perform Ignition Cycle
4. Turn off tdk, Hello SDL app notification should be removed.

### Summary
- In order to work with older clients, the router service would remove parcel objects that were added in 4.7 so that the TransportBroker could parse the Bundle it received in the Message object. However, it would remove the parcel from the source message that was sent to all clients, and if one client was older it would be removed for all other clients.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
