### PR TITLE
make sure hasQueuedUpdate gets set

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/BaseTextAndGraphicManager.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/BaseTextAndGraphicManager.java
@@ -226,9 +226,10 @@ abstract class BaseTextAndGraphicManager extends BaseSubManager {
 
 			if (listener != null){
 				queuedUpdateListener = listener;
-			}else{
-				hasQueuedUpdate = true;
 			}
+
+			hasQueuedUpdate = true;
+
 			return;
 		}
 


### PR DESCRIPTION
Fixes #1035

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Smoke tests

### Summary
In the `sdlUpdate` function, there is a line that tells the manager that there is a queuedUpdate ready, if the manager is in the process of completing an update:

```java
		//Updating Text and Graphics
		if (inProgressUpdate != null){

			//In progress update exists, queueing update
			if (queuedUpdateListener != null){

				//Queued update already exists, superseding previous queued update
				queuedUpdateListener.onComplete(false);
				queuedUpdateListener = null;
			}

			if (listener != null){
				queuedUpdateListener = listener;
			}else{
				hasQueuedUpdate = true; // <- here
			}
			return;
		}
```

However, if an update is sent with a listener, and a subsequent update is not, that second update will never tell the manager that there is a queued update available, and it will not be sent. By removing that boolean from the `if`, we will allow the manager to know there is a queued update even if a completionListener is not set:

```java
		if (inProgressUpdate != null){

			//In progress update exists, queueing update
			if (queuedUpdateListener != null){

				//Queued update already exists, superseding previous queued update
				queuedUpdateListener.onComplete(false);
				queuedUpdateListener = null;
			}

			if (listener != null){
				queuedUpdateListener = listener;
			}
				
			hasQueuedUpdate = true; // <- Always set now
			
			return;
		}
```

### Tasks Remaining:
- [X] [More smoke testing]

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)