### PR TITLE
Fix NPE for processControlService

### DIFF
--- a/base/src/main/java/com/smartdevicelink/session/BaseSdlSession.java
+++ b/base/src/main/java/com/smartdevicelink/session/BaseSdlSession.java
@@ -240,6 +240,7 @@ public abstract class BaseSdlSession implements ISdlProtocol, ISecurityInitializ
         // Assemble a security query payload header for our response
         SecurityQueryPayload responseHeader = new SecurityQueryPayload();
 
+        byte[] returnBytes;
         if (iNumBytes == null || iNumBytes <= 0) {
             DebugTool.logError(TAG, "Internal Error processing control service");
 
@@ -247,16 +248,18 @@ public abstract class BaseSdlSession implements ISdlProtocol, ISecurityInitializ
             responseHeader.setQueryType(SecurityQueryType.NOTIFICATION);
             responseHeader.setCorrelationID(msg.getCorrID());
             responseHeader.setJsonSize(0);
+            returnBytes = new byte[12];
         } else {
             responseHeader.setQueryID(SecurityQueryID.SEND_HANDSHAKE_DATA);
             responseHeader.setQueryType(SecurityQueryType.RESPONSE);
             responseHeader.setCorrelationID(msg.getCorrID());
             responseHeader.setJsonSize(0);
+            returnBytes = new byte[iNumBytes + 12];
+            System.arraycopy(dataToRead, 0, returnBytes, 12, iNumBytes);
         }
 
-        byte[] returnBytes = new byte[iNumBytes + 12];
+
         System.arraycopy(responseHeader.assembleHeaderBytes(), 0, returnBytes, 0, 12);
-        System.arraycopy(dataToRead, 0, returnBytes, 12, iNumBytes);
 
         ProtocolMessage protocolMessage = new ProtocolMessage();
         protocolMessage.setSessionType(SessionType.CONTROL);


### PR DESCRIPTION
Fixes #1750 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [X] I have tested Android, Java SE, and Java EE

#### Unit Tests
N/A

#### Core Tests
Test to verify Encryption still works, try sending an encrypted RPC from the test app.
To verify error logs work correctly update the ProtocolMessage to send junk data in BaseSdlSession.processControlService

protocolMessage.setData(new byte[iNumBytes + 12]);
This should trigger the error logs in processControlService here DebugTool.logError(TAG, "Client internal error: " + receivedHeader.getErrorCode().getName()); when core responds

After verifying encryption still works, set iNumBytes to null after the sendHandshake call, test again, verify no NPEs occur

Core version / branch / commit hash / module tested against: Core 8.0
HMI name / version / branch / commit hash / module tested against: Sdl HMI 5.6

### Summary
Fix to avoid possible NPE when sendHandshake fails

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
