### PR TITLE
Fix issues in updating BuildConfig

### DIFF
--- a/javaEE/build.gradle
+++ b/javaEE/build.gradle
@@ -39,8 +39,40 @@ sourceSets {
 }
 
 jar {
+    dependsOn 'generateSources'
     from {
         configurations.extraLibs.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+}
+
+task generateSources {
+    outputs.upToDateWhen { false }
+    File outputDir = file("$buildDir/../../javaSE/src/main/java/com/smartdevicelink/")
+    outputs.dir outputDir
+    doFirst {
+        println "Generating BuildConfig.java ..."
+        def srcFile = new File(outputDir, "BuildConfig.java")
+        srcFile.parentFile.mkdirs()
+        File license = new File("$buildDir/../../LICENSE")
+        if (license.exists()) {
+            srcFile.write("/*\n")
+            def lines = license.readLines()
+            for (line in lines) {
+                srcFile.append("* ")
+                srcFile.append(line)
+                srcFile.append("\n")
+            }
+            srcFile.append("*/\n")
+        }else{
+            srcFile.write("\n")
+        }
+        srcFile.append(
+                """package com.smartdevicelink;
+
+// THIS FILE IS AUTO GENERATED, DO NOT MODIFY!!
+public final class BuildConfig {
+    public static final String VERSION_NAME = "$project.version";
+}""")
     }
 }
 

--- a/javaSE/build.gradle
+++ b/javaSE/build.gradle
@@ -39,15 +39,18 @@ sourceSets {
 }
 
 jar {
+    dependsOn 'generateSources'
     from {
         configurations.extraLibs.collect { it.isDirectory() ? it : zipTree(it) }
     }
 }
 
 task generateSources {
+    outputs.upToDateWhen { false }
     File outputDir = file("$buildDir/../src/main/java/com/smartdevicelink/")
     outputs.dir outputDir
     doFirst {
+        println "Generating BuildConfig.java ..."
         def srcFile = new File(outputDir, "BuildConfig.java")
         srcFile.parentFile.mkdirs()
         File license = new File("$buildDir/../../LICENSE")
@@ -72,7 +75,5 @@ public final class BuildConfig {
 }""")
     }
 }
-
-compileJava.dependsOn generateSources
 
 apply from: 'bintray.gradle'


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
~1 - Remove `BuildConfig.java` file from sdl_android/javaSE/src/main/java/com/smartdevicelink~
2 - Change lib version in `VERSION` file
3 - Run `gradle build` and make sure the jar is generated correctly and that `versionName` is correct in `BuildConfig` file in the jar
4 - Change lib version again in `VERSION` file
5 - Run `gradle bintrayUpload` and make sure the lib is uploaded to bintray and that `versionName` is correct in `BuildConfig` in the uploaded lib
6 - Repeat steps (1 -> 5) for javaEE library

### Summary
This PR fixes some issues in `generateSources` gradle task
* Add the new task to javaEE
* Set the `upToDateWhen` to `false` to prevent the task from beeing skipped

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
