### PR TITLE
Handle corner case during transport d/c

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
@@ -535,6 +535,10 @@ public class TransportBroker {
 
     }
 
+    protected int getRouterServiceVersion(){
+        return routerServiceVersion;
+    }
+
     /**
      * We want to check to see if the Router service is already up and running
      *


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
1. Install an app with 4.7.x
2. Install an app with 4.8RC, but remove manifest declaration for RS
3. Connect to module
4. Disconnect form module via Ignition Cycle

### Summary
There is an issue in the first gen of multi transport router services that will remove certain extras from messages to the TransportBroker if older apps are connected that do not support the multi transport messages. Because of that, we check the records we have and if the transport matches we assume it was the original transport that was received regardless of the address.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
