### PR TITLE
Remove cloning the ImageRPC in the clone method for SdlArtwork

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
@@ -158,6 +158,11 @@ public class SdlArtwork extends SdlFile implements Cloneable {
      */
     @Override
     public SdlArtwork clone() {
-        return (SdlArtwork) super.clone();
+        SdlArtwork artwork = (SdlArtwork) super.clone();
+        if (artwork != null) {
+            artwork.imageRPC = null;
+            return artwork;
+        }
+        return null;
     }
 }

--- a/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
+++ b/javaSE/javaSE/src/main/java/com/smartdevicelink/managers/file/filetypes/SdlArtwork.java
@@ -158,6 +158,11 @@ public class SdlArtwork extends SdlFile implements Cloneable {
      */
     @Override
     public SdlArtwork clone() {
-        return (SdlArtwork) super.clone();
+        SdlArtwork artwork = (SdlArtwork) super.clone();
+        if (artwork != null) {
+            artwork.imageRPC = null;
+            return artwork;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Fixes #1818 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android, Java SE, and Java EE

#### Unit Tests
Github CI unit test

#### Core Tests
Tested on Manticore for SDL Core v8.1.0 for Android and Generic_HMI v0.12.0 with SDL Core v8.1.0 for JavaSE

### Summary
When cloning a SdlArtwork instance, do not clone the imageRPC object with it. This prevents a case where the user changes the file name but the cached object does not update and the T&G manager uses that outdated information.

### Changelog
##### Bug Fixes
* Fix cloning issue as described in #1818 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
