### PR TITLE
Handle AppService Removed reason in SCM

### DIFF
--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/proxy/SystemCapabilityManagerTests.java
@@ -30,6 +30,7 @@ import com.smartdevicelink.proxy.rpc.SystemCapability;
 import com.smartdevicelink.proxy.rpc.VideoStreamingCapability;
 import com.smartdevicelink.proxy.rpc.enums.AppServiceType;
 import com.smartdevicelink.proxy.rpc.enums.HmiZoneCapabilities;
+import com.smartdevicelink.proxy.rpc.enums.ServiceUpdateReason;
 import com.smartdevicelink.proxy.rpc.enums.SpeechCapabilities;
 import com.smartdevicelink.proxy.rpc.enums.SystemCapabilityType;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
@@ -275,6 +276,25 @@ public class SystemCapabilityManagerTests extends AndroidTestCase2 {
 		cachedCap = (AppServicesCapabilities)systemCapabilityManager.getCapability(SystemCapabilityType.APP_SERVICES);
 		assertNotNull(cachedCap);
 		assertEquals(cachedCap.getAppServices().size(), 2);
+
+		/* PERFORM A NOTIFICATION SEND THROUGH THE SCM WITH A REMOVED SERVICE */
+		AppServiceCapability removedService = AppServiceFactory.createAppServiceCapability(AppServiceType.NAVIGATION, "NewNav", "eeeeeeeee", false, null);
+		removedService.setUpdateReason(ServiceUpdateReason.REMOVED);
+		AppServicesCapabilities removedServiceASC = new AppServicesCapabilities();
+		removedServiceASC.setAppServices(Collections.singletonList(removedService));
+
+		systemCapability = new SystemCapability();
+		systemCapability.setSystemCapabilityType(SystemCapabilityType.APP_SERVICES);
+		systemCapability.setCapabilityForType(SystemCapabilityType.APP_SERVICES, removedServiceASC);
+
+		onSystemCapabilityUpdated = new OnSystemCapabilityUpdated();
+		onSystemCapabilityUpdated.setSystemCapability(systemCapability);
+
+		scmRpcListener.onReceived(onSystemCapabilityUpdated);
+
+		cachedCap = (AppServicesCapabilities)systemCapabilityManager.getCapability(SystemCapabilityType.APP_SERVICES);
+		assertNotNull(cachedCap);
+		assertEquals(cachedCap.getAppServices().size(), 1);
 
 	}
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/AppServicesCapabilitiesTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/rpc/datatypes/AppServicesCapabilitiesTests.java
@@ -3,6 +3,7 @@ package com.smartdevicelink.test.rpc.datatypes;
 import com.smartdevicelink.proxy.rpc.AppServiceCapability;
 import com.smartdevicelink.proxy.rpc.AppServicesCapabilities;
 import com.smartdevicelink.proxy.rpc.enums.AppServiceType;
+import com.smartdevicelink.proxy.rpc.enums.ServiceUpdateReason;
 import com.smartdevicelink.test.JsonUtils;
 import com.smartdevicelink.test.Test;
 import com.smartdevicelink.test.Validator;
@@ -124,6 +125,18 @@ public class AppServicesCapabilitiesTests extends TestCase {
 
 		/* TEST TO ENSURE A NEW RECORD WAS NOT ADDED */
 		assertEquals(capabilities1.getAppServices().size(), 3);
+
+
+		capability5.setUpdateReason(ServiceUpdateReason.REMOVED);
+
+		/* TEST TO ENSURE A THE LIST BEING STORED WAS MODIFIED */
+		assertTrue(capabilities1.updateAppServices(Collections.singletonList(capability5)));
+
+		/* TEST TO ENSURE THE RECORD WAS REMOVED */
+		assertEquals(capabilities1.getAppServices().size(), 2);
+
+		/* TEST TO ENSURE THE RECORD REMOVED WAS THE CORRECT ONE */
+		assertFalse(capabilities1.getAppServices().contains(capability5));
 
 
 	}

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -115,13 +115,15 @@ public class SystemCapabilityManager {
                                                 // App services only updates what was changed so we need
                                                 // to update the capability rather than override it
                                                 AppServicesCapabilities appServicesCapabilities = (AppServicesCapabilities) capability;
-                                                List<AppServiceCapability> appServicesCapabilitiesList = appServicesCapabilities.getAppServices();
-                                                AppServicesCapabilities cachedAppServicesCapabilities = (AppServicesCapabilities) cachedSystemCapabilities.get(systemCapabilityType);
+                                                if(capability != null) {
+													List<AppServiceCapability> appServicesCapabilitiesList = appServicesCapabilities.getAppServices();
+													AppServicesCapabilities cachedAppServicesCapabilities = (AppServicesCapabilities) cachedSystemCapabilities.get(systemCapabilityType);
 
-                                                //Update the cached app services
-                                                cachedAppServicesCapabilities.updateAppServices(appServicesCapabilitiesList);
-                                                //Set the new capability object to the updated cached capabilities
-                                                capability = cachedAppServicesCapabilities;
+													//Update the cached app services
+													cachedAppServicesCapabilities.updateAppServices(appServicesCapabilitiesList);
+													//Set the new capability object to the updated cached capabilities
+													capability = cachedAppServicesCapabilities;
+												}
                                                 break;
                                         }
                                     }

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -118,10 +118,10 @@ public class SystemCapabilityManager {
                                                 if(capability != null) {
                                                 	List<AppServiceCapability> appServicesCapabilitiesList = appServicesCapabilities.getAppServices();
                                                 	AppServicesCapabilities cachedAppServicesCapabilities = (AppServicesCapabilities) cachedSystemCapabilities.get(systemCapabilityType);
-													//Update the cached app services
-													cachedAppServicesCapabilities.updateAppServices(appServicesCapabilitiesList);
-													//Set the new capability object to the updated cached capabilities
-													capability = cachedAppServicesCapabilities;
+                                                	//Update the cached app services
+                                                	cachedAppServicesCapabilities.updateAppServices(appServicesCapabilitiesList);
+                                                	//Set the new capability object to the updated cached capabilities
+                                                	capability = cachedAppServicesCapabilities;
                                                 }
                                                 break;
                                         }

--- a/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/SystemCapabilityManager.java
@@ -116,14 +116,13 @@ public class SystemCapabilityManager {
                                                 // to update the capability rather than override it
                                                 AppServicesCapabilities appServicesCapabilities = (AppServicesCapabilities) capability;
                                                 if(capability != null) {
-													List<AppServiceCapability> appServicesCapabilitiesList = appServicesCapabilities.getAppServices();
-													AppServicesCapabilities cachedAppServicesCapabilities = (AppServicesCapabilities) cachedSystemCapabilities.get(systemCapabilityType);
-
+                                                	List<AppServiceCapability> appServicesCapabilitiesList = appServicesCapabilities.getAppServices();
+                                                	AppServicesCapabilities cachedAppServicesCapabilities = (AppServicesCapabilities) cachedSystemCapabilities.get(systemCapabilityType);
 													//Update the cached app services
 													cachedAppServicesCapabilities.updateAppServices(appServicesCapabilitiesList);
 													//Set the new capability object to the updated cached capabilities
 													capability = cachedAppServicesCapabilities;
-												}
+                                                }
                                                 break;
                                         }
                                     }

--- a/base/src/main/java/com/smartdevicelink/proxy/rpc/AppServicesCapabilities.java
+++ b/base/src/main/java/com/smartdevicelink/proxy/rpc/AppServicesCapabilities.java
@@ -34,6 +34,7 @@ package com.smartdevicelink.proxy.rpc;
 import android.support.annotation.NonNull;
 
 import com.smartdevicelink.proxy.RPCStruct;
+import com.smartdevicelink.proxy.rpc.enums.ServiceUpdateReason;
 
 import java.util.ArrayList;
 import java.util.Hashtable;
@@ -96,34 +97,33 @@ public class AppServicesCapabilities extends RPCStruct {
 		if(updatedAppServiceCapabilities == null){
 			return false;
 		}
-		final List<AppServiceCapability> appServiceCapabilities = getAppServices();
 
-		if(appServiceCapabilities == null || appServiceCapabilities.isEmpty()){
-			//If this list is null or empty, just copy the updated list into this object
-			setAppServices(updatedAppServiceCapabilities);
-			return true;
+		List<AppServiceCapability> appServiceCapabilities = getAppServices();
+
+		if(appServiceCapabilities == null){
+			//If there are currently no app services, create one to iterate over with no entries
+			appServiceCapabilities = new ArrayList<>(0);
 		}
 
 		//Create a shallow copy for us to alter while iterating through the original list
 		List<AppServiceCapability> tempList = new ArrayList<>(appServiceCapabilities);
 
-		boolean updated;
 		for(AppServiceCapability updatedAppServiceCapability: updatedAppServiceCapabilities){
-			updated = false;
 			if(updatedAppServiceCapability != null) {
+				//First search if the record exists in the current list and remove it if so
 				for (AppServiceCapability appServiceCapability : appServiceCapabilities) {
 					if (updatedAppServiceCapability.matchesAppService(appServiceCapability)) {
 						tempList.remove(appServiceCapability); //Remove the old entry
-						tempList.add(updatedAppServiceCapability); //Add the new entry
-						updated = true;
 						break;
 					}
 				}
-			}
 
-			if(!updated){
-				//If the updated App Service capability doesn't exist in the old list, just add it
-				tempList.add(updatedAppServiceCapability);
+				if(!ServiceUpdateReason.REMOVED.equals(updatedAppServiceCapability.getUpdateReason())){
+					//If the app service was anything but removed, we can add the updated
+					//record back into the temp list. If it was REMOVED as the update reason
+					//it will not be added back.
+					tempList.add(updatedAppServiceCapability);
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- New unit tests added
- A publisher should publish a service, ensure it gets added to the SCM. Have the publisher's service removed and check the SCM that it removed the entry.

### Summary
- Add a check to the `AppServiceCapabilities.updateAppServices` for update reason
- Refactor the method as well for simpler code path. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
