### PR TITLE
Fix the issue-1894: BluetoothSocket read change introduced in API37

### DIFF
--- a/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
+++ b/android/sdl_android/src/main/java/com/smartdevicelink/transport/MultiplexBluetoothTransport.java
@@ -777,6 +777,14 @@ public class MultiplexBluetoothTransport extends MultiplexBaseTransport {
             while (true) {
                 try {
                     bytesRead = mmInStream.read(buffer);
+                    // API-37 changes the read value to -1 when connection is dropped.
+                    // See https://developer.android.com/about/versions/17/behavior-changes-17#bluetooth-rfcomm-socket-change for details.
+                    // We need to handle this case to break the loop.
+                    if (bytesRead == -1) {
+                        DebugTool.logInfo(TAG, "bytesRead returns -1...dealing with connection lost");
+                        connectionLost();
+                        break;
+                    }
                     // Log.i(getClass().getName(), "Received " + bytesRead + " bytes from Bluetooth");
                     for (int i = 0; i < bytesRead; i++) {
                         input = buffer[i];


### PR DESCRIPTION
This fix covers the BluetoothSocket read change introduced in API37

Fixes #1894

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [ ] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).
- [ ] I have tested Android, Java SE, and Java EE

#### Unit Tests
n/a

#### Core Tests
n/a

Core version / branch / commit hash / module tested against: [INSERT]
Custom SDL core running on Toyota head unit, but this can duplicate any Core version.

### Summary
[Summary of PR changes]

### Changelog
##### Breaking Changes
* n/a

##### Enhancements
* n/a

##### Bug Fixes
* #1894 

### Tasks Remaining:
- n/a

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)