### PR TITLE
Remove unnecessary SdlFile constructor in javaSE

### DIFF
--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
@@ -50,10 +50,6 @@ public class SdlArtwork extends SdlFile {
         super(staticIconName);
     }
 
-    public SdlArtwork(@NonNull String fileName, @NonNull FileType fileType, int id, boolean persistentFile) {
-        super(fileName, fileType, id, persistentFile);
-    }
-
     public SdlArtwork(@NonNull String fileName, @NonNull FileType fileType, String filePath, boolean persistentFile) {
         super(fileName, fileType, filePath, persistentFile);
     }

--- a/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
+++ b/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlFile.java
@@ -40,7 +40,6 @@ import com.smartdevicelink.proxy.rpc.enums.StaticIconName;
  */
 public class SdlFile{
     private String      fileName;
-    private int         id = -1;
     private String      filePath;
     private byte[]      fileData;
     private FileType    fileType;
@@ -54,13 +53,6 @@ public class SdlFile{
         this.fileData = staticIconName.toString().getBytes();
         this.persistentFile = false;
         this.isStaticIcon = true;
-    }
-
-    public SdlFile(@NonNull String fileName, @NonNull FileType fileType, int id, boolean persistentFile){
-        this.fileName = fileName;
-        this.fileType = fileType;
-        this.id = id;
-        this.persistentFile = persistentFile;
     }
 
     public SdlFile(@NonNull String fileName, @NonNull FileType fileType, byte[] data, boolean persistentFile){
@@ -82,13 +74,6 @@ public class SdlFile{
     }
     public String getName(){
         return fileName;
-    }
-
-    public void setResourceId(int id){
-        this.id = id;
-    }
-    public int getResourceId(){
-        return id;
     }
 
     public void setFilePath(String filePath){


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
This PR removes the `SdlFile` constructor that takes resourceId as a param because `resourceId` works only for android, not pure java.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
