### PR TITLE
Log warning message when voice commands are attached to sub menu cells 

### DIFF
--- a/base/src/main/java/com/smartdevicelink/managers/screen/menu/MenuReplaceUtilities.java
+++ b/base/src/main/java/com/smartdevicelink/managers/screen/menu/MenuReplaceUtilities.java
@@ -52,6 +52,7 @@ import com.smartdevicelink.proxy.rpc.enums.ImageFieldName;
 import com.smartdevicelink.proxy.rpc.enums.MenuLayout;
 import com.smartdevicelink.proxy.rpc.enums.TextFieldName;
 import com.smartdevicelink.proxy.rpc.listeners.OnMultipleRequestListener;
+import com.smartdevicelink.util.DebugTool;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -64,6 +65,7 @@ import java.util.Set;
  * Created by Bilal Alsharifi on 1/25/21.
  */
 class MenuReplaceUtilities {
+    private static final String TAG = "MenuReplaceUtilities";
     private static int menuId = 0;
 
     static int getNextMenuId() {
@@ -270,6 +272,10 @@ class MenuReplaceUtilities {
         Image icon = (shouldCellIncludePrimaryImage ? cell.getIcon().getImageRPC() : null);
         boolean shouldCellIncludeSecondaryImage = cell.getSecondaryArtwork() != null && cell.getSecondaryArtwork().getImageRPC() != null && shouldCellIncludeSecondaryImageFromCell(cell, fileManager, windowCapability);
         Image secondaryIcon = (shouldCellIncludeSecondaryImage ? cell.getSecondaryArtwork().getImageRPC() : null);
+
+        if (cell.getVoiceCommands() != null && !cell.getVoiceCommands().isEmpty()) {
+            DebugTool.logWarning(TAG, "Setting voice commands for submenu cells is not supported. The voice commands will not be set.");
+        }
 
         MenuLayout submenuLayout;
         List<MenuLayout> availableMenuLayouts = windowCapability != null ? windowCapability.getMenuLayoutsAvailable() : null;


### PR DESCRIPTION
Fixes #1760 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

### Summary
This PR adds a warning message for when the developer tries to send a MenuCell with SubCells and voice commands, because the AddSubMenu RPC does not support voice commands

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
