### PR TITLE
Update to gradle version 8.13 and target API level 36

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test_Android:
-    runs-on: macOS-latest
+    runs-on: macos-13
     steps:
 
     - name: Checkout
@@ -15,13 +15,17 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
         
     - name: Sdl Android Tests
       # For more info, please check out: https://github.com/marketplace/actions/android-emulator-runner
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
+        api-level: 34
+        cores: 3
+        ram-size: 6000M
+        heap-size: 4000M
+        arch: x86_64
         script: ./android/gradlew -p ./android :sdl_android:connectedCheck
         
     - name: Hello Sdl Android Tests
@@ -33,7 +37,7 @@ jobs:
         yml: ./codecov.yml
 
   test_Java:
-    runs-on: macOS-latest
+    runs-on: macos-13
     steps:
 
     - name: Checkout

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,7 +25,10 @@ jobs:
         arch: x86_64
         profile: "pixel_7"                 
         script: ./android/gradlew -p ./android :sdl_android:connectedCheck
-        emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -no-metrics
+        emulator-options: >
+            -no-window -gpu host -no-boot-anim -no-audio -no-metrics
+            -camera-back none -camera-front none
+            -cores 6 -memory 6144
         
     - name: Hello Sdl Android Tests
       run: ./android/gradlew -p ./android/hello_sdl_android test

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test_Android:
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     steps:
 
     - name: Checkout
@@ -22,10 +22,8 @@ jobs:
       with:
         api-level: 36               
         target: google_apis          
-        arch: arm64-v8a                        
-        cores: 1
-        ram-size: 6144
-        heap-size: 512
+        arch: x86_64
+        profile: "pixel_7"                 
         script: ./android/gradlew -p ./android :sdl_android:connectedCheck
         emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -no-metrics
         

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,20 +16,23 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 17
-        
-    - name: SDL Android Tests (ARM64)
+
+    - name: SDL Android Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 36               
-        target: google_apis          
+        api-level: 36
+        target: google_apis
         arch: x86_64
-        profile: "pixel_7"                 
-        script: ./android/gradlew -p ./android :sdl_android:connectedCheck
+        profile: pixel_7
+        disable-animations: true
+        emulator-boot-timeout: 1200
         emulator-options: >
-            -no-window -gpu host -no-boot-anim -no-audio -no-metrics
-            -camera-back none -camera-front none
-            -cores 6 -memory 6144
-        
+          -no-window -gpu host -no-boot-anim -no-audio -no-metrics
+          -camera-back none -camera-front none
+          -cores 4 -memory 4096
+        script: ./android/gradlew -p ./android :sdl_android:connectedDebugAndroidTest --max-workers=4
+
+
     - name: Hello Sdl Android Tests
       run: ./android/gradlew -p ./android/hello_sdl_android test
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,16 +17,17 @@ jobs:
       with:
         java-version: 17
         
-    - name: Sdl Android Tests
-      # For more info, please check out: https://github.com/marketplace/actions/android-emulator-runner
+    - name: SDL Android Tests (ARM64)
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 36
+        api-level: 36               
+        target: google_apis          
+        arch: arm64-v8a                        
         cores: 1
         ram-size: 6144
         heap-size: 512
-        arch: x86_64
         script: ./android/gradlew -p ./android :sdl_android:connectedCheck
+        emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -no-metrics
         
     - name: Hello Sdl Android Tests
       run: ./android/gradlew -p ./android/hello_sdl_android test

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test_Android:
-    runs-on: ubuntu-latest
+    runs-on: macos-15-intel
     steps:
 
     - name: Checkout

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,7 +21,7 @@ jobs:
       # For more info, please check out: https://github.com/marketplace/actions/android-emulator-runner
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 36
+        api-level: 35
         cores: 1
         ram-size: 6144
         heap-size: 512

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,9 +21,12 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 36
-        target: google_apis
+        target: default 
         arch: x86_64
         profile: pixel_7
+        no-audio: true 
+        ram-size: 2048M 
+        disk-size: 4096M 
         disable-animations: true
         emulator-boot-timeout: 1200
         script: ./android/gradlew -p ./android :sdl_android:connectedDebugAndroidTest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test_Android:
-    runs-on: macos-15-intel
+    runs-on: macos-26
     steps:
 
     - name: Checkout
@@ -21,7 +21,7 @@ jobs:
       # For more info, please check out: https://github.com/marketplace/actions/android-emulator-runner
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 35
+        api-level: 36
         cores: 1
         ram-size: 6144
         heap-size: 512

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,14 +21,14 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 36
-        target: default 
+        target: google_apis
         arch: x86_64
         profile: pixel_7
-        no-audio: true 
-        ram-size: 2048M 
-        disk-size: 4096M 
+        ram-size: 2048M
+        disk-size: 4096M
         disable-animations: true
         emulator-boot-timeout: 1200
+        emulator-options: "-no-window -no-snapshot -no-audio"
         script: ./android/gradlew -p ./android :sdl_android:connectedDebugAndroidTest
 
     - name: Hello Sdl Android Tests

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,6 +17,13 @@ jobs:
       with:
         java-version: 17
 
+    - name: Enable KVM group perms
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+        ls -l /dev/kvm || true
+
     - name: SDL Android Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
@@ -40,7 +47,7 @@ jobs:
         yml: ./codecov.yml
 
   test_Java:
-    runs-on: macos-13
+    runs-on: ubuntu-latest
     steps:
 
     - name: Checkout

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test_Android:
-    runs-on: macos-15-intel
+    runs-on: ubuntu-latest
     steps:
 
     - name: Checkout
@@ -26,12 +26,7 @@ jobs:
         profile: pixel_7
         disable-animations: true
         emulator-boot-timeout: 1200
-        emulator-options: >
-          -no-window -gpu host -no-boot-anim -no-audio -no-metrics
-          -camera-back none -camera-front none
-          -cores 4 -memory 4096
-        script: ./android/gradlew -p ./android :sdl_android:connectedDebugAndroidTest --max-workers=4
-
+        script: ./android/gradlew -p ./android :sdl_android:connectedDebugAndroidTest
 
     - name: Hello Sdl Android Tests
       run: ./android/gradlew -p ./android/hello_sdl_android test

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test_Android:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
 
     - name: Checkout
@@ -21,10 +21,10 @@ jobs:
       # For more info, please check out: https://github.com/marketplace/actions/android-emulator-runner
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 34
-        cores: 3
-        ram-size: 6000M
-        heap-size: 4000M
+        api-level: 36
+        cores: 1
+        ram-size: 6144
+        heap-size: 512
         arch: x86_64
         script: ./android/gradlew -p ./android :sdl_android:connectedCheck
         

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools.build:gradle:8.13.0'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,6 +10,9 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false
+android.nonTransitiveRClass=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip

--- a/android/hello_sdl_android/build.gradle
+++ b/android/hello_sdl_android/build.gradle
@@ -61,6 +61,7 @@ android {
     lintOptions {
         disable 'GoogleAppIndexingWarning'
     }
+    namespace 'com.sdl.hellosdlandroid'
 }
 
 

--- a/android/hello_sdl_android/build.gradle
+++ b/android/hello_sdl_android/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 36
     defaultConfig {
         applicationId "com.sdl.hellosdlandroid"
-        minSdkVersion 16
-        targetSdkVersion 34
+        minSdkVersion 21
+        targetSdkVersion 36
         versionCode 1
         versionName "1.0"
         resValue "string", "app_name", "Hello Sdl Android"

--- a/android/hello_sdl_android/build.gradle
+++ b/android/hello_sdl_android/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation project(path: ':sdl_android')
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/android/hello_sdl_android/src/main/AndroidManifest.xml
+++ b/android/hello_sdl_android/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.sdl.hellosdlandroid">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -38,9 +38,11 @@ android {
         main.java.srcDirs += '../../base/src/main/java'
         androidTest.assets.srcDirs += '../../generator/rpc_spec/'
     }
+
     buildFeatures {
         aidl true
     }
+
     namespace 'com.smartdevicelink'
     testNamespace 'com.smartdevicelink.test'
 }

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -67,7 +67,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.13.0'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.27.0'
     }
 }
 

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -57,11 +57,12 @@ dependencies {
     api 'androidx.annotation:annotation:1.1.0'
     annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.2.0'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.7.0'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
     androidTestImplementation 'org.mockito:mockito-core:5.7.0'
     androidTestImplementation 'org.mockito:mockito-android:5.7.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
 }

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -38,6 +38,8 @@ android {
         main.java.srcDirs += '../../base/src/main/java'
         androidTest.assets.srcDirs += '../../generator/rpc_spec/'
     }
+    namespace 'com.smartdevicelink'
+    testNamespace 'com.smartdevicelink.test'
 }
 
 ext { VERSION_NAME = "$project.android.defaultConfig.versionName" }

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -38,6 +38,9 @@ android {
         main.java.srcDirs += '../../base/src/main/java'
         androidTest.assets.srcDirs += '../../generator/rpc_spec/'
     }
+    buildFeatures {
+        aidl true
+    }
     namespace 'com.smartdevicelink'
     testNamespace 'com.smartdevicelink.test'
 }

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -50,19 +50,19 @@ ext { VERSION_NAME = "$project.android.defaultConfig.versionName" }
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
     //api 'com.livio.taskmaster:taskmaster:0.6.0'
-    api 'com.smartdevicelink:bson_java_port:1.2.5'
+    api 'com.smartdevicelink:bson_java_port:1.2.6'
     api 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    api 'androidx.annotation:annotation:1.1.0'
-    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.2.0'
+    api 'androidx.annotation:annotation:1.9.1'
+    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.9.4'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:5.7.0'
-    androidTestImplementation 'androidx.test:rules:1.5.0'
-    androidTestImplementation 'org.mockito:mockito-core:5.7.0'
-    androidTestImplementation 'org.mockito:mockito-android:5.7.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
+    testImplementation 'org.mockito:mockito-core:5.20.0'
+    androidTestImplementation 'androidx.test:rules:1.7.0'
+    androidTestImplementation 'org.mockito:mockito-core:5.20.0'
+    androidTestImplementation 'org.mockito:mockito-android:5.20.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.7.0'
 }
 
 buildscript {
@@ -71,7 +71,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.27.0'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.34.0'
     }
 }
 

--- a/android/sdl_android/build.gradle
+++ b/android/sdl_android/build.gradle
@@ -1,12 +1,10 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 36
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 34
-        versionCode 26
-        versionName new File(projectDir.path, ('/../../VERSION')).text.trim()
+        minSdkVersion 21
+        targetSdkVersion 36
         buildConfigField "String", "VERSION_NAME", '\"' + versionName + '\"'
         resValue "string", "SDL_LIB_VERSION", '\"' + versionName + '\"'
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/android/sdl_android/src/androidTest/AndroidManifest.xml
+++ b/android/sdl_android/src/androidTest/AndroidManifest.xml
@@ -29,6 +29,16 @@
     <application android:debuggable="true">
         <uses-library android:name="android.test.runner" />
         <activity android:name="com.smartdevicelink.managers.lockscreen.SDLLockScreenActivity" />
+        <receiver
+            android:name=".TestSdlReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.smartdevicelink.USB_ACCESSORY_ATTACHED" /> <!--For AOA -->
+                <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
+                <action android:name="sdl.router.startservice" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/android/sdl_android/src/androidTest/AndroidManifest.xml
+++ b/android/sdl_android/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="com.smartdevicelink.test"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-sdk android:minSdkVersion="16" />
     <uses-permission android:name="android.permission.BLUETOOTH" />

--- a/android/sdl_android/src/androidTest/AndroidManifest.xml
+++ b/android/sdl_android/src/androidTest/AndroidManifest.xml
@@ -12,6 +12,19 @@
         android:name="android.test.InstrumentationTestRunner"
         android:targetPackage="com.smartdevicelink.test" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+
+    <queries>
+        <intent>
+            <action android:name="com.smartdevicelink.router.service" />
+        </intent>
+        <intent>
+            <action android:name="sdl.router.startservice" />
+        </intent>
+    </queries>
 
     <application android:debuggable="true">
         <uses-library android:name="android.test.runner" />

--- a/android/sdl_android/src/androidTest/AndroidManifest.xml
+++ b/android/sdl_android/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-sdk android:minSdkVersion="16" />
+    <uses-sdk android:minSdkVersion="21" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <!-- Required to pair Bluetooth devices -->
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/TestSdlReceiver.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/TestSdlReceiver.java
@@ -1,0 +1,14 @@
+package com.smartdevicelink;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Added so we pass IntegrationValidator when running unit test.
+ */
+public class TestSdlReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+    }
+}

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/audio/AudioStreamManagerTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/audio/AudioStreamManagerTest.java
@@ -134,99 +134,131 @@ public class AudioStreamManagerTest extends TestCase {
     }
 
     public void testWithSquareSampleAudio16BitAnd8KhzApi16() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 16);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._8KHZ, BitsPerSample._16_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(8000, SampleType.SIGNED_16_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio16BitAnd16KhzApi16() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 16);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._16KHZ, BitsPerSample._16_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(16000, SampleType.SIGNED_16_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio16BitAnd22KhzApi16() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 16);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._22KHZ, BitsPerSample._16_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(22050, SampleType.SIGNED_16_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio16BitAnd44KhzApi16() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 16);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._44KHZ, BitsPerSample._16_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(44100, SampleType.SIGNED_16_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio8BitAnd8KhzApi16() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 16);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._8KHZ, BitsPerSample._8_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(8000, SampleType.UNSIGNED_8_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio8BitAnd16KhzApi16() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 16);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._16KHZ, BitsPerSample._8_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(16000, SampleType.UNSIGNED_8_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio8BitAnd22KhzApi16() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 16);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._22KHZ, BitsPerSample._8_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(22050, SampleType.UNSIGNED_8_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio8BitAnd44KhzApi16() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 16);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._44KHZ, BitsPerSample._8_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(44100, SampleType.UNSIGNED_8_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio16BitAnd8KhzApi21() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 21);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._8KHZ, BitsPerSample._16_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(8000, SampleType.SIGNED_16_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio16BitAnd16KhzApi21() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 21);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._16KHZ, BitsPerSample._16_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(16000, SampleType.SIGNED_16_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio16BitAnd22KhzApi21() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 21);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._22KHZ, BitsPerSample._16_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(22050, SampleType.SIGNED_16_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio16BitAnd44KhzApi21() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 21);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._44KHZ, BitsPerSample._16_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(44100, SampleType.SIGNED_16_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio8BitAnd8KhzApi21() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 21);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._8KHZ, BitsPerSample._8_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(8000, SampleType.UNSIGNED_8_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio8BitAnd16KhzApi21() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 21);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._16KHZ, BitsPerSample._8_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(16000, SampleType.UNSIGNED_8_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio8BitAnd22KhzApi21() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 21);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._22KHZ, BitsPerSample._8_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(22050, SampleType.UNSIGNED_8_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     public void testWithSquareSampleAudio8BitAnd44KhzApi21() throws Exception {
+        int versionCode = Build.VERSION.SDK_INT;
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 21);
         AudioPassThruCapabilities audioPassThruCapabilities = new AudioPassThruCapabilities(SamplingRate._44KHZ, BitsPerSample._8_BIT, AudioType.PCM);
         runFullAudioManagerDecodeFlowWithSquareSampleAudio(44100, SampleType.UNSIGNED_8_BIT, audioPassThruCapabilities);
+        setFinalStatic(Build.VERSION.class.getField("SDK_INT"), versionCode);
     }
 
     private int testFullAudioManagerDecodeFlowCorrectCounter = 0;

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/SoftButtonManagerTests.java
@@ -178,7 +178,7 @@ public class SoftButtonManagerTests {
 
     private void sleep() {
         try {
-            Thread.sleep(100);
+            Thread.sleep(1000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/PreloadPresentChoicesOperationTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/PreloadPresentChoicesOperationTests.java
@@ -246,7 +246,7 @@ public class PreloadPresentChoicesOperationTests {
 
     private void sleep() {
         try {
-            Thread.sleep(100);
+            Thread.sleep(1000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/PresentKeyboardOperationTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/choiceset/PresentKeyboardOperationTests.java
@@ -129,7 +129,7 @@ public class PresentKeyboardOperationTests {
 
     private void sleep() {
         try {
-            Thread.sleep(100);
+            Thread.sleep(1000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/MenuManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/managers/screen/menu/MenuManagerTests.java
@@ -785,7 +785,7 @@ public class MenuManagerTests {
 
     private void sleep() {
         try {
-            Thread.sleep(250);
+            Thread.sleep(1000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/MultiplexBluetoothTransportTest.java
@@ -52,9 +52,7 @@ public class MultiplexBluetoothTransportTest extends TestCase {
         assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
 
         bluetooth.start();
-        if (DeviceUtil.isEmulator()) {
-            assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_NONE);
-        } else {
+        if (!DeviceUtil.isEmulator()) {
             assertEquals(bluetooth.getState(), MultiplexBluetoothTransport.STATE_LISTEN);
         }
 

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/WiFiSocketFactoryTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/WiFiSocketFactoryTest.java
@@ -111,8 +111,7 @@ public class WiFiSocketFactoryTest extends TestCase {
         // Since NetworkCapabilities class is 'final', we cannot create its mock. To create a dummy
         // instance, here we use reflection to call its constructor and a method that are marked
         // with "@hide".
-        // It is possible that these methods will not be available in a future version of Android.
-        // In that case we need to update our code accordingly.
+        // Starting in API level 30, this no longer works.
         Class<NetworkCapabilities> c = NetworkCapabilities.class;
         try {
             Method addTransportTypeMethod = c.getMethod("addTransportType", int.class);
@@ -176,7 +175,9 @@ public class WiFiSocketFactoryTest extends TestCase {
         Socket ret = WiFiSocketFactory.createSocket(mMockContext);
 
         assertNotNull("createSocket() should always return a Socket instance", ret);
-        assertEquals("Returned Socket should be created through SocketFactory", mWiFiBoundSocket, ret);
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+            assertEquals("Returned Socket should be created through SocketFactory", mWiFiBoundSocket, ret);
+        }
     }
 
     // test the case where SDK_INT is less than 21
@@ -272,7 +273,9 @@ public class WiFiSocketFactoryTest extends TestCase {
         Socket ret = WiFiSocketFactory.createSocket(mMockContext);
 
         assertNotNull("createSocket() should always return a Socket instance", ret);
-        assertEquals("Returned Socket should be created through SocketFactory", mWiFiBoundSocket, ret);
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+            assertEquals("Returned Socket should be created through SocketFactory", mWiFiBoundSocket, ret);
+        }
     }
 
     // test the case where the phone isn't connected to Wi-Fi network
@@ -316,7 +319,9 @@ public class WiFiSocketFactoryTest extends TestCase {
         Socket ret = WiFiSocketFactory.createSocket(mMockContext);
 
         assertNotNull("createSocket() should always return a Socket instance", ret);
-        assertEquals("Returned Socket should be created through SocketFactory", mWiFiBoundSocket, ret);
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+            assertEquals("Returned Socket should be created through SocketFactory", mWiFiBoundSocket, ret);
+        }
     }
 
     // test the case where we get an exception with SocketFactory.createSocket()
@@ -349,6 +354,8 @@ public class WiFiSocketFactoryTest extends TestCase {
         Socket ret = WiFiSocketFactory.createSocket(mMockContext);
 
         assertNotNull("createSocket() should always return a Socket instance", ret);
-        assertEquals("Returned Socket should be created through SocketFactory", mWiFiBoundSocket, ret);
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+            assertEquals("Returned Socket should be created through SocketFactory", mWiFiBoundSocket, ret);
+        }
     }
 }

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/WiFiSocketFactoryTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/transport/WiFiSocketFactoryTest.java
@@ -112,6 +112,7 @@ public class WiFiSocketFactoryTest extends TestCase {
         // instance, here we use reflection to call its constructor and a method that are marked
         // with "@hide".
         // Starting in API level 30, this no longer works.
+        // There is not a good way to bypass this so some test will check API level
         Class<NetworkCapabilities> c = NetworkCapabilities.class;
         try {
             Method addTransportTypeMethod = c.getMethod("addTransportType", int.class);

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/DeviceUtil.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/test/util/DeviceUtil.java
@@ -10,6 +10,7 @@ public class DeviceUtil {
                 || Build.MODEL.contains("Emulator")
                 || Build.MODEL.contains("Android SDK built for")
                 || Build.MANUFACTURER.contains("Genymotion")
+                || Build.DEVICE.startsWith("emu")
                 || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
                 || (Build.BRAND.startsWith("Android") && Build.DEVICE.startsWith("generic"))
                 || (Build.PRODUCT != null && Build.PRODUCT.startsWith("sdk_google_phone"))

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/transport/TransportBrokerTest.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/transport/TransportBrokerTest.java
@@ -13,6 +13,7 @@ import com.smartdevicelink.test.SdlUnitTestContants;
 import com.smartdevicelink.test.util.DeviceUtil;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -22,6 +23,7 @@ import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
+@Ignore // MUST HAVE AN SDL APP WITH A ROUTER SERVICE RUNNING ON PHONE TO RUN THESE TEST
 public class TransportBrokerTest { //FIXME this test class needs to be fixed. At this point these tests are not helpful
     RouterServiceValidator rsvp;
     //		public TransportBrokerThread(Context context, String appId, ComponentName service){

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/transport/TransportManagerTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/transport/TransportManagerTests.java
@@ -1,9 +1,12 @@
 package com.smartdevicelink.transport;
 
+import android.Manifest;
 import android.content.ComponentName;
+import android.os.Build;
 import android.os.Looper;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
 
 import com.smartdevicelink.protocol.SdlPacket;
 import com.smartdevicelink.protocol.SdlPacketFactory;
@@ -13,6 +16,7 @@ import com.smartdevicelink.transport.enums.TransportType;
 import com.smartdevicelink.transport.utl.TransportRecord;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -29,6 +33,9 @@ import static junit.framework.TestCase.assertTrue;
 @RunWith(AndroidJUnit4.class)
 public class TransportManagerTests {
 
+
+    @Rule
+    public GrantPermissionRule btRuntimePermissionRule = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? GrantPermissionRule.grant(Manifest.permission.BLUETOOTH_CONNECT) : null;
     MultiplexTransportConfig config;
     final TransportRecord defaultBtRecord = new TransportRecord(TransportType.BLUETOOTH, "12:34:56:78:90");
     final ComponentName routerServiceComponentName = new ComponentName("com.smartdevicelink.test", "com.smartdevicelink.test.SdlRouterService");

--- a/android/sdl_android/src/androidTest/java/com/smartdevicelink/util/MediaStreamingStatusTests.java
+++ b/android/sdl_android/src/androidTest/java/com/smartdevicelink/util/MediaStreamingStatusTests.java
@@ -1,11 +1,13 @@
 package com.smartdevicelink.util;
 
+import android.Manifest;
 import android.content.Context;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import android.os.Build;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
 
 import com.smartdevicelink.managers.SdlManager;
 import com.smartdevicelink.managers.SdlManagerListener;
@@ -14,6 +16,7 @@ import com.smartdevicelink.test.TestValues;
 import com.smartdevicelink.transport.MultiplexTransportConfig;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -35,6 +38,8 @@ import static org.mockito.Mockito.spy;
 public class MediaStreamingStatusTests {
 
 
+    @Rule
+    public GrantPermissionRule btRuntimePermissionRule = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? GrantPermissionRule.grant(Manifest.permission.BLUETOOTH_CONNECT) : null;
     @Mock
     private AudioManager audioManager = mock(AudioManager.class);
 

--- a/android/sdl_android/src/main/AndroidManifest.xml
+++ b/android/sdl_android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="com.smartdevicelink"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:tools="http://schemas.android.com/tools">
 
     <uses-sdk tools:overrideLibrary="android.arch.lifecycle, android.arch.lifecycle.extensions, android.arch.lifecycle.livedata, android.arch.lifecycle.livedata.core, android.arch.core, android.arch.lifecycle.viewmodel, android.support.fragment, android.support.coreui, android.support.coreutils, android.support.compat" />
 </manifest>


### PR DESCRIPTION
Fixes #1883 

This PR is **[ready]** for review.

### Risk
This PR makes **[no]** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [x] I have tested Android

#### Unit Tests
Unit test were updated to work with API level 36 and new gradle version

#### Core Tests
Verified Hello_SDL app successfully connects to Sync 3.

Installed and tested Hello_SDL on an API level 36 emulator with 16 KB page sizes, confirming successful connection to Manticore.

Tested video streaming over both Wireless and AOA (Android Open Accessory) connections.

Confirmed multiple SDL apps can connect simultaneously using a single app’s RouterService.

Ran a subset of UI-related tests from the test suite to ensure general functionality remains stable.

Core version / branch / commit hash / module tested against: Sync, Sync 4 , Manticore
HMI name / version / branch / commit hash / module tested against: Sync 3, Sync 4 , Manticore

### Summary
This PR updates the project to use Gradle 8.13.0, ensuring compatibility with Android API level 36 and support for 16 KB page sizes. Additionally, it updates unit tests and CI checks to align with the new Gradle configuration. Some import statements used in unit testing have also been cleaned up and modernized.

`android.yml`:
`Runs-on` - changed from `macOS-latest` to `ubuntu-latest`, which allows for a faster andorid emulator.

`AudioStreamManagerTest`:
We had test failing randomly when broadcast receiver were registered through some test specifying that the exported flag needed to be set, I discovered that some test in `AudioStreamManagerTest` were overwriting the `Build.VERSION.SDK_INT` to a lower api level for all test ran after, causing the exported flag to not get set.

Upon fixing this we had other issues with test for the `IntegrationValidator`, I had to add `TestSdlReceiver` to pass checks for the BroadcastRecevier.

`WiFiSocketFactoryTest`:
Some test were failing due to the fact that starting in API level 30 we can no longer use reflection to fake NetworkCapabilities. I added an api level check to bypass them. There is no good way to mock them as the class is final, I tried looking into `mockito inline` and `Roboelectric` but could not use them as they are unavailable in `androidTestImplementation`. There is `dexmaker-mockito-inline` that could be a possibility, but that would change how `mockito` is imported into the project and could affect other test.

`MultiplexBluetoothTransportTest`:
`testStateTransitions` had to be modified due to the new emulator actually starting the `MultiplexBluetoothTransport`, so to prevent incompatibility with older emulators I modified it to only check on actual devices

Other unit test issues:
I had to add permissions to the manifest for our unit test as well as the queries section for the router service that is required in newer android versions

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
