### PR TITLE
Refactoring SdlRouterService and SdlBroadcastReceiver

### DIFF
--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -5,9 +5,10 @@ import android.content.Intent;
 import android.os.Build;
 import android.util.Log;
 
+import com.smartdevicelink.transport.BaseBroadcastReceiver;
 import com.smartdevicelink.transport.BaseRouterService;
 
-public class SdlReceiver  extends BaseRouterService {
+public class SdlReceiver  extends BaseBroadcastReceiver {
 	private static final String TAG = "SdlBroadcastReciever";
 
 	@Override

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -5,10 +5,9 @@ import android.content.Intent;
 import android.os.Build;
 import android.util.Log;
 
-import com.smartdevicelink.transport.BaseBroadcastReceiver;
 import com.smartdevicelink.transport.BaseRouterService;
 
-public class SdlReceiver  extends BaseBroadcastReceiver {
+public class SdlReceiver  extends BaseRouterService {
 	private static final String TAG = "SdlBroadcastReciever";
 
 	@Override
@@ -27,8 +26,8 @@ public class SdlReceiver  extends BaseBroadcastReceiver {
 	}
 
 	@Override
-	public Class<? extends BaseRouterService> defineLocalSdlRouterClass() {
-		return com.sdl.hellosdlandroid.BaseRouterService.class;
+	public Class<? extends SdlRouterService> defineLocalSdlRouterClass() {
+		return com.sdl.hellosdlandroid.SdlRouterService.class;
 	}
 
 	@Override

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlReceiver.java
@@ -5,10 +5,10 @@ import android.content.Intent;
 import android.os.Build;
 import android.util.Log;
 
-import com.smartdevicelink.transport.SdlBroadcastReceiver;
-import com.smartdevicelink.transport.SdlRouterService;
+import com.smartdevicelink.transport.BaseBroadcastReceiver;
+import com.smartdevicelink.transport.BaseRouterService;
 
-public class SdlReceiver  extends SdlBroadcastReceiver {
+public class SdlReceiver  extends BaseBroadcastReceiver {
 	private static final String TAG = "SdlBroadcastReciever";
 
 	@Override
@@ -27,8 +27,8 @@ public class SdlReceiver  extends SdlBroadcastReceiver {
 	}
 
 	@Override
-	public Class<? extends SdlRouterService> defineLocalSdlRouterClass() {
-		return com.sdl.hellosdlandroid.SdlRouterService.class;
+	public Class<? extends BaseRouterService> defineLocalSdlRouterClass() {
+		return com.sdl.hellosdlandroid.BaseRouterService.class;
 	}
 
 	@Override

--- a/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlRouterService.java
+++ b/android/hello_sdl_android/src/main/java/com/sdl/hellosdlandroid/SdlRouterService.java
@@ -1,7 +1,7 @@
 package com.sdl.hellosdlandroid;
 
 
-public class SdlRouterService extends  com.smartdevicelink.transport.SdlRouterService {
+public class SdlRouterService extends  com.smartdevicelink.transport.BaseRouterService {
 
 
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
@@ -5,8 +5,8 @@ import android.os.Looper;
 import android.os.Message;
 
 import com.smartdevicelink.test.util.DeviceUtil;
+import com.smartdevicelink.transport.BaseRouterService;
 import com.smartdevicelink.transport.MultiplexBluetoothTransport;
-import com.smartdevicelink.transport.SdlRouterService;
 
 import junit.framework.TestCase;
 
@@ -34,7 +34,7 @@ public class MultiplexBluetoothTransportTest extends TestCase {
 					return;
 				}
 				switch(msg.what){
-					case SdlRouterService.MESSAGE_STATE_CHANGE:
+					case BaseRouterService.MESSAGE_STATE_CHANGE:
 						if(msg.arg1 == stateDesired){
 							didCorrectThing = true;
 							break;

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/transport/LocalRouterServiceTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/transport/LocalRouterServiceTests.java
@@ -21,7 +21,7 @@ public class LocalRouterServiceTests extends AndroidTestCase2 {
 		p.writeParcelable(new ComponentName(mContext, "test"), 0);
 		p.setDataPosition(0);
 		
-		SdlRouterService.LocalRouterService local = new SdlRouterService.LocalRouterService(p);
+		BaseRouterService.LocalRouterService local = new BaseRouterService.LocalRouterService(p);
 		
 		assertNotNull(local);
 		assertEquals(local.version,4);
@@ -36,8 +36,8 @@ public class LocalRouterServiceTests extends AndroidTestCase2 {
 		p.writeParcelable(new Intent(), 0);
 		p.writeParcelable(new ComponentName(mContext, "test"), 0);
 		p.setDataPosition(0);
-		
-		SdlRouterService.LocalRouterService local = SdlRouterService.LocalRouterService.CREATOR.createFromParcel(p);
+
+		BaseRouterService.LocalRouterService local = BaseRouterService.LocalRouterService.CREATOR.createFromParcel(p);
 		
 		assertNotNull(local);
 		assertEquals(local.version,4);
@@ -45,11 +45,11 @@ public class LocalRouterServiceTests extends AndroidTestCase2 {
 		
 	}
 
-	public SdlRouterService.LocalRouterService getLocalRouterService(int testWith, Parcel p){
+	public BaseRouterService.LocalRouterService getLocalRouterService(int testWith, Parcel p){
 		if(testWith == TEST_WITH_CONSTRUCTOR){
-			return new SdlRouterService.LocalRouterService(p);
+			return new BaseRouterService.LocalRouterService(p);
 		}else{
-			return SdlRouterService.LocalRouterService.CREATOR.createFromParcel(p);
+			return BaseRouterService.LocalRouterService.CREATOR.createFromParcel(p);
 		}
 	}
 	
@@ -60,8 +60,8 @@ public class LocalRouterServiceTests extends AndroidTestCase2 {
 		p.writeParcelable(new ComponentName(mContext, "test"), 0);
 		p.writeParcelable(new Intent(), 0);
 		p.setDataPosition(0);
-		
-		SdlRouterService.LocalRouterService local = getLocalRouterService(testWith, p);
+
+		BaseRouterService.LocalRouterService local = getLocalRouterService(testWith, p);
 
 		assertNotNull(local);
 		assertNull(local.launchIntent);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/transport/RegisteredAppTests.java
@@ -23,8 +23,8 @@ public class RegisteredAppTests extends AndroidTestCase2 {
         }
 
         // Instantiate SdlRouterService and Registered App class
-        SdlRouterService router = new SdlRouterService();
-        SdlRouterService.RegisteredApp app = router.new RegisteredApp(APP_ID, messenger);
+        BaseRouterService router = new BaseRouterService();
+        BaseRouterService.RegisteredApp app = router.new RegisteredApp(APP_ID, messenger);
 
         // Call Handle Message
         app.handleMessage(TransportConstants.BYTES_TO_SEND_FLAG_LARGE_PACKET_START,bytes);
@@ -42,8 +42,8 @@ public class RegisteredAppTests extends AndroidTestCase2 {
         }
 
         // Instantiate SdlRouterService and Registered App class
-        SdlRouterService router = new SdlRouterService();
-        SdlRouterService.RegisteredApp app = router.new RegisteredApp(APP_ID, messenger);
+        BaseRouterService router = new BaseRouterService();
+        BaseRouterService.RegisteredApp app = router.new RegisteredApp(APP_ID, messenger);
 
         // Force Null Buffer
         app.buffer = null;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/SdlConnection/SdlConnection.java
@@ -44,12 +44,12 @@ import com.smartdevicelink.protocol.WiProProtocol;
 import com.smartdevicelink.protocol.enums.SessionType;
 import com.smartdevicelink.transport.BTTransport;
 import com.smartdevicelink.transport.BTTransportConfig;
+import com.smartdevicelink.transport.BaseBroadcastReceiver;
 import com.smartdevicelink.transport.BaseTransportConfig;
 import com.smartdevicelink.transport.ITransportListener;
 import com.smartdevicelink.transport.MultiplexTransport;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
 import com.smartdevicelink.transport.RouterServiceValidator;
-import com.smartdevicelink.transport.SdlBroadcastReceiver;
 import com.smartdevicelink.transport.SdlTransport;
 import com.smartdevicelink.transport.TCPTransport;
 import com.smartdevicelink.transport.TCPTransportConfig;
@@ -90,7 +90,7 @@ public class SdlConnection implements IProtocolListener, ITransportListener {
 		RouterServiceValidator vlad = null;
 		//Let's check if we can even do multiplexing
 		if(transportConfig.getTransportType() == TransportType.MULTIPLEX){
-			ComponentName tempCompName = SdlBroadcastReceiver.consumeQueuedRouterService();
+			ComponentName tempCompName = BaseBroadcastReceiver.consumeQueuedRouterService();
 			MultiplexTransportConfig multiConfig = (MultiplexTransportConfig)transportConfig;
 			if(tempCompName!=null){
 				vlad =new RouterServiceValidator(multiConfig.getContext(),tempCompName);
@@ -582,7 +582,7 @@ public class SdlConnection implements IProtocolListener, ITransportListener {
 		if(_transport!=null && (_transport.getTransportType()==TransportType.MULTIPLEX)){ //This is only valid for the multiplex connection
 			MultiplexTransport multi = ((MultiplexTransport)_transport);
 			MultiplexTransportConfig config = multi.getConfig();
-			ComponentName tempCompName = SdlBroadcastReceiver.consumeQueuedRouterService();
+			ComponentName tempCompName = BaseBroadcastReceiver.consumeQueuedRouterService();
 			if(config.getService() != null && config.getService().equals(tempCompName)){ //If this is the same service that just connected that we are already looking at. Attempt to reconnect
 				if(!multi.getIsConnected() && multi.isDisconnecting() ){ //If we aren't able to force a connection it means the 
 					_transport = new MultiplexTransport(config,this);
@@ -611,7 +611,7 @@ public class SdlConnection implements IProtocolListener, ITransportListener {
 				&& !_transport.getIsConnected()){
 			if(cachedMultiConfig!=null){
 				//We are in legacy mode, but just received a force connect. The router service should never be pointing us here if we are truely in legacy mode
-				ComponentName tempCompName = SdlBroadcastReceiver.consumeQueuedRouterService();
+				ComponentName tempCompName = BaseBroadcastReceiver.consumeQueuedRouterService();
 				RouterServiceValidator vlad = new RouterServiceValidator(cachedMultiConfig.getContext(),tempCompName);
 				if(vlad.validate()){
 					cachedMultiConfig.setService(tempCompName);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/BaseBroadcastReceiver.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/BaseBroadcastReceiver.java
@@ -1,0 +1,4 @@
+package com.smartdevicelink.transport;
+
+public abstract class BaseBroadcastReceiver extends SdlBroadcastReceiver {
+}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/BaseRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/BaseRouterService.java
@@ -1,0 +1,4 @@
+package com.smartdevicelink.transport;
+
+public class BaseRouterService extends SdlRouterService {
+}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBaseTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBaseTransport.java
@@ -76,7 +76,7 @@ public abstract class MultiplexBaseTransport {
 
         // Give the new state to the Handler so the UI Activity can update
         //Also sending the previous state so we know if we lost a connection
-        handler.obtainMessage(SdlRouterService.MESSAGE_STATE_CHANGE, state, previousState, getTransportRecord()).sendToTarget();
+        handler.obtainMessage(BaseRouterService.MESSAGE_STATE_CHANGE, state, previousState, getTransportRecord()).sendToTarget();
     }
 
     public String getAddress(){

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -86,7 +86,7 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
     public MultiplexBluetoothTransport(Handler handler) {
         super(handler, TransportType.BLUETOOTH);
          //This will keep track of which method worked last night
-        mBluetoothLevel = SdlRouterService.getBluetoothPrefs(SHARED_PREFS);
+        mBluetoothLevel = BaseRouterService.getBluetoothPrefs(SHARED_PREFS);
     }
 
 
@@ -248,7 +248,7 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
         }
         
         // Send the name of the connected device back to the UI Activity
-        Message msg = handler.obtainMessage(SdlRouterService.MESSAGE_DEVICE_NAME);
+        Message msg = handler.obtainMessage(BaseRouterService.MESSAGE_DEVICE_NAME);
         Bundle bundle = new Bundle();
         if(connectedDeviceName != null) {
             bundle.putString(DEVICE_NAME, connectedDeviceName);
@@ -310,7 +310,7 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
      */
     private void connectionFailed() {
     	// Send a failure message back to the Activity
-        Message msg = handler.obtainMessage(SdlRouterService.MESSAGE_LOG);
+        Message msg = handler.obtainMessage(BaseRouterService.MESSAGE_LOG);
         Bundle bundle = new Bundle();
         bundle.putString(LOG, "Unable to connect device");
         msg.setData(bundle);
@@ -325,7 +325,7 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
      */
     private void connectionLost() {
         // Send a failure message back to the Activity
-        Message msg = handler.obtainMessage(SdlRouterService.MESSAGE_LOG);
+        Message msg = handler.obtainMessage(BaseRouterService.MESSAGE_LOG);
         Bundle bundle = new Bundle();
         bundle.putString(LOG, "Device connection was lost");
         msg.setData(bundle);
@@ -509,7 +509,7 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
 	            try {
 	                // This is a blocking call and will only return on a
 	                // successful connection or an exception
-	            	mBluetoothLevel = SdlRouterService.getBluetoothPrefs(SHARED_PREFS);
+	            	mBluetoothLevel = BaseRouterService.getBluetoothPrefs(SHARED_PREFS);
 	            	long waitTime = 3000;
 	                try {
 						Thread.sleep(waitTime);
@@ -525,7 +525,7 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
 
 	                if(mBluetoothLevel<=1){
 	                try {
-	                	SdlRouterService.setBluetoothPrefs(2,SHARED_PREFS);
+                        BaseRouterService.setBluetoothPrefs(2,SHARED_PREFS);
 	                      Method m = mmDevice.getClass().getMethod("createRfcommSocket", new Class[] {int.class});
 	                      //Log.i(TAG,"connecting using createRfcommSocket");
 	                        mmSocket = (BluetoothSocket) m.invoke(mmDevice, Integer.valueOf(1));
@@ -539,13 +539,13 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
 	    						    Looper.myLooper().quit();
 	    						}
 	    						success=true;
-	    						SdlRouterService.setBluetoothPrefs(1,SHARED_PREFS);
+                                BaseRouterService.setBluetoothPrefs(1,SHARED_PREFS);
 	    	                	break;
 	    					} else{trySecure = true;}
 
 	                } catch (Exception e) {
 	                      //Log.e(TAG,"createRfcommSocket exception - " + e.toString());
-	                      SdlRouterService.setBluetoothPrefs(0,SHARED_PREFS);
+                        BaseRouterService.setBluetoothPrefs(0,SHARED_PREFS);
 
 	                		trySecure = true;
 	    	                try {
@@ -557,7 +557,7 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
 	            }else{trySecure = true;}
 	                if(trySecure && mBluetoothLevel<=2){
 	                    try {
-	                    	SdlRouterService.setBluetoothPrefs(3,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(3,SHARED_PREFS);
     	                	//Log.i(TAG, "connecting using createRfcommSocketToServiceRecord ");
 	                         mmSocket = mmDevice.createRfcommSocketToServiceRecord(SERVER_UUID);                        
 	     					if(mmSocket!=null){
@@ -570,17 +570,17 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
 	    						    Looper.myLooper().quit();
 	    						}
 	    						success=true;
-	    						SdlRouterService.setBluetoothPrefs(2,SHARED_PREFS);
+                                BaseRouterService.setBluetoothPrefs(2,SHARED_PREFS);
 	    	                	break;
 	    					}else{tryInsecure = true;}
 	                    } catch (IOException io) {
 	                        tryInsecure = true;
 	                         Log.e(TAG,"createRfcommSocketToServiceRecord exception - " + io.toString());
-	                         SdlRouterService.setBluetoothPrefs(0,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(0,SHARED_PREFS);
 
 	                    } catch (Exception e){
 	                         Log.e(TAG,"createRfcommSocketToServiceRecord exception - " + e.toString());
-	                         SdlRouterService.setBluetoothPrefs(0,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(0,SHARED_PREFS);
 
 	                    }
 	                }else{tryInsecure = true;}
@@ -588,7 +588,7 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
 	                if (tryInsecure && mBluetoothLevel<=3) {
 	                    // try again using insecure comm if available
 	                    try {
-	                    	SdlRouterService.setBluetoothPrefs(4,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(4,SHARED_PREFS);
 	                        //Log.i(TAG,"connecting using createInsecureRfcommSocketToServiceRecord");
 	                        Method m = mmDevice.getClass().getMethod("createInsecureRfcommSocketToServiceRecord", new Class[] {UUID.class});
 	                        mmSocket = (BluetoothSocket) m.invoke(mmDevice, new Object[] {SERVER_UUID});
@@ -602,20 +602,20 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
     						}
     						success=true;
 		                	tryInsecure = false;
-		                	SdlRouterService.setBluetoothPrefs(3,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(3,SHARED_PREFS);
 		                	break;
 	                    } catch (NoSuchMethodException ie) {
-	                    	SdlRouterService.setBluetoothPrefs(0,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(0,SHARED_PREFS);
 	                    } catch (IllegalAccessException ie) {
-	                    	SdlRouterService.setBluetoothPrefs(0,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(0,SHARED_PREFS);
 	                    } catch (InvocationTargetException ie) {
-	                    	SdlRouterService.setBluetoothPrefs(0,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(0,SHARED_PREFS);
 	                    }
 	                }
 	                if (tryInsecure && mBluetoothLevel<=4) {
 	                    // try again using insecure comm if available
 	                    try {
-	                    	SdlRouterService.setBluetoothPrefs(0,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(0,SHARED_PREFS);
 	                        //Log.i(TAG,"connecting using createInsecureRfcommSocket()");
 	                        Method m = mmDevice.getClass().getMethod("createInsecureRfcommSocket()", new Class[] {UUID.class});
 	                        mmSocket = (BluetoothSocket) m.invoke(mmDevice, new Object[] {SERVER_UUID});
@@ -628,14 +628,14 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
     						    Looper.myLooper().quit();
     						}
     						success=true;
-    						SdlRouterService.setBluetoothPrefs(4,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(4,SHARED_PREFS);
 		                	break;
 	                    } catch (NoSuchMethodException ie) {
-	                    	SdlRouterService.setBluetoothPrefs(0,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(0,SHARED_PREFS);
 	                    } catch (IllegalAccessException ie) {
-	                    	SdlRouterService.setBluetoothPrefs(0,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(0,SHARED_PREFS);
 	                    } catch (InvocationTargetException ie) {
-	                    	SdlRouterService.setBluetoothPrefs(0,SHARED_PREFS);
+                            BaseRouterService.setBluetoothPrefs(0,SHARED_PREFS);
 	                    }
 	                }
 	            }  catch (IOException e) {
@@ -796,7 +796,7 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport{
                             //Log.d(TAG, "Packet formed, sending off");
                             SdlPacket packet = psm.getFormedPacket();
                             packet.setTransportRecord(getTransportRecord());
-                            handler.obtainMessage(SdlRouterService.MESSAGE_READ, packet).sendToTarget();
+                            handler.obtainMessage(BaseRouterService.MESSAGE_READ, packet).sendToTarget();
                             psm.reset();
                         }
                     }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTcpTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexTcpTransport.java
@@ -107,7 +107,7 @@ public class MultiplexTcpTransport extends MultiplexBaseTransport {
 		}
 
 		// Send the name of the connected device back to the UI Activity
-		Message msg = handler.obtainMessage(SdlRouterService.MESSAGE_DEVICE_NAME);
+		Message msg = handler.obtainMessage(BaseRouterService.MESSAGE_DEVICE_NAME);
 		Bundle bundle = new Bundle();
 		bundle.putString(DEVICE_NAME, connectedDeviceName);
 		bundle.putString(DEVICE_ADDRESS, connectedDeviceAddress);
@@ -317,7 +317,7 @@ public class MultiplexTcpTransport extends MultiplexBaseTransport {
 								Log.d(TAG, "Packet formed, sending off");
 								SdlPacket packet = psm.getFormedPacket();
 								packet.setTransportRecord(getTransportRecord());
-								handler.obtainMessage(SdlRouterService.MESSAGE_READ, packet).sendToTarget();
+								handler.obtainMessage(BaseRouterService.MESSAGE_READ, packet).sendToTarget();
 							}
 							//We put a trace statement in the message read so we can avoid all the extra bytes
 							psm.reset();

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexUsbTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexUsbTransport.java
@@ -114,7 +114,7 @@ public class MultiplexUsbTransport extends MultiplexBaseTransport{
         writerThread.start();
 
         // Send the name of the connected device back to the UI Activity
-        Message msg = handler.obtainMessage(SdlRouterService.MESSAGE_DEVICE_NAME);
+        Message msg = handler.obtainMessage(BaseRouterService.MESSAGE_DEVICE_NAME);
         Bundle bundle = new Bundle();
         bundle.putString(DEVICE_NAME, connectedDeviceName);
         bundle.putString(DEVICE_ADDRESS, connectedDeviceAddress);
@@ -176,7 +176,7 @@ public class MultiplexUsbTransport extends MultiplexBaseTransport{
      */
     private void connectionFailed() {
         // Send a failure message back to the Activity
-        Message msg = handler.obtainMessage(SdlRouterService.MESSAGE_LOG);
+        Message msg = handler.obtainMessage(BaseRouterService.MESSAGE_LOG);
         Bundle bundle = new Bundle();
         bundle.putString(LOG, "Unable to connect device");
         msg.setData(bundle);
@@ -191,7 +191,7 @@ public class MultiplexUsbTransport extends MultiplexBaseTransport{
      */
     private void connectionLost() {
         // Send a failure message back to the Activity
-        Message msg = handler.obtainMessage(SdlRouterService.MESSAGE_LOG);
+        Message msg = handler.obtainMessage(BaseRouterService.MESSAGE_LOG);
         Bundle bundle = new Bundle();
         bundle.putString(LOG, "Device connection was lost");
         msg.setData(bundle);
@@ -257,7 +257,7 @@ public class MultiplexUsbTransport extends MultiplexBaseTransport{
                                 //Log.d(TAG, "Packet formed, sending off");
                                 SdlPacket packet = psm.getFormedPacket();
                                 packet.setTransportRecord(getTransportRecord());
-                                handler.obtainMessage(SdlRouterService.MESSAGE_READ, packet).sendToTarget();
+                                handler.obtainMessage(BaseRouterService.MESSAGE_READ, packet).sendToTarget();
                             }
                             //Reset the PSM now that we have a finished packet.
                             //We will continue to loop through the data to see if any other packet

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/RouterServiceValidator.java
@@ -472,7 +472,7 @@ public class RouterServiceValidator {
 		for (RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
 			//Log.d(TAG, service.service.getClassName());
 			//We will check to see if it contains this name, should be pretty specific
-			if ((service.service.getClassName()).toLowerCase(Locale.US).contains(SdlBroadcastReceiver.SDL_ROUTER_SERVICE_CLASS_NAME)){ 
+			if ((service.service.getClassName()).toLowerCase(Locale.US).contains(BaseBroadcastReceiver.SDL_ROUTER_SERVICE_CLASS_NAME)){
 				//this.service = service.service; //This is great
 				if(service.started && service.restarting==0){ //If this service has been started and is not crashed
 					return service.service; //appPackageForComponenetName(service.service,pm);

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlBroadcastReceiver.java
@@ -65,6 +65,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static com.smartdevicelink.transport.TransportConstants.FOREGROUND_EXTRA;
 
+@Deprecated
 public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 	
 	private static final String TAG = "Sdl Broadcast Receiver";
@@ -87,7 +88,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 	private static Thread.UncaughtExceptionHandler foregroundExceptionHandler = null;
 
 	public int getRouterServiceVersion(){
-		return SdlRouterService.ROUTER_SERVICE_VERSION_NUMBER;	
+		return BaseRouterService.ROUTER_SERVICE_VERSION_NUMBER;
 	}
 	
 	@Override
@@ -158,7 +159,8 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 			}
 		}
 
-		if(localRouterClass != null && localRouterClass.getName().equalsIgnoreCase(com.smartdevicelink.transport.SdlRouterService.class.getName())){
+		if(localRouterClass != null && localRouterClass.getName().equalsIgnoreCase(com.smartdevicelink.transport.BaseRouterService
+				.class.getName())){
 			Log.e(TAG, "You cannot use the default SdlRouterService class, it must be extended in your project. THIS WILL THROW AN EXCEPTION IN FUTURE RELEASES!!");
 		}
 
@@ -215,8 +217,8 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 	    	//We will send it an intent with the version number of the local instance and an intent to start this instance
 	    	
 	    	Intent serviceIntent =  new Intent(context, localRouterClass);
-	    	SdlRouterService.LocalRouterService self = SdlRouterService.getLocalRouterService(serviceIntent, serviceIntent.getComponent());
-	    	Intent restart = new Intent(SdlRouterService.REGISTER_NEWER_SERVER_INSTANCE_ACTION);
+			BaseRouterService.LocalRouterService self = BaseRouterService.getLocalRouterService(serviceIntent, serviceIntent.getComponent());
+	    	Intent restart = new Intent(BaseRouterService.REGISTER_NEWER_SERVER_INSTANCE_ACTION);
 	    	restart.putExtra(LOCAL_ROUTER_SERVICE_EXTRA, self);
 	    	restart.putExtra(LOCAL_ROUTER_SERVICE_DID_START_OWN, didStart);
 	    	context.sendBroadcast(restart);
@@ -259,8 +261,8 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 
 							}
 							//Make sure to send this out for old apps to close down
-							SdlRouterService.LocalRouterService self = SdlRouterService.getLocalRouterService(serviceIntent, serviceIntent.getComponent());
-							Intent restart = new Intent(SdlRouterService.REGISTER_NEWER_SERVER_INSTANCE_ACTION);
+							BaseRouterService.LocalRouterService self = BaseRouterService.getLocalRouterService(serviceIntent, serviceIntent.getComponent());
+							Intent restart = new Intent(BaseRouterService.REGISTER_NEWER_SERVER_INSTANCE_ACTION);
 							restart.putExtra(LOCAL_ROUTER_SERVICE_EXTRA, self);
 							restart.putExtra(LOCAL_ROUTER_SERVICE_DID_START_OWN, true);
 							context.sendBroadcast(restart);
@@ -514,7 +516,7 @@ public abstract class SdlBroadcastReceiver extends BroadcastReceiver{
 	 * @return Return the local copy of SdlRouterService.class
 	 * {@inheritDoc}
 	 */
-	public abstract Class<? extends SdlRouterService> defineLocalSdlRouterClass();
+	public abstract Class<? extends BaseRouterService> defineLocalSdlRouterClass();
 
 	
 	

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterService.java
@@ -132,6 +132,7 @@ import static com.smartdevicelink.transport.TransportConstants.TRANSPORT_DISCONN
  * @author Joey Grover
  *
  */
+@Deprecated
 @SuppressWarnings({"UnusedReturnValue", "WeakerAccess", "Convert2Diamond", "deprecation"})
 public class SdlRouterService extends Service{
 	

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/SdlRouterStatusProvider.java
@@ -133,7 +133,7 @@ public class SdlRouterStatusProvider {
 			context.startService(bindingIntent);
 		}else {
 			bindingIntent.putExtra(FOREGROUND_EXTRA, true);
-			SdlBroadcastReceiver.setForegroundExceptionHandler(); //Prevent ANR in case the OS takes too long to start the service
+			BaseBroadcastReceiver.setForegroundExceptionHandler(); //Prevent ANR in case the OS takes too long to start the service
 			context.startForegroundService(bindingIntent);
 
 		}

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TCPTransportManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TCPTransportManager.java
@@ -91,7 +91,7 @@ public class TCPTransportManager extends TransportManagerBase{
                 return;
             }
             switch (msg.what) {
-                case SdlRouterService.MESSAGE_STATE_CHANGE:
+                case BaseRouterService.MESSAGE_STATE_CHANGE:
                     switch (msg.arg1) {
                         case MultiplexBaseTransport.STATE_CONNECTED:
                             synchronized (service.TRANSPORT_STATUS_LOCK){
@@ -126,7 +126,7 @@ public class TCPTransportManager extends TransportManagerBase{
                     }
                     break;
 
-                case SdlRouterService.MESSAGE_READ:
+                case BaseRouterService.MESSAGE_READ:
                     service.transportListener.onPacketReceived((SdlPacket) msg.obj);
                     break;
             }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportBroker.java
@@ -561,7 +561,7 @@ public class TransportBroker {
         ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         for (RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
             //We will check to see if it contains this name, should be pretty specific
-            if ((service.service.getClassName()).toLowerCase(Locale.US).contains(SdlBroadcastReceiver.SDL_ROUTER_SERVICE_CLASS_NAME)) {
+            if ((service.service.getClassName()).toLowerCase(Locale.US).contains(BaseBroadcastReceiver.SDL_ROUTER_SERVICE_CLASS_NAME)) {
                 this.routerClassName = service.service.getClassName();
                 this.routerPackage = service.service.getPackageName();
                 return true;
@@ -651,7 +651,7 @@ public class TransportBroker {
 
         if (!sendBindingIntent()) {
             Log.e(TAG, "Something went wrong while trying to bind with the router service.");
-            SdlBroadcastReceiver.queryForConnectedService(currentContext);
+            BaseBroadcastReceiver.queryForConnectedService(currentContext);
             return false;
         }
         return true;

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/TransportManager.java
@@ -81,7 +81,7 @@ public class TransportManager extends TransportManagerBase{
         this.mConfig = config;
 
         if(config.service == null) {
-            config.service = SdlBroadcastReceiver.consumeQueuedRouterService();
+            config.service = BaseBroadcastReceiver.consumeQueuedRouterService();
         }
 
         contextWeakReference = new WeakReference<>(config.context);
@@ -496,7 +496,7 @@ public class TransportManager extends TransportManagerBase{
                 return;
             }
             switch (msg.what) {
-                case SdlRouterService.MESSAGE_STATE_CHANGE:
+                case BaseRouterService.MESSAGE_STATE_CHANGE:
                     switch (msg.arg1) {
                         case MultiplexBaseTransport.STATE_CONNECTED:
                             synchronized (service.TRANSPORT_STATUS_LOCK){
@@ -525,7 +525,7 @@ public class TransportManager extends TransportManagerBase{
                     }
                     break;
 
-                case SdlRouterService.MESSAGE_READ:
+                case BaseRouterService.MESSAGE_READ:
                     service.transportListener.onPacketReceived((SdlPacket) msg.obj);
                     break;
             }

--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/USBAccessoryAttachmentActivity.java
@@ -190,10 +190,10 @@ public class USBAccessoryAttachmentActivity extends Activity {
                         }
 
                         //Make sure to send this out for old apps to close down
-                        SdlRouterService.LocalRouterService self = SdlRouterService.getLocalRouterService(serviceIntent, serviceIntent.getComponent());
-                        Intent restart = new Intent(SdlRouterService.REGISTER_NEWER_SERVER_INSTANCE_ACTION);
-                        restart.putExtra(SdlBroadcastReceiver.LOCAL_ROUTER_SERVICE_EXTRA, self);
-                        restart.putExtra(SdlBroadcastReceiver.LOCAL_ROUTER_SERVICE_DID_START_OWN, true);
+                        BaseRouterService.LocalRouterService self = BaseRouterService.getLocalRouterService(serviceIntent, serviceIntent.getComponent());
+                        Intent restart = new Intent(BaseRouterService.REGISTER_NEWER_SERVER_INSTANCE_ACTION);
+                        restart.putExtra(BaseBroadcastReceiver.LOCAL_ROUTER_SERVICE_EXTRA, self);
+                        restart.putExtra(BaseBroadcastReceiver.LOCAL_ROUTER_SERVICE_DID_START_OWN, true);
                         context.sendBroadcast(restart);
 
                         if (usbAccessory!=null) {

--- a/android/sdl_android/src/main/java/com/smartdevicelink/util/ServiceFinder.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/util/ServiceFinder.java
@@ -42,7 +42,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
-import com.smartdevicelink.transport.SdlRouterService;
+import com.smartdevicelink.transport.BaseRouterService;
 
 import java.util.HashMap;
 import java.util.Vector;
@@ -162,7 +162,7 @@ public class ServiceFinder {
 
     private static Intent createQueryIntent(String receiverLocation) {
         Intent intent = new Intent();
-        intent.setAction(SdlRouterService.REGISTER_WITH_ROUTER_ACTION);
+        intent.setAction(BaseRouterService.REGISTER_WITH_ROUTER_ACTION);
         intent.putExtra(SEND_PACKET_TO_APP_LOCATION_EXTRA_NAME, receiverLocation);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             intent.setFlags(Intent.FLAG_RECEIVER_FOREGROUND);


### PR DESCRIPTION
Fixes #349 

This PR is **[not ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
- [ ] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [ ] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [ ] I have tested Android, Java SE, and Java EE

### Summary
This branch will deprecate SDLRouterService and SDLBroadcastReceiver and create BaseRouterService and BaseBroadcastReceiver which extend these deprecated classes. This is because there is a lot of confusion added by the creating a SDLRouterService class in the application which uses the same name as its parent class.

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
