### PR TITLE
Fix issue in PLAY_PAUSE button handling 

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2077,18 +2077,20 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					ButtonName buttonName = (ButtonName) request.getObject(ButtonName.class, SubscribeButton.KEY_BUTTON_NAME);
 
 
-					if (rpcSpecVersion.getMajor() < 5) {
+					if (rpcSpecVersion != null) {
+						if (rpcSpecVersion.getMajor() < 5) {
 
-						if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
-							request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
-						}
-					} else { //Newer than version 5.0.0
-						if (ButtonName.OK.equals(buttonName)) {
-							RPCRequest request2 = new RPCRequest(request);
-							request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
-							request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
-							sendRPCMessagePrivate(request2);
-							return;
+							if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
+								request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
+							}
+						} else { //Newer than version 5.0.0
+							if (ButtonName.OK.equals(buttonName)) {
+								RPCRequest request2 = new RPCRequest(request);
+								request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
+								request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
+								sendRPCMessagePrivate(request2);
+								return;
+							}
 						}
 					}
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3817,6 +3817,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 							_proxyListener.onOnButtonPress(msg);
 							onRPCNotificationReceived(msg);
 							if(onButtonPressCompat != null){
+								onRPCNotificationReceived(onButtonPressCompat);
 								_proxyListener.onOnButtonPress(onButtonPressCompat);
 							}
 						}
@@ -3825,6 +3826,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					_proxyListener.onOnButtonPress(msg);
 					onRPCNotificationReceived(msg);
 					if(onButtonPressCompat != null){
+						onRPCNotificationReceived(onButtonPressCompat);
 						_proxyListener.onOnButtonPress(onButtonPressCompat);
 					}
 				}
@@ -3843,6 +3845,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 							_proxyListener.onOnButtonEvent(msg);
 							onRPCNotificationReceived(msg);
 							if(onButtonEventCompat != null){
+								onRPCNotificationReceived(onButtonEventCompat);
 								_proxyListener.onOnButtonEvent(onButtonEventCompat);
 							}
 						}
@@ -3851,6 +3854,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 					_proxyListener.onOnButtonEvent(msg);
 					onRPCNotificationReceived(msg);
 					if(onButtonEventCompat != null){
+						onRPCNotificationReceived(onButtonEventCompat);
 						_proxyListener.onOnButtonEvent(onButtonEventCompat);
 					}
 				}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2064,35 +2064,34 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 	
 	// Private sendRPCMessagePrivate method. All RPCMessages are funneled through this method after error checking.
 	private void sendRPCMessagePrivate(RPCMessage message) throws SdlException {
-		SdlTrace.logRPCEvent(InterfaceActivityDirection.Transmit, message, SDL_LIB_TRACE_KEY);
+		try {
+			SdlTrace.logRPCEvent(InterfaceActivityDirection.Transmit, message, SDL_LIB_TRACE_KEY);
 
-		//FIXME this is temporary until the next major release of the library where OK is removed
-		if (message.getMessageType().equals(RPCMessage.KEY_REQUEST)) {
-			RPCRequest request = (RPCRequest) message;
-			if(FunctionID.SUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
-					|| FunctionID.UNSUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
-					|| FunctionID.BUTTON_PRESS.toString().equals(request.getFunctionName())) {
+			//FIXME this is temporary until the next major release of the library where OK is removed
+			if (message.getMessageType().equals(RPCMessage.KEY_REQUEST)) {
+				RPCRequest request = (RPCRequest) message;
+				if(FunctionID.SUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
+						|| FunctionID.UNSUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
+						|| FunctionID.BUTTON_PRESS.toString().equals(request.getFunctionName())) {
 
-				ButtonName buttonName = (ButtonName) request.getObject(ButtonName.class, SubscribeButton.KEY_BUTTON_NAME);
+					ButtonName buttonName = (ButtonName) request.getObject(ButtonName.class, SubscribeButton.KEY_BUTTON_NAME);
 
-				if (rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
+					if (rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
 
-					if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
-						request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
-					}
-				} else { //Newer than version 5.0.0
-					if (ButtonName.OK.equals(buttonName)) {
-						RPCRequest request2 = new RPCRequest(request);
-						request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
-						request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
-						sendRPCMessagePrivate(request2);
-						return;
+						if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
+							request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
+						}
+					} else { //Newer than version 5.0.0
+						if (ButtonName.OK.equals(buttonName)) {
+							RPCRequest request2 = new RPCRequest(request);
+							request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
+							request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
+							sendRPCMessagePrivate(request2);
+							return;
+						}
 					}
 				}
 			}
-		}
-
-		try {
 
 			message.format(rpcSpecVersion,true);
 			byte[] msgBytes = JsonRPCMarshaller.marshall(message, (byte)getProtocolVersion().getMajor());

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2076,18 +2076,20 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 					ButtonName buttonName = (ButtonName) request.getObject(ButtonName.class, SubscribeButton.KEY_BUTTON_NAME);
 
-					if (rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
+					if (rpcSpecVersion != null) {
+						if (rpcSpecVersion.getMajor() < 5) {
 
-						if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
-							request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
-						}
-					} else { //Newer than version 5.0.0
-						if (ButtonName.OK.equals(buttonName)) {
-							RPCRequest request2 = new RPCRequest(request);
-							request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
-							request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
-							sendRPCMessagePrivate(request2);
-							return;
+							if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
+								request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
+							}
+						} else { //Newer than version 5.0.0
+							if (ButtonName.OK.equals(buttonName)) {
+								RPCRequest request2 = new RPCRequest(request);
+								request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
+								request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
+								sendRPCMessagePrivate(request2);
+								return;
+							}
 						}
 					}
 				}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2070,7 +2070,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 			//FIXME this is temporary until the next major release of the library where OK is removed
 			if (message.getMessageType().equals(RPCMessage.KEY_REQUEST)) {
 				RPCRequest request = (RPCRequest) message;
-				if(FunctionID.SUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
+				if (FunctionID.SUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
 						|| FunctionID.UNSUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
 						|| FunctionID.BUTTON_PRESS.toString().equals(request.getFunctionName())) {
 

--- a/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -2076,22 +2076,22 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 
 					ButtonName buttonName = (ButtonName) request.getObject(ButtonName.class, SubscribeButton.KEY_BUTTON_NAME);
 
-					if (rpcSpecVersion != null) {
-						if (rpcSpecVersion.getMajor() < 5) {
 
-							if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
-								request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
-							}
-						} else { //Newer than version 5.0.0
-							if (ButtonName.OK.equals(buttonName)) {
-								RPCRequest request2 = new RPCRequest(request);
-								request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
-								request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
-								sendRPCMessagePrivate(request2);
-								return;
-							}
+					if (rpcSpecVersion.getMajor() < 5) {
+
+						if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
+							request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
+						}
+					} else { //Newer than version 5.0.0
+						if (ButtonName.OK.equals(buttonName)) {
+							RPCRequest request2 = new RPCRequest(request);
+							request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
+							request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
+							sendRPCMessagePrivate(request2);
+							return;
 						}
 					}
+
 				}
 			}
 

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -653,18 +653,20 @@ public class LifecycleManager extends BaseLifecycleManager {
                     ButtonName buttonName = (ButtonName) request.getObject(ButtonName.class, SubscribeButton.KEY_BUTTON_NAME);
 
 
-                    if (rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
+                    if (rpcSpecVersion != null) {
+                        if (rpcSpecVersion.getMajor() < 5) {
 
-                        if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
-                            request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
-                        }
-                    } else { //Newer than version 5.0.0
-                        if (ButtonName.OK.equals(buttonName)) {
-                            RPCRequest request2 = new RPCRequest(request);
-                            request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
-                            request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
-                            sendRPCMessagePrivate(request2);
-                            return;
+                            if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
+                                request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
+                            }
+                        } else { //Newer than version 5.0.0
+                            if (ButtonName.OK.equals(buttonName)) {
+                                RPCRequest request2 = new RPCRequest(request);
+                                request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
+                                request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
+                                sendRPCMessagePrivate(request2);
+                                return;
+                            }
                         }
                     }
 

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -652,22 +652,22 @@ public class LifecycleManager extends BaseLifecycleManager {
 
                     ButtonName buttonName = (ButtonName) request.getObject(ButtonName.class, SubscribeButton.KEY_BUTTON_NAME);
 
-                    if (rpcSpecVersion != null){
-                        if (rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
 
-                            if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
-                                request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
-                            }
-                        } else { //Newer than version 5.0.0
-                            if (ButtonName.OK.equals(buttonName)) {
-                                RPCRequest request2 = new RPCRequest(request);
-                                request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
-                                request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
-                                sendRPCMessagePrivate(request2);
-                                return;
-                            }
+                    if (rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
+
+                        if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
+                            request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
+                        }
+                    } else { //Newer than version 5.0.0
+                        if (ButtonName.OK.equals(buttonName)) {
+                            RPCRequest request2 = new RPCRequest(request);
+                            request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
+                            request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
+                            sendRPCMessagePrivate(request2);
+                            return;
                         }
                     }
+
                 }
             }
 

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -642,34 +642,33 @@ public class LifecycleManager extends BaseLifecycleManager {
 
 
     private void sendRPCMessagePrivate(RPCMessage message){
-        //FIXME this is temporary until the next major release of the library where OK is removed
-        if (message.getMessageType().equals(RPCMessage.KEY_REQUEST)) {
-            RPCRequest request = (RPCRequest) message;
-            if(FunctionID.SUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
-                    || FunctionID.UNSUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
-                    || FunctionID.BUTTON_PRESS.toString().equals(request.getFunctionName())) {
+        try {
+            //FIXME this is temporary until the next major release of the library where OK is removed
+            if (message.getMessageType().equals(RPCMessage.KEY_REQUEST)) {
+                RPCRequest request = (RPCRequest) message;
+                if(FunctionID.SUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
+                        || FunctionID.UNSUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
+                        || FunctionID.BUTTON_PRESS.toString().equals(request.getFunctionName())) {
 
-                ButtonName buttonName = (ButtonName) request.getObject(ButtonName.class, SubscribeButton.KEY_BUTTON_NAME);
+                    ButtonName buttonName = (ButtonName) request.getObject(ButtonName.class, SubscribeButton.KEY_BUTTON_NAME);
 
-                if (rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
+                    if (rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
 
-                    if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
-                        request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
-                    }
-                } else { //Newer than version 5.0.0
-                    if (ButtonName.OK.equals(buttonName)) {
-                        RPCRequest request2 = new RPCRequest(request);
-                        request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
-                        request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
-                        sendRPCMessagePrivate(request2);
-                        return;
+                        if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
+                            request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
+                        }
+                    } else { //Newer than version 5.0.0
+                        if (ButtonName.OK.equals(buttonName)) {
+                            RPCRequest request2 = new RPCRequest(request);
+                            request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
+                            request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
+                            sendRPCMessagePrivate(request2);
+                            return;
+                        }
                     }
                 }
             }
-        }
 
-
-        try {
 
             message.format(rpcSpecVersion,true);
             byte[] msgBytes = JsonRPCMarshaller.marshall(message, (byte)getProtocolVersion().getMajor());

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -642,6 +642,33 @@ public class LifecycleManager extends BaseLifecycleManager {
 
 
     private void sendRPCMessagePrivate(RPCMessage message){
+        //FIXME this is temporary until the next major release of the library where OK is removed
+        if (message.getMessageType().equals(RPCMessage.KEY_REQUEST)) {
+            RPCRequest request = (RPCRequest) message;
+            if(FunctionID.SUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
+                    || FunctionID.UNSUBSCRIBE_BUTTON.toString().equals(request.getFunctionName())
+                    || FunctionID.BUTTON_PRESS.toString().equals(request.getFunctionName())) {
+
+                ButtonName buttonName = (ButtonName) request.getObject(ButtonName.class, SubscribeButton.KEY_BUTTON_NAME);
+
+                if (rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
+
+                    if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
+                        request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
+                    }
+                } else { //Newer than version 5.0.0
+                    if (ButtonName.OK.equals(buttonName)) {
+                        RPCRequest request2 = new RPCRequest(request);
+                        request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
+                        request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
+                        sendRPCMessagePrivate(request2);
+                        return;
+                    }
+                }
+            }
+        }
+
+
         try {
 
             message.format(rpcSpecVersion,true);
@@ -742,11 +769,6 @@ public class LifecycleManager extends BaseLifecycleManager {
 
                     rpc.format(rpcSpecVersion, true);
 
-                    FunctionID functionID = rpc.getFunctionID();
-                    if (functionID != null && (functionID.equals(FunctionID.ON_BUTTON_PRESS.toString()) || functionID.equals(FunctionID.ON_BUTTON_EVENT.toString()))) {
-                        rpc = handleButtonNotificationFormatting(rpc);
-                    }
-
                     onRPCReceived(rpc);
 
                     if (RPCMessage.KEY_RESPONSE.equals(messageType)) {
@@ -754,6 +776,13 @@ public class LifecycleManager extends BaseLifecycleManager {
                         onRPCResponseReceived((RPCResponse) rpc);
 
                     } else if (RPCMessage.KEY_NOTIFICATION.equals(messageType)) {
+                        FunctionID functionID = rpc.getFunctionID();
+                        if (functionID != null && (functionID.equals(FunctionID.ON_BUTTON_PRESS)) || functionID.equals(FunctionID.ON_BUTTON_EVENT)) {
+                            RPCNotification notificationCompat = handleButtonNotificationFormatting(rpc);
+                            if(notificationCompat != null){
+                                onRPCNotificationReceived((notificationCompat));
+                            }
+                        }
 
                         onRPCNotificationReceived((RPCNotification) rpc);
 

--- a/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/lifecycle/LifecycleManager.java
@@ -652,18 +652,20 @@ public class LifecycleManager extends BaseLifecycleManager {
 
                     ButtonName buttonName = (ButtonName) request.getObject(ButtonName.class, SubscribeButton.KEY_BUTTON_NAME);
 
-                    if (rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
+                    if (rpcSpecVersion != null){
+                        if (rpcSpecVersion != null && rpcSpecVersion.getMajor() < 5) {
 
-                        if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
-                            request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
-                        }
-                    } else { //Newer than version 5.0.0
-                        if (ButtonName.OK.equals(buttonName)) {
-                            RPCRequest request2 = new RPCRequest(request);
-                            request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
-                            request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
-                            sendRPCMessagePrivate(request2);
-                            return;
+                            if (ButtonName.PLAY_PAUSE.equals(buttonName)) {
+                                request.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.OK);
+                            }
+                        } else { //Newer than version 5.0.0
+                            if (ButtonName.OK.equals(buttonName)) {
+                                RPCRequest request2 = new RPCRequest(request);
+                                request2.setParameters(SubscribeButton.KEY_BUTTON_NAME, ButtonName.PLAY_PAUSE);
+                                request2.setOnRPCResponseListener(request.getOnRPCResponseListener());
+                                sendRPCMessagePrivate(request2);
+                                return;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #1037

This PR is **Ready** for review.

### Risk
This PR makes **no** API changes

### Summary
This PR fixes the issue where app receives only `OK` button press notification after subscribing and pressing the `PLAY_PAUSE` button. It also adds `PLAY_PAUSE` button handling to javaSE.

### Testing Plan
- Add a listener for `OnButtonPress`
- Send a `SubscribeButton` request with button name set to `PLAY_PAUSE`
- Run the app
- Press the OK/PLAY_PAUSE button on the head unit
- Confirm that the app receives `OnButtonPress` notifications for both OK & PLAY_PAUSE 
- Repeat the test for the javaSE library
### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
