### PR TITLE
Get loadedCells if developer tries to present a recreated choiceset

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PreloadPresentChoicesOperation.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/choiceset/PreloadPresentChoicesOperation.java
@@ -629,9 +629,13 @@ class PreloadPresentChoicesOperation extends Task {
 
     private void updateChoiceSet(ChoiceSet choiceSet, HashSet<ChoiceCell> loadedCells, HashSet<ChoiceCell> cellsToUpload) {
         ArrayList<ChoiceCell> choiceSetCells = new ArrayList<>();
+        ArrayList<ChoiceCell> loadedCellsList = new ArrayList<>(loadedCells);
+        ArrayList<ChoiceCell> CellsToUploadList = new ArrayList<>(cellsToUpload);
         for (ChoiceCell cell : choiceSet.getChoices()) {
-            if (loadedCells.contains(cell) || cellsToUpload.contains(cell)) {
-                choiceSetCells.add(cell);
+            if (loadedCells.contains(cell)) {
+                choiceSetCells.add(loadedCellsList.get(loadedCellsList.indexOf(cell)));
+            } else if (cellsToUpload.contains(cell)) {
+                choiceSetCells.add(CellsToUploadList.get(CellsToUploadList.indexOf(cell)));
             }
         }
         this.choiceSet.setChoices((List<ChoiceCell>) choiceSetCells.clone());


### PR DESCRIPTION
Fixes #1748 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
N/A

#### Core Tests
edit the 1st menu cell in HelloSdl to the below behavior
```
MenuCell mainCell1 = new MenuCell("Test Cell 1 (speak)", "Secondary Text", "Tertiary Text", livio, livio, null, new MenuSelectionListener() {
            @Override
            public void onTriggered(TriggerSource trigger) {
//                Log.i(TAG, "Test cell 1 triggered. Source: " + trigger.toString());
//                showTest();
                ChoiceCell cell1 = new ChoiceCell("cell1", Collections.singletonList("cell 1"), livio);
                ChoiceCell cell2 = new ChoiceCell("cell2", "cell 2 B", null, Collections.singletonList("cell 2"), null, livio);
                ChoiceCell cell3 = new ChoiceCell("cell3", "cell 3 B", "cell 3 C", Collections.singletonList("cell 3"), livio, livio);
                List<ChoiceCell> choices = Arrays.asList(cell1, cell2, cell3);


                choiceSet = new ChoiceSet("GodHelpUs", choices, new ChoiceSetSelectionListener() {
                    @Override
                    public void onChoiceSelected(ChoiceCell choiceCell, TriggerSource triggerSource, int rowIndex) {
                        DebugTool.logInfo(TAG, "Choice Cell: " + choiceCell.getText() + " Trigger: " + triggerSource.toString() + " Index: " + rowIndex, true);
                    }

                    @Override
                    public void onError(String error) {
                        DebugTool.logError(TAG, " Error: " + error);
                    }
                });


                sdlManager.getScreenManager().presentChoiceSet(choiceSet, InteractionMode.MANUAL_ONLY);
            }
        });
```

Try to present the choiceSet twice and the choiceSet should be presented in both cases.


Core version / branch / commit hash / module tested against: Core 8.0
HMI name / version / branch / commit hash / module tested against: Sdl_hm 5.6.0

### Summary
When updating the choiceSet that will be presented we will pull the cells from the loadedCells and CellsToUpload rather than the unaltered choiceSet provided by the developer.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
